### PR TITLE
NOW: minor error message improvement; WAS (but is no longer): xhatbase now calls the post_iter0 for an extension *on* *its* opt object

### DIFF
--- a/mpisppy/extensions/xhatbase.py
+++ b/mpisppy/extensions/xhatbase.py
@@ -215,10 +215,6 @@ class XhatBase(mpisppy.extensions.extension.PHExtension):
     def post_iter0(self):
         # the base class needs this
         self.comms = self.opt.comms
-        # As long as were are here, we might as well check
-        # to see if the underlying opt object itself has an extension.
-        if hasattr(self.opt, "extobject") and self.opt.extobject is not None:
-            self.opt.extobject.post_iter0()
         
 """
 May 2020, DLW

--- a/mpisppy/extensions/xhatbase.py
+++ b/mpisppy/extensions/xhatbase.py
@@ -215,6 +215,9 @@ class XhatBase(mpisppy.extensions.extension.PHExtension):
     def post_iter0(self):
         # the base class needs this
         self.comms = self.opt.comms
+        # This checks to see if the underlying opt object itself has an extension.
+        if self.opt.extobject is not None:
+            self.opt.extobject.post_iter0()
         
 """
 May 2020, DLW

--- a/mpisppy/extensions/xhatbase.py
+++ b/mpisppy/extensions/xhatbase.py
@@ -215,8 +215,9 @@ class XhatBase(mpisppy.extensions.extension.PHExtension):
     def post_iter0(self):
         # the base class needs this
         self.comms = self.opt.comms
-        # This checks to see if the underlying opt object itself has an extension.
-        if self.opt.extobject is not None:
+        # As long as were are here, we might as well check
+        # to see if the underlying opt object itself has an extension.
+        if hasattr(self.opt, "extobject") and self.opt.extobject is not None:
             self.opt.extobject.post_iter0()
         
 """

--- a/mpisppy/spbase.py
+++ b/mpisppy/spbase.py
@@ -434,8 +434,8 @@ class SPBase(object):
                         bad_vars = [ s._nonant_indexes[ndn,idx].name for idx in indices ]
                         badprobs = [ global_concats[ndn][idx] for idx in indices]
                         raise RuntimeError(f"Node {ndn}, variables {bad_vars} have respective"
-                                           f" conditional probabilities {badprobs}"
-                                           " which do not sum to 1")
+                                           f" conditional probability sum {badprobs}"
+                                           " which are not 1")
                     checked_nodes.append(ndn)
 
     def _look_before_leap(self, scen, addlist):

--- a/mpisppy/spbase.py
+++ b/mpisppy/spbase.py
@@ -431,9 +431,11 @@ class SPBase(object):
                     if not np.allclose(global_concats[ndn], 1., atol=tol):
                         close = ~np.isclose(global_concats[ndn], 1., atol=tol)
                         indices = np.nonzero(close)[0]
-                        bad_vars = [ s._nonant_indexes[ndn,idx] for idx in indices ]
-                        raise RuntimeError(f"Node {ndn}, variables {bad_vars} have conditional"
-                                            "probabilities which do not sum to 1")
+                        bad_vars = [ s._nonant_indexes[ndn,idx].name for idx in indices ]
+                        badprobs = [ global_concats[ndn][idx] for idx in indices]
+                        raise RuntimeError(f"Node {ndn}, variables {bad_vars} have respective"
+                                           f" conditional probabilities {badprobs}"
+                                           " which do not sum to 1")
                     checked_nodes.append(ndn)
 
     def _look_before_leap(self, scen, addlist):


### PR DESCRIPTION
This PR is being superseded by a branch Ben started that allows for callbacks after every subproblem solve. I am going merge it with the (unrelated) improvement to an error message.

Old Text:
I happen to need to have xhatters call the post_iter0 on the extension on the opt object that they own (never mind that the
xhatter itself might be an extension). 

As luck would have it, it turns out that post_iter0 is the only callback that was easy.  I'm not quite sure how, or even whether, the other extension calls should be supported.  (Iter 0 is very special in our implementation of PH, so the post-iter0 extension
call is sometimes the only one needed).