### PR TITLE
Varprob

### DIFF
--- a/doc/src/extensions.rst
+++ b/doc/src/extensions.rst
@@ -72,8 +72,47 @@ There is an example of the function in the sizes example (``_rho_setter``).
 variable_probability
 ====================
 
-A function similar to ``rho_setter`` can be passed to the ``SPBase`` constructor
-via the ``PHBase`` construtor
-as the ``variable_probability`` argument to allow for per variable probability
-specification. So it can be passed through by ``vanilla`` via
-``ph_hub``. The function should return (vid, probability) pairs.
+This is experimental as of February 2021.  The main use-case is
+to allow zero-probability variables.
+
+A function similar to ``rho_setter`` can be passed to the ``SPBase``
+constructor via the ``PHBase`` construtor as the
+``variable_probability`` argument to allow for per variable
+probability specification. So it can be passed through by ``vanilla``
+via ``ph_hub``. The function should return (vid, probability) pairs.
+
+Of course the variable probabilities impact the computation of
+``xbars``.
+
+Objective function considerations
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If variables with by-variable probability are in the objective function, it is
+up to the scenario creator code to deal with it. This is not so difficult for
+zero-probability variables.
+
+zero-probability variables
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You probably want to fix zero probability variables and perhaps give
+them a zero coefficient if they appear in the objective when you
+create the scenario. Fixed variables will not get a nonanticipativity
+in bundles and if you create the EF directly, you probably want to set
+``nonant_for_fixed_vars`` to `False` in the call to ``create_EF``. If
+you are not calling ``create_EF`` directly, but rather using the
+``mpisppy.opt.ef.ExtensiveForm`` object, add ``nonant_for_fixed_vars``
+to the dict passed as its ``options`` argument with the value
+``False``.
+
+Note that the ``W`` value for a zero-probability variable
+may be updated by PH so it could become extreme. This will harmless for
+optimizastion of subproblems if the variable is
+fixed buy might cause problems for code that analyzes ``W`` values.
+
+A fixed variable may also cause trouble if you are relying on the internal
+PH convergence metric.
+
+.. Note::
+   You must declare variables to be in the nonant list even for those scenarios where they have
+   zero probability if they are in other scenarios that share a scenario tree node at the variable's stage.
+

--- a/doc/src/extensions.rst
+++ b/doc/src/extensions.rst
@@ -24,7 +24,7 @@ passed to the PH constructor and it is assumed to have methods defined
 for all the callout points in PH (so all of the examples do).  If you
 want to use more than one extension, define a main extension that has
 a reference to the other extensions and can call their methods in the
-appropriate order. Extensions typicall access low level elements of
+appropriate order. Extensions typically access low level elements of
 ``mpi-sppy`` so writing your extensions is an advanced topic. We will
 now describe a few of the extensions in the release.
 
@@ -72,7 +72,7 @@ There is an example of the function in the sizes example (``_rho_setter``).
 variable_probability
 ====================
 
-This is experimental as of February 2021.  The main use-case is
+This is experimental as of February 2021; use with caution.  The main use-case is
 to allow zero-probability variables.
 
 A function similar to ``rho_setter`` can be passed to the ``SPBase``
@@ -81,7 +81,7 @@ constructor via the ``PHBase`` construtor as the
 probability specification. So it can be passed through by ``vanilla``
 via ``ph_hub``. The function should return (vid, probability) pairs.
 
-Of course the variable probabilities impact the computation of
+The variable probabilities impact the computation of
 ``xbars``.
 
 Objective function considerations
@@ -94,10 +94,11 @@ zero-probability variables.
 zero-probability variables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-You probably want to fix zero probability variables and perhaps give
-them a zero coefficient if they appear in the objective when you
-create the scenario. Fixed variables will not get a nonanticipativity
-in bundles and if you create the EF directly, you probably want to set
+When you
+create the scenario, you probably want to fix zero probability variables and perhaps give
+them a zero coefficient if they appear in the objective. Fixed
+variables will not get a nonanticipativity constraint in bundles. If you
+create the EF directly, you probably want to set
 ``nonant_for_fixed_vars`` to `False` in the call to ``create_EF``. If
 you are not calling ``create_EF`` directly, but rather using the
 ``mpisppy.opt.ef.ExtensiveForm`` object, add ``nonant_for_fixed_vars``
@@ -106,7 +107,7 @@ to the dict passed as its ``options`` argument with the value
 
 Note that the ``W`` value for a zero-probability variable
 may be updated by PH so it could become extreme. This will harmless for
-optimizastion of subproblems if the variable is
+optimization of subproblems if the variable is
 fixed buy might cause problems for code that analyzes ``W`` values.
 
 A fixed variable may also cause trouble if you are relying on the internal

--- a/doc/src/extensions.rst
+++ b/doc/src/extensions.rst
@@ -109,7 +109,7 @@ to the dict passed as its ``options`` argument with the value
    The ``W`` value for a zero-probability variable will be stay at zero.
 
 
-A fixed variable may also cause trouble if you are relying on the internal
+A fixed variables may cause trouble if you are relying on the internal
 PH convergence metric.
 
 .. Note::

--- a/doc/src/extensions.rst
+++ b/doc/src/extensions.rst
@@ -105,10 +105,9 @@ you are not calling ``create_EF`` directly, but rather using the
 to the dict passed as its ``options`` argument with the value
 ``False``.
 
-Note that the ``W`` value for a zero-probability variable
-may be updated by PH so it could become extreme. This will harmless for
-optimization of subproblems if the variable is
-fixed buy might cause problems for code that analyzes ``W`` values.
+.. Note::
+   The ``W`` value for a zero-probability variable will be stay at zero.
+
 
 A fixed variable may also cause trouble if you are relying on the internal
 PH convergence metric.

--- a/mpisppy/opt/aph.py
+++ b/mpisppy/opt/aph.py
@@ -721,7 +721,8 @@ class APH(ph_base.PHBase):  # ??????
                 self.extobject.miditer()
             
             teeme = ("tee-rank0-solves" in self.PHoptions) \
-                 and (self.PHoptions["tee-rank0-solves"] == True)
+                 and (self.PHoptions["tee-rank0-solves"] == True
+                      and self.rank == self.rank0)
             # Let the solve loop deal with persistent solvers & signal handling
             # Aug2020 switch to a partial loop xxxxx maybe that is enough.....
             # Aug2020 ... at least you would get dispatch

--- a/mpisppy/phbase.py
+++ b/mpisppy/phbase.py
@@ -1369,9 +1369,10 @@ class PHBase(mpisppy.spbase.SPBase):
         global_toc("Creating solvers")
         self._create_solvers()
         
-        teeme = False
-        if ("tee-rank0-solves" in self.PHoptions):
-            teeme = self.PHoptions['tee-rank0-solves']
+        teeme = ("tee-rank0-solves" in self.PHoptions
+                 and teeme = self.PHoptions['tee-rank0-solves']
+                 and self.rank = self.rank0
+                 )
             
         if self.PHoptions["verbose"]:
             print ("About to call PH Iter0 solve loop on rank={}".format(self.rank))

--- a/mpisppy/phbase.py
+++ b/mpisppy/phbase.py
@@ -223,6 +223,7 @@ class PHBase(mpisppy.spbase.SPBase):
         # Assumes the scenarios are up to date
         for k,s in self.local_scenarios.items():
             for ndn_i, nonant in s._nonant_indexes.items():
+                (lndn, li) = ndn_i
                 xdiff = nonant._value \
                         - s._xbars[ndn_i]._value
                 s._Ws[ndn_i]._value += pyo.value(s._PHrho[ndn_i]) * xdiff
@@ -230,6 +231,11 @@ class PHBase(mpisppy.spbase.SPBase):
                     print ("rank, node, scen, var, W", ndn_i[0], k,
                            self.rank, nonant.name,
                            pyo.value(s._Ws[ndn_i]))
+            # Special code for variable probabilities to mask W; rarely used.
+            if hasattr(s,"_PySP_W_coeff") and type(s._PySP_W_coeff) is not float:
+                for ndn_i in s._nonant_indexes:
+                    (lndn, li) = ndn_i
+                    s._Ws[ndn_i] *= s._PySP_W_coeff[lndn][li]
 
     def convergence_diff(self):
         """ Compute the convergence metric ||x_s - \\bar{x}||_1 / num_scenarios.

--- a/mpisppy/phbase.py
+++ b/mpisppy/phbase.py
@@ -1510,6 +1510,7 @@ class PHBase(mpisppy.spbase.SPBase):
             teeme = (
                 "tee-rank0-solves" in self.PHoptions
                  and self.PHoptions["tee-rank0-solves"]
+                and self.rank == self.rank0
             )
             self.solve_loop(
                 solver_options=self.current_solver_options,

--- a/mpisppy/phbase.py
+++ b/mpisppy/phbase.py
@@ -236,7 +236,7 @@ class PHBase(mpisppy.spbase.SPBase):
                 for ndn_i in s._nonant_indexes:
                     (lndn, li) = ndn_i
                     if type(s._PySP_W_coeff[lndn]) is not float:
-                    s._Ws[ndn_i] *= s._PySP_W_coeff[lndn][li]
+                        s._Ws[ndn_i] *= s._PySP_W_coeff[lndn][li]
 
     def convergence_diff(self):
         """ Compute the convergence metric ||x_s - \\bar{x}||_1 / num_scenarios.

--- a/mpisppy/phbase.py
+++ b/mpisppy/phbase.py
@@ -232,11 +232,12 @@ class PHBase(mpisppy.spbase.SPBase):
                            self.rank, nonant.name,
                            pyo.value(s._Ws[ndn_i]))
             # Special code for variable probabilities to mask W; rarely used.
-            if hasattr(s,"_PySP_W_coeff"):
+            if s._PySP_has_varprob:
                 for ndn_i in s._nonant_indexes:
                     (lndn, li) = ndn_i
-                    if type(s._PySP_W_coeff[lndn]) is not float:
-                        s._Ws[ndn_i] *= s._PySP_W_coeff[lndn][li]
+                    # Requiring a vector for every tree node? (should we?)
+                    # if type(s._PySP_W_coeff[lndn]) is not float:
+                    s._Ws[ndn_i] *= s._PySP_W_coeff[lndn][li]
 
     def convergence_diff(self):
         """ Compute the convergence metric ||x_s - \\bar{x}||_1 / num_scenarios.

--- a/mpisppy/phbase.py
+++ b/mpisppy/phbase.py
@@ -1370,8 +1370,8 @@ class PHBase(mpisppy.spbase.SPBase):
         self._create_solvers()
         
         teeme = ("tee-rank0-solves" in self.PHoptions
-                 and teeme = self.PHoptions['tee-rank0-solves']
-                 and self.rank = self.rank0
+                 and self.PHoptions['tee-rank0-solves']
+                 and self.rank == self.rank0
                  )
             
         if self.PHoptions["verbose"]:

--- a/mpisppy/phbase.py
+++ b/mpisppy/phbase.py
@@ -232,9 +232,10 @@ class PHBase(mpisppy.spbase.SPBase):
                            self.rank, nonant.name,
                            pyo.value(s._Ws[ndn_i]))
             # Special code for variable probabilities to mask W; rarely used.
-            if hasattr(s,"_PySP_W_coeff") and type(s._PySP_W_coeff) is not float:
+            if hasattr(s,"_PySP_W_coeff"):
                 for ndn_i in s._nonant_indexes:
                     (lndn, li) = ndn_i
+                    if type(s._PySP_W_coeff[lndn]) is not float:
                     s._Ws[ndn_i] *= s._PySP_W_coeff[lndn][li]
 
     def convergence_diff(self):

--- a/mpisppy/spbase.py
+++ b/mpisppy/spbase.py
@@ -248,6 +248,7 @@ class SPBase(object):
             s = self.scenario_creator(sname, node_names=None, cb_data=cb_data)
             if not hasattr(s, "PySP_prob"):
                 s.PySP_prob = 1.0 / len(self.all_scenario_names)
+            s._PySP_has_varprob = False  # Might be later set to True (but rarely)
             self.local_scenarios[sname] = s
             if "display_timing" in self.options and self.options["display_timing"]:
                 instance_creation_time = time.time() - instance_creation_start_time
@@ -380,6 +381,7 @@ class SPBase(object):
                             else dict()
         for sname, s in self.local_scenarios.items():
             variable_probability = self.variable_probability(s, **variable_probability_kwargs)
+            s._PySP_has_varprob = True
             for (vid, prob) in variable_probability:
                 ndn, i = s._varid_to_nonant_index[vid]
                 # If you are going to do any variables at a node, you have to do all.

--- a/mpisppy/spbase.py
+++ b/mpisppy/spbase.py
@@ -347,16 +347,19 @@ class SPBase(object):
 
 
     def compute_unconditional_node_probabilities(self):
-        """ calculates unconditional node probabilities and _PySP_prob_coeff """
+        """ calculates unconditional node probabilities and _PySP_prob_coeff
+            and _PySP_W_coeff is set to a scalar 1 (used by variable_probability)"""
         for k,s in self.local_scenarios.items():
             root = s._PySPnode_list[0]
             root.uncond_prob = 1.0
             for parent,child in zip(s._PySPnode_list[:-1],s._PySPnode_list[1:]):
                 child.uncond_prob = parent.uncond_prob * child.cond_prob
             if not hasattr(s, '_PySP_prob_coeff'):
-                s._PySP_prob_coeff = {}
+                s._PySP_prob_coeff = dict()
+                s._PySP_W_coeff = dict()
                 for node in s._PySPnode_list:
                     s._PySP_prob_coeff[node.name] = (s.PySP_prob / node.uncond_prob)
+                    s._PySP_W_coeff[node.name] = 1.0  # needs to be a float
 
 
     def set_multistage(self):
@@ -365,7 +368,8 @@ class SPBase(object):
     def use_variable_probability_setter(self, verbose=False):
         """ set variable probability unconditional values using a function self.variable_probability
         that gives us a list of (id(vardata), probability)]
-        Note: We estimate that less then 0.01 of mpi-sppy runs will call this.
+        ALSO set _PySP_W_coeff, which is a mask for W calculations (mask out zero probs)
+        Note: We estimate that less than 0.01 of mpi-sppy runs will call this.
         """
         if self.variable_probability is None:
             return
@@ -382,7 +386,10 @@ class SPBase(object):
                 if type(s._PySP_prob_coeff[ndn]) is float:  # not yet a vector
                     defprob = s._PySP_prob_coeff[ndn]
                     s._PySP_prob_coeff[ndn] = np.full(s._PySP_nlens[ndn], defprob, dtype='d')
+                    s._PySP_W_coeff[ndn] = np.ones(s._PySP_nlens[ndn], dtype='d')
                 s._PySP_prob_coeff[ndn][i] = prob
+                if prob == 0:  # there's probably a way to do this in numpy...
+                    s._PySP_W_coeff[ndn][i] = 0
             didit += len(variable_probability)
             skipped += len(s._varid_to_nonant_index) - didit
         if verbose and self.rank == self.rank0:

--- a/mpisppy/utils/sputils.py
+++ b/mpisppy/utils/sputils.py
@@ -166,7 +166,8 @@ def get_objs(scenario_instance):
     return scenario_objs
 
 def create_EF(scenario_names, scenario_creator, creator_options=None,
-              EF_name=None, suppress_warnings=False):
+              EF_name=None, suppress_warnings=False,
+              nonant_for_fixed_vars=True):
     """ Create a ConcreteModel of the extensive form.
 
         Args:
@@ -182,6 +183,9 @@ def create_EF(scenario_names, scenario_creator, creator_options=None,
                 Name of the ConcreteModel of the EF.
             suppress_warnings (boolean, optional):
                 If true, do not display warnings. Default False.
+            nonant_for_fixed_vars (bool--optional): If True, enforces
+                non-anticipativity constraints for all variables, including
+                those which have been fixed. Default is True.
 
         Returns:
             EF_instance (ConcreteModel):
@@ -234,7 +238,9 @@ def create_EF(scenario_names, scenario_creator, creator_options=None,
             print('WARNING: At least one scenario is missing PySP_prob attribute.',
                   'Assuming equally-likely scenarios...')
 
-    EF_instance = _create_EF_from_scen_dict(scen_dict, EF_name=EF_name)
+    EF_instance = _create_EF_from_scen_dict(scen_dict,
+                                            EF_name=EF_name,
+                                            nonant_for_fixed_vars=True)
     return EF_instance
 
 def _create_EF_from_scen_dict(scen_dict, EF_name=None,
@@ -249,7 +255,7 @@ def _create_EF_from_scen_dict(scen_dict, EF_name=None,
             EF_name (str--optional): Name of the resulting EF model.
             nonant_for_fixed_vars (bool--optional): If True, enforces
                 non-anticipativity constraints for all variables, including
-                those which have been fixed. Deafult is True.
+                those which have been fixed. Default is True.
 
         Returns:
             EF_instance (ConcreteModel): ConcreteModel of extensive form with


### PR DESCRIPTION
Do not update W for zero probability variables.

Expose the EF option for not providing nonant constraints in the EF for fixed Vars. 

There is also some rambling text added to the documentation for variable probabilities.

Fix a bug re: tee-rank0-solves