### PR TITLE
making sizes use linearize so xpress might be able to run longer tests

### DIFF
--- a/examples/run_all.py
+++ b/examples/run_all.py
@@ -112,9 +112,11 @@ do_one("netdes", "netdes_cylinders.py", 5,
        "--max-iterations=3 --instance-name=network-10-20-L-01 "
        "--solver-name={} --rel-gap=0.0 --default-rho=1 "
        "--no-fwph --max-solver-threads=2".format(solver_name))
+# sizes is slow for xpress so try linearizing the proximal term.
 do_one("sizes",
        "sizes_cylinders.py",
        3,
+       "--linearize-proximal-terms "
        "--num-scens=10 --bundles-per-rank=0 --max-iterations=5 "
        "--default-rho=1 "
        "--iter0-mipgap=0.01 --iterk-mipgap=0.001 "
@@ -123,7 +125,7 @@ do_one("sizes",
        "sizes_cylinders.py",
        4,
        "--num-scens=3 --bundles-per-rank=0 --max-iterations=5 "
-       "--iter0-mipgap=0.01 --iterk-mipgap=0.001 "
+       "--iter0-mipgap=0.01 --iterk-mipgap=0.005 "
        "--default-rho=1 --solver-name={} --with-display-progress".format(solver_name))
 do_one("sizes", "sizes_pysp.py", 1, "3 {}".format(solver_name))
 

--- a/mpisppy/cylinders/lagrangian_bounder.py
+++ b/mpisppy/cylinders/lagrangian_bounder.py
@@ -16,10 +16,11 @@ class LagrangianOuterBound(mpisppy.cylinders.spoke.OuterBoundWSpoke):
         self.opt.subproblem_creation(verbose)
         self.opt._create_solvers()
 
-    # This signature changed April 2020 (delete these two comments in Aug 2020)
-    #def lagrangian(self, PH_extensions=None, PH_converger=None, rho_setter=None):
     def lagrangian(self):
         verbose = self.opt.options['verbose']
+        # This is sort of a hack, but might help folks:
+        if "ipopt" in self.opt.options["solvername"]:
+            print("\n WARNING: An ipopt solver will not give outer bounds\n")
         teeme = False
         if "tee-rank0-solves" in self.opt.options:
             teeme = self.opt.options['tee-rank0-solves']
@@ -42,7 +43,6 @@ class LagrangianOuterBound(mpisppy.cylinders.spoke.OuterBoundWSpoke):
         # the weights came from the same PH iteration
         serial_number = self.get_serial_number()
         bound, extra_sums  = self.opt.Ebound(verbose, extra_sum_terms=[serial_number])
-
         serial_number_sum = int(round(extra_sums[0]))
 
         total = int(self.intracomm.Get_size())*serial_number


### PR DESCRIPTION
changes to run_all.py to try to get the bi-weekly tests to be able to complete in less than three
hours (xpress hates the sizes problem)