### PR TITLE
Updates to proximal approximation

### DIFF
--- a/mpisppy/phbase.py
+++ b/mpisppy/phbase.py
@@ -12,7 +12,7 @@ import mpisppy.utils.sputils as sputils
 import mpisppy.utils.listener_util.listener_util as listener_util
 import mpisppy.spopt
 
-from mpisppy.utils.prox_approx import ProxApproxManager
+from mpisppy.utils.prox_approx import ProxApproxManager, ProxApproxCuts
 from mpisppy import global_toc
 
 # decorator snarfed from stack overflow - allows per-rank profile output file generation.
@@ -581,6 +581,7 @@ class PHBase(mpisppy.spopt.SPOpt):
         tol = self.prox_approx_tol
         for sn, s in self.local_scenarios.items():
             persistent_solver = (s._solver_plugin if sputils.is_persistent(s._solver_plugin) else None)
+            s._mpisppy_model.xsqvar_cuts.cut_manager(tol, persistent_solver)
             for prox_approx_manager in s._mpisppy_data.xsqvar_prox_approx.values():
                 prox_approx_manager.check_tol_add_cut(tol, persistent_solver)
 
@@ -662,7 +663,7 @@ class PHBase(mpisppy.spopt.SPOpt):
                 # Define the first cut to be _xsqvar >= 0
                 scenario._mpisppy_model.xsqvar = pyo.Var(scenario._mpisppy_data.nonant_indices, dense=False,
                                             within=pyo.NonNegativeReals)
-                scenario._mpisppy_model.xsqvar_cuts = pyo.Constraint(scenario._mpisppy_data.nonant_indices, pyo.Integers)
+                scenario._mpisppy_model.xsqvar_cuts = ProxApproxCuts(scenario._mpisppy_data.nonant_indices, pyo.Integers)
                 scenario._mpisppy_data.xsqvar_prox_approx = {}
             else:
                 scenario._mpisppy_model.xsqvar = None

--- a/mpisppy/phbase.py
+++ b/mpisppy/phbase.py
@@ -642,7 +642,7 @@ class PHBase(mpisppy.spopt.SPOpt):
             if 'initial_proximal_cut_count' in self.options:
                 initial_prox_cuts = self.options['initial_proximal_cut_count']
             else:
-                initial_prox_cuts = 2
+                initial_prox_cuts = 0
         else:
             self._prox_approx = False
 

--- a/mpisppy/utils/cfg_vanilla.py
+++ b/mpisppy/utils/cfg_vanilla.py
@@ -95,6 +95,7 @@ def ph_hub(
     options["linearize_binary_proximal_terms"] = cfg.linearize_binary_proximal_terms
     options["linearize_proximal_terms"] = cfg.linearize_proximal_terms
     options["proximal_linearization_tolerance"] = cfg.proximal_linearization_tolerance
+    options["initial_proximal_cut_count"] = cfg.initial_proximal_cut_count
 
     if _hasit(cfg, "cross_scenario_cuts") and cfg.cross_scenario_cuts:
         hub_class = CrossScenarioHub

--- a/mpisppy/utils/config.py
+++ b/mpisppy/utils/config.py
@@ -231,9 +231,11 @@ class Config(pyofig.ConfigDict):
         self.add_to_config("proximal_linearization_tolerance",
                             description="For PH, when linearizing proximal terms, "
                             "a cut will be added if the proximal term approximation "
-                            "is looser than this value (default 1e-1)",
+                            "is looser than this value (default 1e-3). Setting this "
+                            "value lower than the square of the subproblem solver's "
+                            "feasibility tolerance will likely have a deleterious effect.",
                             domain=float,
-                            default=1.e-1)
+                            default=1.e-3)
 
         self.add_to_config("initial_proximal_cut_count",
                             description="For PH, when linearizing proximal terms, "

--- a/mpisppy/utils/config.py
+++ b/mpisppy/utils/config.py
@@ -235,6 +235,13 @@ class Config(pyofig.ConfigDict):
                             domain=float,
                             default=1.e-1)
 
+        self.add_to_config("initial_proximal_cut_count",
+                            description="For PH, when linearizing proximal terms, "
+                            "the is the number of additional proximal cuts initially "
+                            "added (default 0)",
+                            domain=int,
+                            default=0)
+
     def make_parser(self, progname=None, num_scens_reqd=False):
         raise RuntimeError("make_parser is no longer used. See comments at top of config.py")
 

--- a/mpisppy/utils/config.py
+++ b/mpisppy/utils/config.py
@@ -232,10 +232,11 @@ class Config(pyofig.ConfigDict):
                             description="For PH, when linearizing proximal terms, "
                             "a cut will be added if the proximal term approximation "
                             "is looser than this value (default 1e-3). Setting this "
-                            "value lower than the square of the subproblem solver's "
-                            "feasibility tolerance will likely have a deleterious effect.",
+                            "value (much) lower than the square root of the subproblem "
+                            "solver's feasibility tolerance will likely have a "
+                            "deleterious effect.",
                             domain=float,
-                            default=1.e-3)
+                            default=1.e-4)
 
         self.add_to_config("initial_proximal_cut_count",
                             description="For PH, when linearizing proximal terms, "

--- a/mpisppy/utils/prox_approx.py
+++ b/mpisppy/utils/prox_approx.py
@@ -146,10 +146,12 @@ class _ProxApproxManager:
                 #print(f"next_val: {next_val}")
                 this_val = next_val
                 next_val = _newton_step(this_val, x_pnt, y_pnt)
-            # This cut seems to help the bound / convergence the most
-            self.add_cut(x_pnt, persistent_solver)
-            # Whereas this one helps the incumbent the most
+            # This cut seems to help the incumbent the most
             self.add_cut(next_val, persistent_solver)
+            # This cut seems to help the bound / convergence the most
+            # But do not add nearly parallel cuts
+            if abs(y_pnt-next_val*next_val) > tolerance:
+                self.add_cut(x_pnt, persistent_solver)
             #print(f"var {self.xvar.name}, total cuts: {self.cut_index}")
             return True
         return False


### PR DESCRIPTION
The current proximal approximation approach does not allow you to start with no cuts.

This PR would update the proximal approximation code such that:
1. Allows for starting with an empty set of cuts
2. Makes starting with the empty set of cuts the new default
3. Adds two cuts per pass: the "nearest point" cut (i.e., at x* = argmin [( x - \hat{x} )^2 + ( x^2 - \hat{y} )^2] and the "straightforward projection cut" (i.e., at x* = \hat{x}). Before we just added the "nearest point" cut.