### PR TITLE
Fixing logic for cistart

### DIFF
--- a/mpisppy/spbase.py
+++ b/mpisppy/spbase.py
@@ -275,9 +275,10 @@ class SPBase(object):
                 for node in scenario._PySPnode_list
             }
             scenario._PySP_cistart = dict()
-            for ndn in scenario._PySP_nlens:
-                sofar = 0 if ndn == "ROOT" else sofar + scenario._PySP_nlens[ndn]
+            sofar = 0
+            for ndn, ndn_len in scenario._PySP_nlens.items():
                 scenario._PySP_cistart[ndn] = sofar
+                sofar += ndn_len
 
     def create_communicators(self):
         # If the scenarios have not been constructed yet, 


### PR DESCRIPTION
For a 3-stage problem with 2 first-stage variables and 3 second-stage variables:
master:
```
_PySP_nlens: {'ROOT': 2, 'ROOT_2': 3}
_PySP_cistart: {'ROOT': 0, 'ROOT_2': 3}
```

PR:
```
_PySP_nlens: {'ROOT': 2, 'ROOT_2': 3}
_PySP_cistart: {'ROOT': 0, 'ROOT_2': 2}
```
