### PR TITLE
Correct extensive form class and function names in docs

### DIFF
--- a/doc/src/ef.rst
+++ b/doc/src/ef.rst
@@ -10,8 +10,8 @@ general-purpose solver." There are two closely related ways
 to do this in ``mpi-sppy``.
 
 
-Preferred method: ``mpisppy.opt.ef.EF``
----------------------------------------
+Preferred method: ``mpisppy.opt.ef.ExtensiveForm``
+--------------------------------------------------
 
 There is a class for the EF that roughly matches the "look and feel" of a hub
 class, but does not function as a hub.

--- a/doc/src/ef.rst
+++ b/doc/src/ef.rst
@@ -26,8 +26,8 @@ class, but does not function as a hub.
 
 .. _sputils.create_EF:
 
-Other method: ``sputils.create_EF``
------------------------------------
+Other method: ``mpisppy.utils.sputils.create_EF``
+-------------------------------------------------
 
 The use of this function does not require the installation of ``mpi4py``. Its use
 is illustrated in ``examples.farmer.farmer_ef.py``. Here are the


### PR DESCRIPTION
The docs referred to `mpisppy.opt.ef.ExtensiveForm` as `mpisppy.opt.ef.EF`, which does not exist. Also, for consistency I added the full module prefix for `create_EF`.