### PR TITLE
Multistage compatibility for xhatshufflelooper spoke

### DIFF
--- a/doc/src/spokes.rst
+++ b/doc/src/spokes.rst
@@ -63,12 +63,16 @@ xhatshufflelooper_bounder
 
 This bounder shuffles the scenarios and loops over them to try a 
 :math:`\hat{x}` until
-the hub provides a new x.  To ensure that all scenarios are tried
+the hub provides a new x.  To ensure that all subproblems are tried
 eventually, the spoke remembers where it left off, and resumes from
 its prior position.  Since the resulting subproblems after fixing the
 first-stage variables are usually much easier to solve, many candidate
 solutions can be tried before receiving new x values from the hub.
 
+This spoke also works with multistage. It does not try every subproblem, but
+shuffles the scenarios and tries subproblems with a first-stage 
+solution specified by the shuffled scenario.
+ 
 slam_heuristic
 ^^^^^^^^^^^^^^
 

--- a/doc/src/spokes.rst
+++ b/doc/src/spokes.rst
@@ -69,16 +69,18 @@ its prior position.  Since the resulting subproblems after fixing the
 first-stage variables are usually much easier to solve, many candidate
 solutions can be tried before receiving new x values from the hub.
 
-This spoke also works with multistage. It does not try every subproblem, but
-shuffles the scenarios and tries subproblems with a first-stage 
-solution specified by the shuffled scenario.
+This spoke also supports multistage problems. It does not try every subproblem, but
+shuffles the scenarios and loops over the shuffled list.
+At each step, it takes the first-stage solution specified by a scenario, 
+ and then uses the scenarios that follows in the shuffled loop to get the 
+ values of the non-first-stage variables that were not fixed before.
  
 slam_heuristic
 ^^^^^^^^^^^^^^
 
 This heuristic attempts to find a feasible solution by slamming every
 variable to its maximum (or minimum) over every scenario associated 
-with that scenario tree node.
+with that scenario tree node. This spokes only supports two-stage problems at this time.
 
 
 General

--- a/doc/src/spokes.rst
+++ b/doc/src/spokes.rst
@@ -61,8 +61,9 @@ trial values for :math:`\hat{x}`.
 xhatshufflelooper_bounder
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This bounder shuffles the scenarios loops over them scenarios until
-the hub provides a new x.  To ensure that all subproblems are tried
+This bounder shuffles the scenarios and loops over them to try a 
+:math:`\hat{x}` until
+the hub provides a new x.  To ensure that all scenarios are tried
 eventually, the spoke remembers where it left off, and resumes from
 its prior position.  Since the resulting subproblems after fixing the
 first-stage variables are usually much easier to solve, many candidate

--- a/examples/aircond/aircond_cylinders.py
+++ b/examples/aircond/aircond_cylinders.py
@@ -151,7 +151,7 @@ def main():
     ScenCount = np.prod(BFs)
     #ScenCount = _get_num_leaves(BFs)
     scenario_creator_kwargs = {"BFs": BFs}
-    all_scenario_names = [f"scen{i+1}" for i in range(ScenCount)]
+    all_scenario_names = [f"scen{i}" for i in range(ScenCount)] #Scens are 0-based
     # print(all_scenario_names)
     scenario_creator = aircond_submodels.scenario_creator
     scenario_denouement = aircond_submodels.scenario_denouement
@@ -167,9 +167,6 @@ def main():
                               rho_setter = rho_setter)
     hub_dict["opt_kwargs"]["all_nodenames"] = all_nodenames
     hub_dict["opt_kwargs"]["options"]["branching_factors"] = BFs
-    if args.default_rho is None:
-        # we need to specify a rho
-        hub_dict["opt_kwargs"]["options"]["defaultPHrho"] = 1  
 
     # Standard Lagrangian bound spoke
     if with_lagrangian:

--- a/examples/aircond/aircond_cylinders.py
+++ b/examples/aircond/aircond_cylinders.py
@@ -140,6 +140,7 @@ def main():
 
     with_xhatspecific = args.with_xhatspecific
     with_lagrangian = args.with_lagrangian
+    with_xhatshuffle = args.with_xhatshuffle
 
     # This is multi-stage, so we need to supply node names
     #all_nodenames = ["ROOT"] # all trees must have this node
@@ -184,6 +185,13 @@ def main():
                                                         BFs,
                                                         scenario_creator_kwargs=scenario_creator_kwargs)
     
+    #xhat shuffle looper bound spoke
+    
+    if with_xhatshuffle:
+        xhatshuffle_spoke = vanilla.xhatshuffle_spoke(*beans, 
+                                                      all_nodenames,
+                                                      BFs,
+                                                      scenario_creator_kwargs=scenario_creator_kwargs)
 
     list_of_spoke_dict = list()
     if with_lagrangian:

--- a/examples/aircond/aircond_cylinders.py
+++ b/examples/aircond/aircond_cylinders.py
@@ -167,6 +167,9 @@ def main():
                               rho_setter = rho_setter)
     hub_dict["opt_kwargs"]["all_nodenames"] = all_nodenames
     hub_dict["opt_kwargs"]["options"]["branching_factors"] = BFs
+    if args.default_rho is None:
+        # we need to specify a rho
+        hub_dict["opt_kwargs"]["options"]["defaultPHrho"] = 1  
 
     # Standard Lagrangian bound spoke
     if with_lagrangian:
@@ -189,6 +192,7 @@ def main():
     
     if with_xhatshuffle:
         xhatshuffle_spoke = vanilla.xhatshuffle_spoke(*beans, 
+                                                      xhat_scenario_dict,
                                                       all_nodenames,
                                                       BFs,
                                                       scenario_creator_kwargs=scenario_creator_kwargs)
@@ -198,6 +202,8 @@ def main():
         list_of_spoke_dict.append(lagrangian_spoke)
     if with_xhatspecific:
         list_of_spoke_dict.append(xhatspecific_spoke)
+    if with_xhatshuffle:
+        list_of_spoke_dict.append(xhatshuffle_spoke)
 
     spcomm, opt_dict = sputils.spin_the_wheel(hub_dict, list_of_spoke_dict)
 

--- a/examples/aircond/aircond_cylinders.py
+++ b/examples/aircond/aircond_cylinders.py
@@ -189,7 +189,6 @@ def main():
     
     if with_xhatshuffle:
         xhatshuffle_spoke = vanilla.xhatshuffle_spoke(*beans, 
-                                                      xhat_scenario_dict,
                                                       all_nodenames,
                                                       BFs,
                                                       scenario_creator_kwargs=scenario_creator_kwargs)

--- a/mpisppy/cylinders/xhatshufflelooper_bounder.py
+++ b/mpisppy/cylinders/xhatshufflelooper_bounder.py
@@ -134,7 +134,8 @@ class XhatShuffleInnerBound(spoke.InnerBoundNonantSpoke):
         self.random_stream.seed(self.random_seed)
         #Check that they have the same stream
         check = self.random_stream.normalvariate(0, 1)
-        print(f"Hello, for global rank {global_rank}, random stream gives a value of {check}")
+        chack2 = self.random_stream.normalvariate(0, 1)
+        print(f"Hello, for global rank {global_rank}, random stream gives a value of {check} and {check2}")
         
         # shuffle the scenarios (i.e., sample without replacement)
         shuffled_scenarios = self.random_stream.sample(

--- a/mpisppy/cylinders/xhatshufflelooper_bounder.py
+++ b/mpisppy/cylinders/xhatshufflelooper_bounder.py
@@ -134,7 +134,7 @@ class XhatShuffleInnerBound(spoke.InnerBoundNonantSpoke):
         self.random_stream.seed(self.random_seed)
         #Check that they have the same stream
         check = self.random_stream.normalvariate(0, 1)
-        chack2 = self.random_stream.normalvariate(0, 1)
+        check2 = self.random_stream.normalvariate(0, 1)
         print(f"Hello, for global rank {global_rank}, random stream gives a value of {check} and {check2}")
         
         # shuffle the scenarios (i.e., sample without replacement)

--- a/mpisppy/cylinders/xhatshufflelooper_bounder.py
+++ b/mpisppy/cylinders/xhatshufflelooper_bounder.py
@@ -4,6 +4,7 @@ import os
 import time
 import logging
 import random
+import numpy as np
 import mpisppy.log
 import mpisppy.utils.sputils as sputils
 import mpisppy.cylinders.spoke as spoke
@@ -11,7 +12,6 @@ import mpi4py.MPI as mpi
 fullcomm = mpi.COMM_WORLD
 global_rank = fullcomm.Get_rank()
 
-from math import inf, isclose
 from mpisppy.utils.xhat_eval import Xhat_Eval
 from mpisppy.extensions.xhatbase import XhatBase
 
@@ -26,8 +26,6 @@ class XhatShuffleInnerBound(spoke.InnerBoundNonantSpoke):
     converger_spoke_char = 'X'
 
     def xhatbase_prep(self):
-        if self.opt.multistage and self.opt.options["xhat_looper_options"]["xhat_scenario_dict"] is None:
-            raise RuntimeError ("For multistage problems, XhatShuffleLooper needs a xhat_scenario_dict attribute")
 
         verbose = self.opt.options['verbose']
         if "bundles_per_rank" in self.opt.options\
@@ -95,11 +93,8 @@ class XhatShuffleInnerBound(spoke.InnerBoundNonantSpoke):
         self.random_stream = random.Random()
 
 
-    def try_scenario(self, scenario, xhat_scenario_dict):
-        if xhat_scenario_dict is None:
-            snamedict = {"ROOT":scenario}
-        else:
-            snamedict = xhat_scenario_dict
+    def try_scenario_dict(self, xhat_scenario_dict):
+        snamedict = xhat_scenario_dict
         obj = self.xhatter._try_one(snamedict,
                             solver_options = self.solver_options,
                             verbose=False,
@@ -110,38 +105,30 @@ class XhatShuffleInnerBound(spoke.InnerBoundNonantSpoke):
 
         if self.running_trace_filen is not None:
             with open(self.running_trace_filen, "a") as f:
-                f.write(f"{time.time()},{scenario},{obj}\n")
+                f.write(f"{time.time()},{snamedict},{obj}\n")
         if obj is None:
-            _vb(f"    Infeasible {scenario}")
+            _vb(f"    Infeasible {snamedict}")
             return False
-        _vb(f"    Feasible {scenario}, obj: {obj}")
+        _vb(f"    Feasible {snamedict}, obj: {obj}")
 
         update = self.update_if_improving(obj)
-        logger.debug(f'   bottom of try_scenario on rank {self.global_rank}')
+        logger.debug(f'   bottom of try_scenario_dict on rank {self.global_rank}')
         return update
 
     def main(self):
         verbose = self.opt.options["verbose"] # typing aid  
         logger.debug(f"Entering main on xhatshuffle spoke rank {self.global_rank}")
 
-        # What to try does not change, but the data in the scenarios should
-        xhat_scenario_dict = self.opt.options["xhat_looper_options"]\
-                                             ["xhat_scenario_dict"]
-
         self.xhatbase_prep()
 
         # give all ranks the same seed
         self.random_stream.seed(self.random_seed)
-        #Check that they have the same stream
-        check = self.random_stream.normalvariate(0, 1)
-        check2 = self.random_stream.normalvariate(0, 1)
-        print(f"Hello, for global rank {global_rank}, random stream gives a value of {check} and {check2}")
         
-        # shuffle the scenarios (i.e., sample without replacement)
-        shuffled_scenarios = self.random_stream.sample(
-            self.opt.all_scenario_names,
-            len(self.opt.all_scenario_names))
-        scenario_cycler = ScenarioCycler(shuffled_scenarios)
+        # shuffle the scenarios associated (i.e., sample without replacement)
+        shuffled_scenarios = self.random_stream.sample(self.opt.all_scenario_names, 
+                                                       len(self.opt.all_scenario_names))
+        scenario_cycler = ScenarioCycler(shuffled_scenarios,
+                                         self.opt.nonleaves)
 
         def _vb(msg): 
             if self.verbose and self.opt.cylinder_rank == 0:
@@ -165,13 +152,13 @@ class XhatShuffleInnerBound(spoke.InnerBoundNonantSpoke):
                 self.opt._put_nonant_cache(self.localnonants)
                 self.opt._restore_nonants()
 
-            next_scenario_name = scenario_cycler.get_next()
-            if next_scenario_name is not None:
-                _vb(f"   Trying next {next_scenario_name}")
-                update = self.try_scenario(next_scenario_name,xhat_scenario_dict)
+            next_scendict = scenario_cycler.get_next()
+            if next_scendict is not None:
+                _vb(f"   Trying next {next_scendict}")
+                update = self.try_scenario_dict(next_scendict)
                 if update:
-                    _vb(f"   Updating best to {next_scenario_name}")
-                    scenario_cycler.best = next_scenario_name
+                    _vb(f"   Updating best to {next_scendict}")
+                    scenario_cycler.best = next_scendict
             else:
                 scenario_cycler.begin_epoch()
 
@@ -182,37 +169,117 @@ class XhatShuffleInnerBound(spoke.InnerBoundNonantSpoke):
 
 class ScenarioCycler:
 
-    def __init__(self, all_scenario_list):
-        self._all_scenario_list = all_scenario_list
-        self._num_scenarios = len(all_scenario_list)
+    def __init__(self, shuffled_snames,nonleaves):
+        root_kids = nonleaves['ROOT'].kids
+        if root_kids[0].is_leaf:
+            self._multi = False
+            self._iter_shift = 1
+        else:
+            self._multi = True
+            self.BF0 = len(root_kids)
+            self._nonleaves = nonleaves
+            
+            self._iter_shift = self.BF0
+            self._reversed = False #Do we iter in reverse mode ?
+        
+        self._shuffled_snames = shuffled_snames
+        self._num_scenarios = len(shuffled_snames)
         self._cycle_idx = 0
-        self._cur_scen = all_scenario_list[0]
+        self._cur_ROOTscen = shuffled_snames[0]
+        self.create_nodescen_dict()
+        
         self._scenarios_this_epoch = set()
         self._best = None
 
     @property
     def best(self):
-        self._scenarios_this_epoch.add(self._best)
         return self._best
 
     @best.setter
     def best(self, value):
         self._best = value
+        
+    def _fill_nodescen_dict(self,empty_nodes):   
+        filling_idx = self._cycle_idx
+        while len(empty_nodes) >0:
+            #Sanity check to make no infinite loop.
+            if filling_idx == self._cycle_idx and 'ROOT' in self.nodescen_dict:
+                raise RuntimeError("_fill_nodescen_dict looped over every scenario but was not able to find a scen for every nonleaf node.")
+            sname = self._shuffled_snames[filling_idx]
+            
+            def _add_sname_to_node(ndn):
+                first = self._nonleaves[ndn].scenfirst
+                last = self._nonleaves[ndn].scenlast
+                snum = sputils.extract_num(sname)
+                if snum>=first and snum<=last:
+                    self.nodescen_dict[ndn] = sname
+                    return False
+                else:
+                    return True
+            #Adding sname to every nodes it goes by, and removing the nodes from empty_nodes
+            empty_nodes = list(filter(_add_sname_to_node,empty_nodes))
+            filling_idx +=1
+            filling_idx %= self._num_scenarios
+        
+    def create_nodescen_dict(self):
+        '''
+        Creates an attribute nodescen_dict. 
+        Keys are nonleaf names, values are local scenario names 
+        (a value can be None if the associated scenario is not in our rank)
+        '''
+        if not self._multi:
+            raise RuntimeWarning("Using create_nodescen_dict for 2stage problems is deprecated. Use directly self._cycle_idx instead")
+        self.nodescen_dict = dict()
+        self._fill_nodescen_dict(self._nonleaves.keys())
+    
+    def update_nodescen_dict(self,snames_to_remove):
+        raise RuntimeError("Do not work yet")
+        
 
     def begin_epoch(self):
         self._scenarios_this_epoch = set()
 
     def get_next(self):
-        next_scen = self._cur_scen
+        next_scen = self._cur_ROOTscen
+        next_scendict = self.nodescen_dict
         if next_scen in self._scenarios_this_epoch:
             self._iter_scen()
-            return None
+            if self._reversed or not self._multi:
+                #For 2stage problem, a scen can be used for 'ROOT' only once
+                #For a multi stage problem, it can be used twice (including reverse)
+                return None
         self._scenarios_this_epoch.add(next_scen)
         self._iter_scen()
-        return next_scen
+        return next_scendict
 
     def _iter_scen(self):
-        self._cycle_idx += 1
+        if len(self._scenarios_this_epoch) == self._num_scenarios:
+            if self._multi and not self._reversed:
+                self.reverse()
+        self._cycle_idx += self._iter_shift
         ## wrap around
         self._cycle_idx %= self._num_scenarios
-        self._cur_scen = self._all_scenario_list[self._cycle_idx]
+        
+        #do not reuse a previously visited scenario for 'ROOT'
+        tmp_cycle_idx = self._cycle_idx
+        while tmp_cycle_idx in self._scenarios_this_epoch and (
+                (tmp_cycle_idx+1)%self._num_scenarios != self._cycle_idx):
+            tmp_cycle_idx +=1
+            tmp_cycle_idx %= self._num_scenarios
+        self._cycle_idx = tmp_cycle_idx
+        
+        #Updating scenarios
+        self._cur_ROOTscen = self._shuffled_snames[self._cycle_idx]
+        self.create_nodescen_dict()
+        #TODO Make a better update system for multistage
+        # if self._multi:
+        #     self.nodescen_dict = {'ROOT': self._cur_ROOTscen}
+        # else:
+        #     self.create_nodescen_dict()
+        
+    
+    def reverse(self):
+        self._shuffled_snames = list(reversed(self._shuffled_snames))
+        self._reversed = True
+        self._scenarios_this_epoch = set() #Resetting the set of visited scenarios
+        self._cycle_idx = 0

--- a/mpisppy/cylinders/xhatshufflelooper_bounder.py
+++ b/mpisppy/cylinders/xhatshufflelooper_bounder.py
@@ -170,8 +170,8 @@ class XhatShuffleInnerBound(spoke.InnerBoundNonantSpoke):
 class ScenarioCycler:
 
     def __init__(self, shuffled_snames,nonleaves):
-        root_kids = nonleaves['ROOT'].kids
-        if root_kids[0].is_leaf:
+        root_kids = nonleaves['ROOT'].kids if 'ROOT' in nonleaves else None
+        if root_kids is None or len(root_kids)==0 or root_kids[0].is_leaf:
             self._multi = False
             self._iter_shift = 1
         else:
@@ -226,11 +226,14 @@ class ScenarioCycler:
         Creates an attribute nodescen_dict. 
         Keys are nonleaf names, values are local scenario names 
         (a value can be None if the associated scenario is not in our rank)
+        
+        WARNING: _cur_ROOTscen must be up to date when calling this method
         '''
         if not self._multi:
-            raise RuntimeWarning("Using create_nodescen_dict for 2stage problems is deprecated. Use directly self._cycle_idx instead")
-        self.nodescen_dict = dict()
-        self._fill_nodescen_dict(self._nonleaves.keys())
+            self.nodescen_dict = {'ROOT':self._cur_ROOTscen}
+        else:
+            self.nodescen_dict = dict()
+            self._fill_nodescen_dict(self._nonleaves.keys())
     
     def update_nodescen_dict(self,snames_to_remove):
         raise RuntimeError("Do not work yet")
@@ -244,7 +247,7 @@ class ScenarioCycler:
         next_scendict = self.nodescen_dict
         if next_scen in self._scenarios_this_epoch:
             self._iter_scen()
-            if self._reversed or not self._multi:
+            if (not self._multi) or self._reversed :
                 #For 2stage problem, a scen can be used for 'ROOT' only once
                 #For a multi stage problem, it can be used twice (including reverse)
                 return None

--- a/mpisppy/cylinders/xhatshufflelooper_bounder.py
+++ b/mpisppy/cylinders/xhatshufflelooper_bounder.py
@@ -8,6 +8,8 @@ import mpisppy.log
 import mpisppy.utils.sputils as sputils
 import mpisppy.cylinders.spoke as spoke
 import mpi4py.MPI as mpi
+fullcomm = mpi.COMM_WORLD
+global_rank = fullcomm.Get_rank()
 
 from math import inf, isclose
 from mpisppy.utils.xhat_eval import Xhat_Eval
@@ -130,6 +132,10 @@ class XhatShuffleInnerBound(spoke.InnerBoundNonantSpoke):
 
         # give all ranks the same seed
         self.random_stream.seed(self.random_seed)
+        #Check that they have the same stream
+        check = self.random_stream.normalvariate(0, 1)
+        print(f"Hello, for global rank {global_rank}, random stream gives a value of {check}")
+        
         # shuffle the scenarios (i.e., sample without replacement)
         shuffled_scenarios = self.random_stream.sample(
             self.opt.all_scenario_names,

--- a/mpisppy/extensions/xhatbase.py
+++ b/mpisppy/extensions/xhatbase.py
@@ -12,7 +12,7 @@ class XhatBase(mpisppy.extensions.extension.Extension):
         Any inherited class must implement the preiter0, postiter etc. methods
         
         Args:
-            opt (SPBase object): gives the problem that we bound
+            opt (SPOpt object): gives the problem that we bound
 
         Attributes:
           scenario_name_to_rank (dict of dict): nodes (i.e. comms) scen names
@@ -269,7 +269,7 @@ to a dictionary mapping scenario name to rank number.
 Naming conventions:
 
 = non-leaf nodes other than ROOT are named <parent>_nodenum so for the
-example, there are three non-leaf nodes named ROOT, ROOT_1, and ROOT_2
+example, there are three non-leaf nodes named ROOT, ROOT_0, and ROOT_1
 
 = we happen to be given a list of scenario names that has the same
 length as the number of scenarios (i.e., the product of the branching

--- a/mpisppy/spbase.py
+++ b/mpisppy/spbase.py
@@ -205,6 +205,7 @@ class SPBase:
         self.scenario_names_to_rank, self._rank_slices, self._scenario_slices =\
                 tree.scen_names_to_ranks(self.n_proc)
         self._scenario_tree = tree
+        self.nonleaves = {node.name : node for node in tree.nonleaves}
 
         # list of scenario names owned locally
         self.local_scenario_names = [

--- a/mpisppy/utils/baseparsers.py
+++ b/mpisppy/utils/baseparsers.py
@@ -461,7 +461,7 @@ def xhatshuffle_args(inparser):
                         help="using also the reversed shuffling (multistage only, default True)",
                         dest = 'add_reversed_shuffle',
                         action='store_true')
-    parser.set_default(add_reversed_shuffle=True)
+    parser.set_defaults(add_reversed_shuffle=True)
     parser.add_argument('--xhatshuffle-iter-step',
                         help="step in shuffled list between 2 scenarios to try (default None)",
                         dest="xhatshuffle_iter_step",

--- a/mpisppy/utils/baseparsers.py
+++ b/mpisppy/utils/baseparsers.py
@@ -457,6 +457,16 @@ def xhatshuffle_args(inparser):
                         dest='with_xhatshuffle',
                         action='store_false')
     parser.set_defaults(with_xhatshuffle=True)
+    parser.add_argument('--add-reversed-shuffle',
+                        help="using also the reversed shuffling (multistage only, default True)",
+                        dest = 'add_reversed_shuffle',
+                        action='store_true')
+    parser.set_default(add_reversed_shuffle=True)
+    parser.add_argument('--xhatshuffle-iter-step',
+                        help="step in shuffled list between 2 scenarios to try (default None)",
+                        dest="xhatshuffle_iter_step",
+                        type=int,
+                        default=None)
 
     return parser
 

--- a/mpisppy/utils/sputils.py
+++ b/mpisppy/utils/sputils.py
@@ -1009,6 +1009,22 @@ def create_nodenames_from_BFs(BFS):
         nodenames += stage_nodes
     return nodenames
 
+def get_BFs_from_nodenames(all_nodenames):
+    #WARNING: Do not work with unbalanced trees
+    staget_node = "ROOT"
+    BFs = []
+    while staget_node+"_0" in all_nodenames:
+        child_regex = re.compile(staget_node+'_\d*\Z')
+        child_list = [x for x in all_nodenames if child_regex.match(x) ]
+        
+        BFs.append(len(child_list))
+        staget_node += "_0"
+    if len(BFs)==1:
+        #2stage
+        return None
+    else:
+        return BFs
+    
 def number_of_nodes(BFs):
     #How many nodes does a tree with a given BFs have ?
     last_node_stage_num = [i-1 for i in BFs]

--- a/mpisppy/utils/vanilla.py
+++ b/mpisppy/utils/vanilla.py
@@ -276,7 +276,7 @@ def xhatshuffle_spoke(
     scenario_creator,
     scenario_denouement,
     all_scenario_names,
-    scenario_dict,
+    scenario_dict=None,
     all_nodenames=None,
     branching_factors=None,
     scenario_creator_kwargs=None,

--- a/mpisppy/utils/vanilla.py
+++ b/mpisppy/utils/vanilla.py
@@ -289,6 +289,11 @@ def xhatshuffle_spoke(
         "dump_prefix": "delme",
         "csvname": "looper.csv",
     }
+    if _hasit(args,"add_reversed_shuffle"):
+        xhat_options["xhat_looper_options"]["reverse"] = args.add_reversed_shuffle
+    if _hasit(args,"add_reversed_shuffle"):
+        xhat_options["xhat_looper_options"]["xhatshuffle_iter_step"] = args.xhatshuffle_iter_step
+    
     if branching_factors:
         xhat_options["branching_factors"] = branching_factors
         if all_nodenames is None:

--- a/mpisppy/utils/vanilla.py
+++ b/mpisppy/utils/vanilla.py
@@ -276,6 +276,8 @@ def xhatshuffle_spoke(
     scenario_creator,
     scenario_denouement,
     all_scenario_names,
+    all_nodenames=None,
+    branching_factors=None,
     scenario_creator_kwargs=None,
 ):
 
@@ -287,6 +289,10 @@ def xhatshuffle_spoke(
         "dump_prefix": "delme",
         "csvname": "looper.csv",
     }
+    if branching_factors:
+        xhat_options["branching_factors"] = branching_factors
+        if all_nodenames is None:
+            all_nodenames = sputils.create_nodenames_from_BFs(branching_factors)
     xhatlooper_dict = {
         "spoke_class": XhatShuffleInnerBound,
         "spoke_kwargs": dict(),
@@ -296,7 +302,8 @@ def xhatshuffle_spoke(
             "all_scenario_names": all_scenario_names,
             "scenario_creator": scenario_creator,
             "scenario_creator_kwargs": scenario_creator_kwargs,
-            "scenario_denouement": scenario_denouement                        
+            "scenario_denouement": scenario_denouement,
+            "all_nodenames": all_nodenames                        
         },
     }
     return xhatlooper_dict
@@ -309,7 +316,7 @@ def xhatspecific_spoke(
     all_scenario_names,
     scenario_dict,
     all_nodenames=None,
-    BFs=None,
+    branching_factors=None,
     scenario_creator_kwargs=None,
 ):
     
@@ -320,10 +327,10 @@ def xhatspecific_spoke(
         "xhat_scenario_dict": scenario_dict,
         "csvname": "specific.csv",
     }
-    if BFs:
-        xhat_options["branching_factors"] = BFs
+    if branching_factors:
+        xhat_options["branching_factors"] = branching_factors
         if all_nodenames is None:
-            all_nodenames = sputils.create_nodenames_from_BFs(BFs)
+            all_nodenames = sputils.create_nodenames_from_BFs(branching_factors)
     #TODO: We need to adjust Vanilla with multistage
 
     xhat_options['bundles_per_rank'] = 0 #  no bundles for xhat

--- a/mpisppy/utils/vanilla.py
+++ b/mpisppy/utils/vanilla.py
@@ -276,7 +276,6 @@ def xhatshuffle_spoke(
     scenario_creator,
     scenario_denouement,
     all_scenario_names,
-    scenario_dict=None,
     all_nodenames=None,
     branching_factors=None,
     scenario_creator_kwargs=None,
@@ -287,7 +286,6 @@ def xhatshuffle_spoke(
     xhat_options['bundles_per_rank'] = 0 #  no bundles for xhat
     xhat_options["xhat_looper_options"] = {
         "xhat_solver_options": shoptions["iterk_solver_options"],
-        "xhat_scenario_dict": scenario_dict,
         "dump_prefix": "delme",
         "csvname": "looper.csv",
     }

--- a/mpisppy/utils/vanilla.py
+++ b/mpisppy/utils/vanilla.py
@@ -276,6 +276,7 @@ def xhatshuffle_spoke(
     scenario_creator,
     scenario_denouement,
     all_scenario_names,
+    scenario_dict,
     all_nodenames=None,
     branching_factors=None,
     scenario_creator_kwargs=None,
@@ -286,6 +287,7 @@ def xhatshuffle_spoke(
     xhat_options['bundles_per_rank'] = 0 #  no bundles for xhat
     xhat_options["xhat_looper_options"] = {
         "xhat_solver_options": shoptions["iterk_solver_options"],
+        "xhat_scenario_dict": scenario_dict,
         "dump_prefix": "delme",
         "csvname": "looper.csv",
     }


### PR DESCRIPTION
1.  Changing the xhatshufflelooper spoke to make it compatible with multistage problems:
- For multistage problems, the spoke shuffles the scenarios, and then loops over the shuffled list (with an increasing starting point) to fill the scenario tree with feasible policies.
- Two attributes ensures a better estimation: reverse (looping over the reversed shuffled list after, to take into account "hidden" scenarios) and iter_step (increasing the starting point between 2 iterations of more than 1, ensuring a better diversity for the first iterations)
2. Adaptation of baseparsers and vanilla to this.
3. Correcting minor typos