### PR TITLE
More numpythonic Compute_Xbar

### DIFF
--- a/mpisppy/phbase.py
+++ b/mpisppy/phbase.py
@@ -146,12 +146,12 @@ class PHBase(mpisppy.spbase.SPBase):
             As of March 2019, we concatenate xbar and xsqbar into one long
             vector to make it easier to use the current asynch code.
         """
+        if synchronizer is not None:
+            raise RuntimeError("Synchronizer is no longer supported; use APH")
 
-        nodenames = list() # to transmit to comms
-        # This "onlyreduce" thing is done for the sake of asynchronous only
-        local_concats = {"OnlyReduce": dict()} # keys are tree node names
-        global_concats =  {"OnlyReduce": dict()} # values are concat of xbar
-                                                 # and xsqbar
+        nodenames = [] # to transmit to comms
+        local_concats = {}   # keys are tree node names
+        global_concats =  {} # values are concat of xbar and xsqbar
 
         # we need to accumulate all local contributions before the reduce
         for k,s in self.local_scenarios.items():
@@ -163,8 +163,8 @@ class PHBase(mpisppy.spbase.SPBase):
                     mylen = 2*nlens[ndn]
                     if synchronizer is not None and node.name == "ROOT":
                         mylen += self.n_proc
-                    local_concats["OnlyReduce"][ndn] = np.zeros(mylen, dtype='d')
-                    global_concats["OnlyReduce"][ndn] = np.zeros(mylen, dtype='d')
+                    local_concats[ndn] = np.zeros(mylen, dtype='d')
+                    global_concats[ndn] = np.zeros(mylen, dtype='d')
 
         # compute the local xbar and sqbar (put the sq in the 2nd 1/2 of concat)
         for k,s in self.local_scenarios.items():
@@ -173,8 +173,8 @@ class PHBase(mpisppy.spbase.SPBase):
                 ndn = node.name
                 nlen = nlens[ndn]
 
-                xbars = local_concats["OnlyReduce"][ndn][:nlen]
-                xsqbars = local_concats["OnlyReduce"][ndn][nlen:]
+                xbars = local_concats[ndn][:nlen]
+                xsqbars = local_concats[ndn][nlen:]
 
                 nonants_array = np.fromiter( (v._value for v in node.nonant_vardata_list),
                                              dtype='d', count=nlen )
@@ -182,49 +182,12 @@ class PHBase(mpisppy.spbase.SPBase):
                 xsqbars += (s.PySP_prob / node.uncond_prob) * nonants_array**2
 
         # compute node xbar values(reduction)
-        if synchronizer is None:
-            for nodename in nodenames:
-                self.comms[nodename].Allreduce(
-                    [local_concats["OnlyReduce"][nodename], mpi.DOUBLE],
-                    [global_concats["OnlyReduce"][nodename], mpi.DOUBLE],
-                    op=mpi.SUM)
-        else: # async
-            # PROBABLY never used... (DLW 2020)
-            secs_sofar = (dt.datetime.now() - self.startdt).total_seconds()
-            # only this rank puts a time for this rank, so the sum is a report
-            local_concats["OnlyReduce"]["ROOT"][2*nlens["ROOT"]+self.rank] \
-                = secs_sofar
-            
-            logger.debug('xbar secs_sofar {} on rank {}'.format(secs_sofar, self.rank))
-            ###logger.debug('   xbar on rank {}; local_concats {}'.format(self.rank, str(local_concats)))
-            synchronizer.compute_global_data(local_concats, global_concats)
+        for nodename in nodenames:
+            self.comms[nodename].Allreduce(
+                [local_concats[nodename], mpi.DOUBLE],
+                [global_concats[nodename], mpi.DOUBLE],
+                op=mpi.SUM)
 
-            # See if we have enough xbars to proceed (need not be perfect)
-            # NOTE: so, for now we start xbarin at one because we are in...
-            xbarin = 0 # count ranks (close enough to be a proxy for scenarios)
-            while synchronizer.global_quitting == 0: # there is also a break
-                for cr in range(self.n_proc):
-                    logger.debug('cr {} on rank {} time {}'.\
-                        format(cr, self.rank,
-                        global_concats["OnlyReduce"]["ROOT"][2*nlens["ROOT"]+cr]))
-                    if  global_concats["OnlyReduce"]["ROOT"][2*nlens["ROOT"]+cr] \
-                        >= secs_sofar:
-                        xbarin += 1
-                        logger.debug('xbarin {} on rank {}'.\
-                                      format(xbarin, self.rank))
-                if xbarin/self.n_proc >= self.PHoptions["async_frac_needed"]:
-                    logger.debug('   break on rank {}'.format(self.rank))
-                    if verbose and self.rank == self.rank0:
-                        print ("(%d)" % xbarin)
-                    break   # leave outer while True loop
-                else:
-                    logger.debug('   sleep on rank {}'.format(self.rank))
-                    if verbose and self.rank == self.rank0:
-                        print ('s'),
-                    time.sleep(self.PHoptions["async_sleep_secs"])
-                    synchronizer.get_global_data(global_concats)
-                    xbarin = 0 # global_data should have been upated
-        
         # set the xbar and xsqbar in all the scenarios
         for k,s in self.local_scenarios.items():
             logger.debug('  top of assign xbar loop for {} on rank {}'.\
@@ -234,8 +197,8 @@ class PHBase(mpisppy.spbase.SPBase):
                 ndn = node.name
                 nlen = nlens[ndn]
 
-                xbars = global_concats["OnlyReduce"][ndn][:nlen]
-                xsqbars = global_concats["OnlyReduce"][ndn][nlen:]
+                xbars = global_concats[ndn][:nlen]
+                xsqbars = global_concats[ndn][nlen:]
 
                 for i in range(nlen):
                     s._xbars[(ndn,i)]._value = xbars[i]


### PR DESCRIPTION
Uses a bit of extra memory to move a several operations into C. This should obviously be carefully checked and verified.

Also renames `node_concats` to `global_concats` in Compute_Xbar.