### PR TITLE
Add RuntimeError for stale non-anticipative variables on feasible scenarios

### DIFF
--- a/mpisppy/spbase.py
+++ b/mpisppy/spbase.py
@@ -436,7 +436,10 @@ class SPBase:
             return False
         _mpisppy_data = scenario_model._mpisppy_data
         ndn, i = _mpisppy_data.varid_to_nonant_index[id(var)]
-        return float(_mpisppy_data.prob_coeff[ndn][i]) == 0.
+        if isinstance(_mpisppy_data.prob_coeff[ndn], np.ndarray):
+            return float(_mpisppy_data.prob_coeff[ndn][i]) == 0.
+        else:
+            return False
 
     def _check_variable_probabilities_sum(self, verbose):
 

--- a/mpisppy/spopt.py
+++ b/mpisppy/spopt.py
@@ -284,13 +284,19 @@ class SPOpt(SPBase):
             if s._mpisppy_data.scenario_feasible:
                 for v in s._mpisppy_data.nonant_indices.values():
                     if v.stale:
-                        raise RuntimeError(
-                                f"Non-anticipative variable {v.name} on scenario {sn} "
-                                 "reported as stale. This usually means this variable "
-                                 "did not appear in any (active) constraints, and hence "
-                                 "was not communicated to the subproblem solver. Please "
-                                 "ensure all non-anticipative variables appear in some "
-                                 "constraint.")
+                        if self.is_zero_prob(s, v) and v._value is None:
+                            raise RuntimeError(
+                                    f"Non-anticipative zero-probability variable {v.name} "
+                                    f"on scenario {sn} reported as stale and has no value. "
+                                     "Zero-probability variables should have a value set.")
+                        else:
+                            raise RuntimeError(
+                                    f"Non-anticipative variable {v.name} on scenario {sn} "
+                                     "reported as stale. This usually means this variable "
+                                     "did not appear in any (active) constraints, and hence "
+                                     "was not communicated to the subproblem solver. Please "
+                                     "ensure all non-anticipative variables appear in some "
+                                     "constraint.")
 
 
 

--- a/mpisppy/spopt.py
+++ b/mpisppy/spopt.py
@@ -288,7 +288,7 @@ class SPOpt(SPBase):
                             raise RuntimeError(
                                     f"Non-anticipative zero-probability variable {v.name} "
                                     f"on scenario {sn} reported as stale and has no value. "
-                                     "Zero-probability variables should have a value set.")
+                                     "Zero-probability variables must have a value (e.g., fixed).")
                         else:
                             raise RuntimeError(
                                     f"Non-anticipative variable {v.name} on scenario {sn} "

--- a/mpisppy/spopt.py
+++ b/mpisppy/spopt.py
@@ -283,7 +283,7 @@ class SPOpt(SPBase):
         for sn, s in self.local_scenarios.items():
             if s._mpisppy_data.scenario_feasible:
                 for v in s._mpisppy_data.nonant_indices.values():
-                    if v.stale:
+                    if (not v.fixed) and v.stale:
                         if self.is_zero_prob(s, v) and v._value is None:
                             raise RuntimeError(
                                     f"Non-anticipative zero-probability variable {v.name} "

--- a/mpisppy/spopt.py
+++ b/mpisppy/spopt.py
@@ -277,6 +277,22 @@ class SPOpt(SPBase):
                       np.mean(all_pyomo_solve_times),
                       np.max(all_pyomo_solve_times)))
 
+        # Look at the feasible scenarios. If we have any stale non-anticipative
+        # variables, complain. Otherwise the user will hit this issue later when
+        # we attempt to access the variables `value` attribute (see Issue #170).
+        for sn, s in self.local_scenarios.items():
+            if s._mpisppy_data.scenario_feasible:
+                for v in s._mpisppy_data.nonant_indices.values():
+                    if v.stale:
+                        raise RuntimeError(
+                                f"Non-anticipative variable {v.name} on scenario {sn} "
+                                 "reported as stale. This usually means this variable "
+                                 "did not appear in any (active) constraints, and hence "
+                                 "was not communicated to the subproblem solver. Please "
+                                 "ensure all non-anticipative variables appear in some "
+                                 "constraint.")
+
+
 
     def Eobjective(self, verbose=False):
         """ Compute the expected objective function across all scenarios.


### PR DESCRIPTION
Fixes #170. Given that the solve need to touch every variable at least once when loading it into the model, this safety check on *only* the nonanticipative variables once per solve should not be onerous. 