### PR TITLE
Adding tree solution tag for lshaped

### DIFF
--- a/mpisppy/opt/lshaped.py
+++ b/mpisppy/opt/lshaped.py
@@ -652,6 +652,7 @@ class LShapedMethod(spbase.SPBase):
                         f"Final Objective: {m.obj.expr():7.2f}"
                     )
                     self.first_stage_solution_available = True
+                    self.tree_solution_available = True
                     break
                 if verbose and self.iter == max_iter - 1:
                     print("WARNING MAX ITERATION LIMIT REACHED !!! ")


### PR DESCRIPTION
#149 points out that LShaped currently does not report a tree solution available at convergence. This PR fixes that.