### PR TITLE
Adding global_toc

### DIFF
--- a/mpisppy/__init__.py
+++ b/mpisppy/__init__.py
@@ -9,6 +9,10 @@ except:
     haveMPI=False
 
 tt_timer = TicTocTimer()
-global_rank = mpi.COMM_WORLD.Get_rank()
+
+if haveMPI:
+    global_rank = mpi.COMM_WORLD.Get_rank()
+else:
+    global_rank = 0
 
 global_toc = lambda msg, cond=(global_rank==0) : tt_timer.toc(msg, delta=False) if cond else None

--- a/mpisppy/__init__.py
+++ b/mpisppy/__init__.py
@@ -9,6 +9,6 @@ except:
     haveMPI=False
 
 tt_timer = TicTocTimer()
-if not haveMPI or mpi.COMM_WORLD.Get_rank() == 0:
-    with open(os.devnull,"w") as f:
-        tt_timer.toc("Initializing mpi-sppy", delta=False, ostream=f)
+global_rank = mpi.COMM_WORLD.Get_rank()
+
+global_toc = lambda msg, cond=(global_rank==0) : tt_timer.toc(msg, delta=False) if cond else None

--- a/mpisppy/cylinders/cross_scen_spoke.py
+++ b/mpisppy/cylinders/cross_scen_spoke.py
@@ -8,8 +8,6 @@ import numpy as np
 import pyomo.environ as pyo
 import mpisppy.cylinders.spoke as spoke
 
-from mpisppy import tt_timer
-
 class CrossScenarioCutSpoke(spoke.Spoke):
     def __init__(self, spbase_object, fullcomm, intercomm, intracomm):
         super().__init__(spbase_object, fullcomm, intercomm, intracomm)

--- a/mpisppy/cylinders/hub.py
+++ b/mpisppy/cylinders/hub.py
@@ -11,7 +11,7 @@ from mpisppy.cylinders.spcommunicator import SPCommunicator
 from math import inf
 from mpisppy.cylinders.spoke import ConvergerSpokeType
 
-from mpisppy import tt_timer
+from mpisppy import global_toc 
 
 # Could also pass, e.g., sys.stdout instead of a filename
 mpisppy.log.setup_logger("mpisppy.cylinders.Hub",
@@ -114,10 +114,10 @@ class Hub(SPCommunicator):
         update_source = self.get_update_string()
         if self.print_init:
             row = f'{"Iter.":>5s}  {"   "}  {"Best Bound":>14s}  {"Best Incumbent":>14s}  {"Rel. Gap":>12s}  {"Abs. Gap":>14s}'
-            tt_timer.toc(row, delta=False)
+            global_toc(row, True)
             self.print_init = False
         row = f"{current_iteration:5d}  {update_source}  {best_bound:14.4f}  {best_solution:14.4f}  {rel_gap*100:12.3f}%  {abs_gap:14.4f}"
-        tt_timer.toc(row, delta=False)
+        global_toc(row, True)
         self.clear_latest_chars()
 
     def determine_termination(self):
@@ -130,10 +130,10 @@ class Hub(SPCommunicator):
             if "abs_gap" in self.options:
                 abs_gap = self.compute_gap(compute_relative=False)
                 abs_gap_satisfied = abs_gap <= self.options["abs_gap"]
-        if abs_gap_satisfied and self.rank_global == 0:
-            tt_timer.toc(f"Terminating based on inter-cylinder absolute gap {abs_gap:12.4f}", delta=False)
-        if rel_gap_satisfied and self.rank_global == 0:
-            tt_timer.toc(f"Terminating based on inter-cylinder relative gap {rel_gap*100:12.3f}%", delta=False)
+        if abs_gap_satisfied:
+            global_toc(f"Terminating based on inter-cylinder absolute gap {abs_gap:12.4f}")
+        if rel_gap_satisfied:
+            global_toc(f"Terminating based on inter-cylinder relative gap {rel_gap*100:12.3f}%")
         return abs_gap_satisfied or rel_gap_satisfied
 
     def hub_finalize(self):
@@ -144,8 +144,7 @@ class Hub(SPCommunicator):
 
         if self.rank_global == 0:
             self.print_init = True
-            tt_timer.toc(f" ", delta=False)
-            tt_timer.toc(f"Statistics at termination", delta=False)
+            global_toc(f"Statistics at termination", True)
             self.screen_trace()
 
     def receive_innerbounds(self):
@@ -450,10 +449,10 @@ class PHHub(Hub):
             return False
 
         if not self.has_outerbound_spokes:
-            if self.opt._PHIter == 1 and self.rank_global == 0:
-                tt_timer.toc(
+            if self.opt._PHIter == 1:
+                global_toc(
                     "Without outer bound spokes, no progress "
-                    "will be made on the Best Bound", delta=False)
+                    "will be made on the Best Bound")
 
         ## log some output
         if self.rank_global == 0:

--- a/mpisppy/extensions/cross_scen_extension.py
+++ b/mpisppy/extensions/cross_scen_extension.py
@@ -4,7 +4,7 @@ from mpisppy.extensions.extension import PHExtension
 from mpisppy.utils.sputils import find_active_objective
 from pyomo.repn.standard_repn import generate_standard_repn
 from pyomo.core.expr.numeric_expr import LinearExpression
-from mpisppy import tt_timer
+from mpisppy import global_toc
 
 import pyomo.environ as pyo
 import sys
@@ -271,8 +271,7 @@ class CrossScenarioExtension(PHExtension):
                 ((self.iter_since_last_check%self.check_bound_iterations == 0) and self.opt.spcomm.new_cuts))
                 # if there hasn't been OB movement, check every so often if we have new cuts
         if check:
-            if self.opt.spcomm.rank_global == 0:
-                tt_timer.toc(f"Attempting to update Best Bound with CrossScenarioExtension", delta=False)
+            global_toc(f"Attempting to update Best Bound with CrossScenarioExtension")
             self._check_bound()
             self.opt.spcomm.new_cuts = False
             self.iter_since_last_check = 0

--- a/mpisppy/spbase.py
+++ b/mpisppy/spbase.py
@@ -14,7 +14,7 @@ import mpisppy.utils.sputils as sputils
 from collections import OrderedDict
 from mpi4py import MPI
 
-from mpisppy import tt_timer
+from mpisppy import global_toc
 
 logger = logging.getLogger("PHBase")
 logger.setLevel(logging.WARN)
@@ -86,8 +86,7 @@ class SPBase(object):
         self.rank0 = rank0
         self.rank_global = MPI.COMM_WORLD.Get_rank()
 
-        if self.rank_global == 0:
-            tt_timer.toc("Start SPBase.__init__" ,delta=False)
+        global_toc("Initializing SPBase")
 
         # This doesn't seemed to be checked anywhere else
         if self.n_proc > len(self.all_scenario_names):

--- a/mpisppy/utils/sputils.py
+++ b/mpisppy/utils/sputils.py
@@ -19,7 +19,7 @@ except:
     haveMPI = False
 from pyomo.core.expr.numeric_expr import LinearExpression
 
-from mpisppy import tt_timer
+from mpisppy import tt_timer, global_toc
 
 def spin_the_wheel(hub_dict, list_of_spoke_dict, comm_world=None):
     """ top level for the hub and spoke system
@@ -111,8 +111,7 @@ def spin_the_wheel(hub_dict, list_of_spoke_dict, comm_world=None):
     spcomm.make_windows()
     if rank_inter == 0:
         spcomm.setup_hub()
-    if rank_global == 0:
-        tt_timer.toc("Starting spcomm.main()", delta=False)
+    global_toc("Starting spcomm.main()")
     spcomm.main()
     if rank_inter == 0: # If this is the hub
         spcomm.send_terminate()
@@ -120,16 +119,14 @@ def spin_the_wheel(hub_dict, list_of_spoke_dict, comm_world=None):
     # Anything that's left to do
     spcomm.finalize()
 
-    if rank_global == 0:
-        tt_timer.toc("Hub algorithm complete, waiting for termination barrier", delta=False)
+    global_toc("Hub algorithm complete, waiting for termination barrier")
     fullcomm.Barrier()
 
     ## give the hub the chance to catch new values
     spcomm.hub_finalize()
 
     spcomm.free_windows()
-    if rank_global == 0:
-        tt_timer.toc("Windows freed", delta=False)
+    global_toc("Windows freed")
 
     return spcomm, opt_dict
     


### PR DESCRIPTION
This PR adds a wrapper around `mpisppy.tt_timer.toc` called `global_toc`. `mpisppy.global_toc` takes two arguments, a message and an optional conditional. If the conditional is `False`, nothing will be printed, otherwise `mpisppy.tt_timer.toc` is called with `delta=False`. By default the conditional is only set to `True` on global rank 0 and `False` on all other ranks.