### PR TITLE
fixing copy-paste error for absolute gap

### DIFF
--- a/mpisppy/cylinders/hub.py
+++ b/mpisppy/cylinders/hub.py
@@ -139,7 +139,7 @@ class Hub(SPCommunicator):
         if "rel_gap" in self.options and rel_gap <= self.options["rel_gap"]:
             rel_gap_satisfied = True 
         if "abs_gap" in self.options and abs_gap <= self.options["abs_gap"]:
-            rel_gap_satisfied = True             
+            abs_gap_satisfied = True             
 
         if "max_stalled_iters" in self.options:
             if abs_gap < self.last_gap:  # liberal test (we could use an epsilon)


### PR DESCRIPTION
As-is, the message "absolute gap satisfied" will not be printed, and the "relative gap satisfied" message will be printed instead. 