### PR TITLE
only run GHA to publish to pypi for tagged commits

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,6 +1,9 @@
 name: Publish Python distributions to PyPI and TestPyPI
 
-on: push
+on:
+  push:
+    tags:
+      - '*'
 
 jobs:
   build-n-publish:


### PR DESCRIPTION
I believe this PR will ensure the "publish-to-test-pypi" tests only get run for tagged commits. This allows GitHub Actions to be enabled on forks.