### PR TITLE
Update .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,8 +8,8 @@ version: 2
 sphinx:
   configuration: doc/src/conf.py
 
-python:
-  version: "3.8"
-  install:
-    - method: setuptools
-      path: .
+#python:
+#  version: "3.8"
+#  install:
+#    - method: setuptools
+#      path: .


### PR DESCRIPTION
reverting attempt to install mpi-sppy on readthedocs for now because mpi4py is required. Not sure how to install mpi on readthedocs.