### PR TITLE
Prox approx xbar

### DIFF
--- a/mpisppy/phbase.py
+++ b/mpisppy/phbase.py
@@ -581,7 +581,7 @@ class PHBase(mpisppy.spopt.SPOpt):
         tol = self.prox_approx_tol
         for sn, s in self.local_scenarios.items():
             persistent_solver = (s._solver_plugin if sputils.is_persistent(s._solver_plugin) else None)
-            print(f"total number of proximal cuts: {len(s._mpisppy_model.xsqvar_cuts)}")
+            #print(f"total number of proximal cuts: {len(s._mpisppy_model.xsqvar_cuts)}")
             for prox_approx_manager in s._mpisppy_data.xsqvar_prox_approx.values():
                 prox_approx_manager.check_tol_add_cut(tol, persistent_solver)
 

--- a/mpisppy/phbase.py
+++ b/mpisppy/phbase.py
@@ -639,10 +639,6 @@ class PHBase(mpisppy.spopt.SPOpt):
                 self.prox_approx_tol = self.options['proximal_linearization_tolerance']
             else:
                 self.prox_approx_tol = 1.e-1
-            if 'initial_proximal_cut_count' in self.options:
-                initial_prox_cuts = self.options['initial_proximal_cut_count']
-            else:
-                initial_prox_cuts = 2
         else:
             self._prox_approx = False
 
@@ -688,7 +684,7 @@ class PHBase(mpisppy.spopt.SPOpt):
                     elif self._prox_approx:
                         xvarsqrd = scenario._mpisppy_model.xsqvar[ndn_i]
                         scenario._mpisppy_data.xsqvar_prox_approx[ndn_i] = \
-                                ProxApproxManager(xvar, xvarsqrd, scenario._mpisppy_model.xsqvar_cuts, ndn_i, initial_prox_cuts)
+                                ProxApproxManager(xvar, xvarsqrd, xbars[ndn_i], scenario._mpisppy_model.xsqvar_cuts, ndn_i)
                     else:
                         xvarsqrd = xvar**2
                     prox_expr += (scenario._mpisppy_model.rho[ndn_i] / 2.0) * \

--- a/mpisppy/phbase.py
+++ b/mpisppy/phbase.py
@@ -581,6 +581,7 @@ class PHBase(mpisppy.spopt.SPOpt):
         tol = self.prox_approx_tol
         for sn, s in self.local_scenarios.items():
             persistent_solver = (s._solver_plugin if sputils.is_persistent(s._solver_plugin) else None)
+            print(f"total number of proximal cuts: {len(s._mpisppy_model.xsqvar_cuts)}")
             for prox_approx_manager in s._mpisppy_data.xsqvar_prox_approx.values():
                 prox_approx_manager.check_tol_add_cut(tol, persistent_solver)
 

--- a/mpisppy/phbase.py
+++ b/mpisppy/phbase.py
@@ -656,8 +656,7 @@ class PHBase(mpisppy.spopt.SPOpt):
                 # set-up pyomo IndexVar, but keep it sparse
                 # since some nonants might be binary
                 # Define the first cut to be _xsqvar >= 0
-                scenario._mpisppy_model.xsqvar = pyo.Var(scenario._mpisppy_data.nonant_indices, dense=False,
-                                            within=pyo.NonNegativeReals)
+                scenario._mpisppy_model.xsqvar = pyo.Var(scenario._mpisppy_data.nonant_indices, dense=False, bounds=(0, None))
                 scenario._mpisppy_model.xsqvar_cuts = pyo.Constraint(scenario._mpisppy_data.nonant_indices, pyo.Integers)
                 scenario._mpisppy_data.xsqvar_prox_approx = {}
             else:

--- a/mpisppy/utils/prox_approx.py
+++ b/mpisppy/utils/prox_approx.py
@@ -202,11 +202,10 @@ if __name__ == '__main__':
     new_cuts = True
     iter_cnt = 0
     while new_cuts:
-        print("")
         s.solve(m,tee=False)
         print(f"x: {pyo.value(m.x)}")
         new_cuts = prox_manager.check_tol_add_cut(1e-1, persistent_solver=s)
         #m.pprint()
         iter_cnt += 1
 
-    print(f"objval: {pyo.value(m.obj)}, x: {pyo.value(m.x)}, iters: {iter_cnt}")
+    print(f"objval: {pyo.value(m.obj)}, x: {pyo.value(m.x)}, cuts: {len(m.xsqrdobj)}, iters: {iter_cnt}")

--- a/mpisppy/utils/prox_approx.py
+++ b/mpisppy/utils/prox_approx.py
@@ -203,9 +203,9 @@ if __name__ == '__main__':
     iter_cnt = 0
     while new_cuts:
         s.solve(m,tee=False)
-        print(f"x: {pyo.value(m.x)}")
+        print(f"x: {pyo.value(m.x):.2e}, obj: {pyo.value(m.obj):.2e}")
         new_cuts = prox_manager.check_tol_add_cut(1e-1, persistent_solver=s)
         #m.pprint()
         iter_cnt += 1
 
-    print(f"objval: {pyo.value(m.obj)}, x: {pyo.value(m.x)}, cuts: {len(m.xsqrdobj)}, iters: {iter_cnt}")
+    print(f"cuts: {len(m.xsqrdobj)}, iters: {iter_cnt}")

--- a/mpisppy/utils/prox_approx.py
+++ b/mpisppy/utils/prox_approx.py
@@ -73,7 +73,6 @@ class _ProxApproxManager:
                 self.add_cut(2*x_bar - x_pnt, persistent_solver)
             return True
 
-
         if (f_val - y_pnt) > tolerance:
             '''
             In this case, we project the point x_pnt, y_pnt onto
@@ -123,7 +122,7 @@ class ProxApproxManagerContinuous(_ProxApproxManager):
         if persistent_solver is not None:
             persistent_solver.add_constraint(self.cuts[self.var_index, self.cut_index])
         self.cut_index += 1
-        print(f"added continuous cut for {self.xvar.name} at {val}, lb: {self.xvar.lb}, ub: {self.xvar.ub}")
+        #print(f"added continuous cut for {self.xvar.name} at {val}, lb: {self.xvar.lb}, ub: {self.xvar.ub}")
 
         return 1
 
@@ -177,7 +176,7 @@ class ProxApproxManagerDiscrete(_ProxApproxManager):
             if persistent_solver is not None:
                 persistent_solver.add_constraint(self.cuts[self.var_index, val])
             cuts_added += 1
-        print(f"added {cuts_added} integer cut(s) for {self.xvar.name} at {val}, lb: {self.xvar.lb}, ub: {self.xvar.ub}")
+        #print(f"added {cuts_added} integer cut(s) for {self.xvar.name} at {val}, lb: {self.xvar.lb}, ub: {self.xvar.ub}")
 
         return cuts_added
 

--- a/mpisppy/utils/prox_approx.py
+++ b/mpisppy/utils/prox_approx.py
@@ -20,11 +20,11 @@ def _newton_step(val, x_pnt, y_pnt):
 class ProxApproxManager:
     __slots__ = ()
 
-    def __new__(cls, xvar, xvarsqrd, xsqvar_cuts, ndn_i, initial_cut_quantity=2):
+    def __new__(cls, xvar, xvarsqrd, xbar, xsqvar_cuts, ndn_i):
         if xvar.is_integer():
-            return ProxApproxManagerDiscrete(xvar, xvarsqrd, xsqvar_cuts, ndn_i, initial_cut_quantity)
+            return ProxApproxManagerDiscrete(xvar, xvarsqrd, xbar, xsqvar_cuts, ndn_i)
         else:
-            return ProxApproxManagerContinuous(xvar, xvarsqrd, xsqvar_cuts, ndn_i, initial_cut_quantity)
+            return ProxApproxManagerContinuous(xvar, xvarsqrd, xbar, xsqvar_cuts, ndn_i)
 
 class _ProxApproxManager:
     '''
@@ -32,43 +32,13 @@ class _ProxApproxManager:
     '''
     __slots__ = ()
 
-    def __init__(self, xvar, xvarsqrd, xsqvar_cuts, ndn_i, initial_cut_quantity):
+    def __init__(self, xvar, xvarsqrd, xbar, xsqvar_cuts, ndn_i):
         self.xvar = xvar
         self.xvarsqrd = xvarsqrd
+        self.xbar = xbar
         self.var_index = ndn_i
         self.cuts = xsqvar_cuts
         self.cut_index = 0
-        self._verify_store_bounds(xvar)
-        self._create_initial_cuts(initial_cut_quantity)
-
-    def _verify_store_bounds(self, xvar):
-        if not (xvar.has_lb() and xvar.has_ub()):
-            raise RuntimeError(f"linearize_nonbinary_proximal_terms requires all "
-                                "nonanticipative variables to have bounds")
-        self.lb = value(xvar.lb)
-        self.ub = value(xvar.ub)
-
-    def _get_additional_points(self, initial_cut_quantity):
-        '''
-        calculate additional points for initial cuts
-        '''
-        # we add 2 cuts at the bound
-        if initial_cut_quantity <= 2:
-            return ()
-
-        lb, ub = self.lb, self.ub
-        bound_range = ub - lb
-        # n+1 points is n hyperplanes,
-        # but we've already added the bounds
-        delta = bound_range / (initial_cut_quantity-1)
-
-        return (lb + i*delta for i in range(1,initial_cut_quantity-1))
-
-    def _create_initial_cuts(self, initial_cut_quantity):
-        '''
-        create initial cuts at val
-        '''
-        pass
 
     def add_cut(self, val, persistent_solver=None):
         '''
@@ -81,10 +51,16 @@ class _ProxApproxManager:
         add a cut if the tolerance is not satified
         '''
         x_pnt = self.xvar.value
+        x_bar = self.xbar.value
         y_pnt = self.xvarsqrd.value
         f_val = x_pnt**2
 
         #print(f"y-distance: {actual_val - measured_val})")
+        if y_pnt is None:
+            self.add_cut(x_pnt, persistent_solver)
+            self.add_cut(2*x_bar - x_pnt, persistent_solver)
+            return True
+
 
         if (f_val - y_pnt) > tolerance:
             '''
@@ -105,31 +81,12 @@ class _ProxApproxManager:
                 #print(f"next_val: {next_val}")
                 this_val = next_val
                 next_val = _newton_step(this_val, x_pnt, y_pnt)
-            #self.add_cut(x_pnt, persistent_solver)
             self.add_cut(next_val, persistent_solver)
+            self.add_cut(2*x_bar - next_val, persistent_solver)
             return True
         return False
 
 class ProxApproxManagerContinuous(_ProxApproxManager):
-
-    def _create_initial_cuts(self, initial_cut_quantity):
-
-        lb, ub = self.lb, self.ub
-
-        # we get zero for free
-        if lb != 0.:
-            self.add_cut(lb)
-
-        if lb == ub:
-            # var is fixed
-            return
-
-        if ub != 0.:
-            self.add_cut(ub)
-
-        additional_points = self._get_additional_points(initial_cut_quantity)
-        for ptn in additional_points:
-            self.add_cut(ptn)
 
     def add_cut(self, val, persistent_solver=None):
         '''
@@ -168,26 +125,6 @@ def _compute_mb(val):
 
 class ProxApproxManagerDiscrete(_ProxApproxManager):
 
-    def _create_initial_cuts(self, initial_cut_quantity):
-        lb, ub = self.lb, self.ub
-
-        if lb == ub:
-            # var is fixed
-            self.create_cut(lb)
-            return
-
-        #print(f"adding cut for lb {lb}")
-        self.add_cut(lb)
-        #print(f"adding cut for ub {ub}")
-        self.add_cut(ub)
-
-        # there's a left and right cut associated with each discrete point
-        # so there's only half the points we cut on total
-        # This rounds down, e.g., 7 cuts specified becomes 6
-        additional_points = self._get_additional_points(initial_cut_quantity//2+1)
-        for ptn in additional_points:
-            self.add_cut(ptn)
-
     def add_cut(self, val, persistent_solver=None):
         '''
         create up to two cuts at val, exploiting integrality
@@ -201,7 +138,7 @@ class ProxApproxManagerDiscrete(_ProxApproxManager):
 
         ## So, a cut to the RIGHT of the point 3 is the cut for (3,4),
         ## which is indexed by 4
-        if (*self.var_index, val+1) not in self.cuts and val < self.ub:
+        if (*self.var_index, val+1) not in self.cuts:
             m,b = _compute_mb(val)
             expr = LinearExpression( linear_coefs=[1, -m],
                                      linear_vars=[self.xvarsqrd, self.xvar],
@@ -214,7 +151,7 @@ class ProxApproxManagerDiscrete(_ProxApproxManager):
 
         ## Similarly, a cut to the LEFT of the point 3 is the cut for (2,3),
         ## which is indexed by 3
-        if (*self.var_index, val) not in self.cuts and val > self.lb:
+        if (*self.var_index, val) not in self.cuts:
             m,b = _compute_mb(val-1)
             expr = LinearExpression( linear_coefs=[1, -m],
                                      linear_vars=[self.xvarsqrd, self.xvar],
@@ -236,14 +173,14 @@ if __name__ == '__main__':
     #m.x = pyo.Var(within=pyo.Integers, bounds = bounds)
     m.xsqrd = pyo.Var(within=pyo.NonNegativeReals)
 
-    zero = -73.2
+    m.zero = pyo.Param(initialize=-73.2, mutable=True)
     ## ( x - zero )^2 = x^2 - 2 x zero + zero^2
-    m.obj = pyo.Objective( expr = m.xsqrd - 2*zero*m.x + zero**2 )
+    m.obj = pyo.Objective( expr = m.xsqrd - 2*m.zero*m.x + m.zero**2 )
 
     m.xsqrdobj = pyo.Constraint([0], pyo.Integers)
 
-    s = pyo.SolverFactory('gurobi_persistent')
-    prox_manager = ProxApproxManager(m.x, m.xsqrd, m.xsqrdobj, 0, 2)
+    s = pyo.SolverFactory('xpress_persistent')
+    prox_manager = ProxApproxManager(m.x, m.xsqrd, m.zero, m.xsqrdobj, 0)
     s.set_instance(m)
     m.pprint()
     new_cuts = True


### PR DESCRIPTION
- Remove "additional cuts" code
- Add first cut at `xhat` and at `2 * xbar - xhat`, which creates a vertex in the approximation at `xbar`
- In subsequent iterations, project the point `xvar, xvarsqrd` onto `xvarsqrd >= xvar * xvar` -- call the point `x_star` -- and add a cut at `x_star` and `2 * xbar - x_star`, creating a vertex in the approximation at `xbar`.

Simple demonstration: `min (x - (-73.2))**2`

`main`, `tolerance = 1e-06`:
```
x: -5.00e+01, obj: -1.96e+03
x: -5.14e+01, obj: -1.88e+03
x: -5.85e+01, obj: -1.51e+03
x: -7.06e+01, obj: -8.58e+02
x: -8.21e+01, obj: -2.42e+02
x: -7.21e+01, obj: -6.24e+01
x: -7.59e+01, obj: -1.03e+01
x: -7.37e+01, obj: -3.88e+00
x: -7.27e+01, obj: -7.77e-01
x: -7.32e+01, obj: -2.57e-01
x: -7.30e+01, obj: -4.87e-03
x: -7.31e+01, obj: -2.39e-03
x: -7.31e+01, obj: -1.15e-03
x: -7.32e+01, obj: -5.27e-04
x: -7.32e+01, obj: -2.15e-04
x: -7.32e+01, obj: -5.92e-05
x: -7.32e+01, obj: -1.15e-05
x: -7.32e+01, obj: -3.92e-06
x: -7.32e+01, obj: -1.44e-07
cuts: 20, iters: 19
```

This PR, `tolerance = 1e-06`:
```
x: -1.00e+02, obj: -9.28e+03
x: -7.32e+01, obj: -4.84e+03
x: -7.32e+01, obj: -2.54e+03
x: -7.32e+01, obj: -4.04e+02
x: -7.32e+01, obj: -7.91e+00
x: -7.32e+01, obj: -2.92e-03
x: -7.32e+01, obj: -3.98e-10
cuts: 12, iters: 7
```


This PR but make cut a `xhat` every iteration, `tolerance = 1e-06`
```
x: -1.00e+02, obj: -9.28e+03
x: -7.32e+01, obj: -7.18e+02
x: -5.98e+01, obj: 9.09e-13
x: -6.65e+01, obj: 9.09e-13
x: -6.99e+01, obj: -9.09e-13
x: -7.15e+01, obj: 0.00e+00
x: -7.24e+01, obj: 0.00e+00
x: -7.28e+01, obj: -9.09e-13
x: -7.30e+01, obj: -9.09e-13
x: -7.31e+01, obj: 0.00e+00
x: -7.31e+01, obj: 0.00e+00
x: -7.32e+01, obj: 0.00e+00
x: -7.32e+01, obj: 0.00e+00
x: -7.32e+01, obj: 9.09e-13
x: -7.32e+01, obj: 0.00e+00
x: -7.32e+01, obj: -1.82e-12
x: -7.32e+01, obj: -9.09e-13
cuts: 31, iters: 17
```