### PR TITLE
A doc update for variable probability

### DIFF
--- a/doc/src/extensions.rst
+++ b/doc/src/extensions.rst
@@ -116,6 +116,10 @@ the ``SPBase`` option ``variable_probability_kwargs``
 The variable probabilities impact the computation of
 ``xbars`` and ``W``.
 
+.. Note::
+   The only xhatter that is likely to work with variable probabilities is xhatxbar. The others
+   are likely to execute without error messages but will not find good solutions.
+
 
 gradient_extension
 ==================


### PR DESCRIPTION
try to warn users of variable probability that they should only use xhatxbar for upper bounds