### PR TITLE
Centralized subproblem creation

### DIFF
--- a/mpisppy/cylinders/lagranger_bounder.py
+++ b/mpisppy/cylinders/lagranger_bounder.py
@@ -18,7 +18,6 @@ class LagrangerOuterBound(mpisppy.cylinders.spoke.OuterBoundNonantSpoke):
         # Scenarios are created here
         self.opt.PH_Prep(attach_prox=False)
         self.opt._reenable_W()
-        self.opt.subproblem_creation(verbose)
         self.opt._create_solvers()
         if "lagranger_rho_rescale_factors_json" in self.opt.options and\
             self.opt.options["lagranger_rho_rescale_factors_json"] is not None:

--- a/mpisppy/cylinders/lagrangian_bounder.py
+++ b/mpisppy/cylinders/lagrangian_bounder.py
@@ -13,7 +13,6 @@ class LagrangianOuterBound(mpisppy.cylinders.spoke.OuterBoundWSpoke):
         # Scenarios are created here
         self.opt.PH_Prep(attach_prox=False)
         self.opt._reenable_W()
-        self.opt.subproblem_creation(verbose)
         self.opt._create_solvers()
 
     def lagrangian(self):

--- a/mpisppy/cylinders/ph_ob.py
+++ b/mpisppy/cylinders/ph_ob.py
@@ -24,7 +24,6 @@ class PhOuterBound(mpisppy.cylinders.spoke.OuterBoundSpoke):
         # Scenarios are created here
         self.opt.PH_Prep(attach_prox=True)
         self.opt._reenable_W()
-        self.opt.subproblem_creation(verbose)
         self.opt._create_solvers()
         self.default_rescale_rho = True
         if "ph_ob_rho_rescale_factors_json" in self.opt.options and\

--- a/mpisppy/extensions/cross_scen_extension.py
+++ b/mpisppy/extensions/cross_scen_extension.py
@@ -1,7 +1,6 @@
 # Copyright 2020 by B. Knueven, D. Mildebrath, C. Muir, J-P Watson, and D.L. Woodruff
 # This software is distributed under the 3-clause BSD License.
 from mpisppy.extensions.extension import Extension
-from mpisppy.utils.sputils import find_active_objective
 from pyomo.repn.standard_repn import generate_standard_repn
 from pyomo.core.expr.numeric_expr import LinearExpression
 from mpisppy import global_toc
@@ -74,7 +73,7 @@ class CrossScenarioExtension(Extension):
         cached_ph_obj = dict()
 
         for k,s in opt.local_subproblems.items():
-            phobj = find_active_objective(s)
+            phobj = opt.saved_objectives[k]
             phobj.deactivate()
             cached_ph_obj[k] = phobj
             s._mpisppy_model.EF_Obj.activate()
@@ -157,7 +156,7 @@ class CrossScenarioExtension(Extension):
         
         for k,s in opt.local_subproblems.items():
 
-            obj = find_active_objective(s)
+            obj = opt.saved_objectives[k]
 
             repn = generate_standard_repn(obj.expr, quadratic=True)
             if len(repn.nonlinear_vars) > 0:

--- a/mpisppy/extensions/cross_scen_extension.py
+++ b/mpisppy/extensions/cross_scen_extension.py
@@ -1,6 +1,7 @@
 # Copyright 2020 by B. Knueven, D. Mildebrath, C. Muir, J-P Watson, and D.L. Woodruff
 # This software is distributed under the 3-clause BSD License.
 from mpisppy.extensions.extension import Extension
+from mpisppy.utils.sputils import find_active_objective
 from pyomo.repn.standard_repn import generate_standard_repn
 from pyomo.core.expr.numeric_expr import LinearExpression
 from mpisppy import global_toc
@@ -73,7 +74,7 @@ class CrossScenarioExtension(Extension):
         cached_ph_obj = dict()
 
         for k,s in opt.local_subproblems.items():
-            phobj = opt.saved_objectives[k]
+            phobj = find_active_objective(s)
             phobj.deactivate()
             cached_ph_obj[k] = phobj
             s._mpisppy_model.EF_Obj.activate()
@@ -156,7 +157,7 @@ class CrossScenarioExtension(Extension):
         
         for k,s in opt.local_subproblems.items():
 
-            obj = opt.saved_objectives[k]
+            obj = find_active_objective(s)
 
             repn = generate_standard_repn(obj.expr, quadratic=True)
             if len(repn.nonlinear_vars) > 0:

--- a/mpisppy/extensions/diagnoser.py
+++ b/mpisppy/extensions/diagnoser.py
@@ -11,7 +11,6 @@ import datetime as dt
 import os
 import pyomo.environ as pyo
 import mpisppy.extensions.xhatbase
-from mpisppy.utils.sputils import find_active_objective
 
 class Diagnoser(mpisppy.extensions.xhatbase.XhatBase):
     """
@@ -42,12 +41,10 @@ class Diagnoser(mpisppy.extensions.xhatbase.XhatBase):
             fname = self.dirname+os.sep+sname+".dag"
             with open(fname, "a") as f:
                 f.write(str(self.ph._PHIter)+",")
-                if not bundling:
-                    objfct = find_active_objective(s)
-                    f.write(str(pyo.value(objfct)))
-                else:
+                objfct = self.ph.saved_objectives[sname]
+                if bundling:
                     f.write("Bundling"+",")
-                    f.write(str(pyo.value(self.ph.saved_objs[sname])))
+                f.write(str(pyo.value(objfct)))
                 f.write("\n")
 
     def pre_iter0(self):

--- a/mpisppy/extensions/fixer.py
+++ b/mpisppy/extensions/fixer.py
@@ -131,7 +131,7 @@ class Fixer(mpisppy.extensions.extension.Extension):
     def iter0(self, local_scenarios):
 
         # first, do some persistent solver with bundles gymnastics        
-        have_bundles = hasattr(self.ph, "saved_objs") # indicates bundles
+        have_bundles = self.ph.bundling # indicates bundles
         if have_bundles:
             subpname = next(iter(self.ph.local_subproblems))
             subp = self.ph.local_subproblems[subpname]
@@ -227,7 +227,7 @@ class Fixer(mpisppy.extensions.extension.Extension):
         """ Before iter k>1 solves, but after x-bar update.
         """
         # first, do some persistent solver with bundles gymnastics        
-        have_bundles = hasattr(self.ph, "saved_objs") # indicates bundles
+        have_bundles = self.ph.bundling # indicates bundles
         if have_bundles:
             subpname = next(iter(self.ph.local_subproblems))
             subp = self.ph.local_subproblems[subpname]

--- a/mpisppy/fwph/fwph.py
+++ b/mpisppy/fwph/fwph.py
@@ -90,7 +90,6 @@ class FWPH(mpisppy.phbase.PHBase):
 
     def fw_prep(self):
         self.PH_Prep(attach_duals=True, attach_prox=False)
-        self.subproblem_creation(self.options['verbose'])
         self._output_header()
 
         if ('point_creator' in self.FW_options):

--- a/mpisppy/opt/aph.py
+++ b/mpisppy/opt/aph.py
@@ -12,7 +12,6 @@ import mpisppy
 import mpisppy.MPI as mpi
 import pyomo.environ as pyo
 from pyomo.opt import SolverFactory, SolverStatus
-from mpisppy.utils.sputils import find_active_objective
 import mpisppy.utils.listener_util.listener_util as listener_util
 import mpisppy.phbase as ph_base
 import mpisppy.utils.sputils as sputils
@@ -866,7 +865,7 @@ class APH(ph_base.PHBase):
 
         if self.plot_trace_prefix is not None:
             for k,s in self.local_scenarios.items():
-                objval = pyo.value(find_active_objective(s))
+                objval = pyo.value(self.saved_objectives[k])
                 with open(f"trace_{k}_{self.conv_trace_filename}", "a") as fil:
                     fil.write(f"{self._PHIter},{objval}")
                     for (ndn,i), xvar in s._mpisppy_data.nonant_indices.items():
@@ -1038,7 +1037,7 @@ class APH(ph_base.PHBase):
                                          initialize = 0.0,
                                          mutable = True)
                 
-            objfct = find_active_objective(scenario)
+            objfct = self.saved_objectives[sname]
                 
             if self.use_lag:
                 assert not scenario._mpisppy_data.has_variable_probability

--- a/mpisppy/opt/aph.py
+++ b/mpisppy/opt/aph.py
@@ -1066,8 +1066,6 @@ class APH(ph_base.PHBase):
                     objfct.expr +=  scenario._mpisppy_model.W_on * scenario._mpisppy_model.W[ndn,i] * xvar
 
         # End APH-specific Prep
-        
-        self.subproblem_creation(self.options["verbose"])
 
         trivial_bound = self.Iter0()
 

--- a/mpisppy/opt/ph.py
+++ b/mpisppy/opt/ph.py
@@ -50,8 +50,6 @@ class PH(mpisppy.phbase.PHBase):
         """
         verbose = self.options['verbose']
         self.PH_Prep()
-        # Why is subproblem_creation() not called in PH_Prep? Answer: xhat_eval.
-        self.subproblem_creation(verbose)
 
         if (verbose):
             print('Calling PH Iter0 on global rank {}'.format(global_rank))

--- a/mpisppy/phbase.py
+++ b/mpisppy/phbase.py
@@ -651,7 +651,7 @@ class PHBase(mpisppy.spopt.SPOpt):
             """
             if ((not add_duals) and (not add_prox)):
                 return
-            objfct = sputils.find_active_objective(scenario)
+            objfct = self.saved_objectives[sname]
             is_min_problem = objfct.is_minimizing()
 
             xbars = scenario._mpisppy_model.xbars

--- a/mpisppy/spopt.py
+++ b/mpisppy/spopt.py
@@ -48,6 +48,7 @@ class SPOpt(SPBase):
             scenario_creator_kwargs=scenario_creator_kwargs,
             variable_probability=variable_probability,
         )
+        self._save_active_objectives()
         self.current_solver_options = None
         self.extensions = extensions
         self.extension_kwargs = extension_kwargs
@@ -322,10 +323,7 @@ class SPOpt(SPBase):
         """
         local_Eobjs = []
         for k,s in self.local_scenarios.items():
-            if self.bundling:
-                objfct = self.saved_objs[k]
-            else:
-                objfct = sputils.find_active_objective(s)
+            objfct = self.saved_objectives[k]
             local_Eobjs.append(s._mpisppy_probability * pyo.value(objfct))
             if verbose:
                 print ("caller", inspect.stack()[1][3])
@@ -736,6 +734,14 @@ class SPOpt(SPBase):
                     persistent_solver.update_var(vardata)
 
 
+    def _save_active_objectives(self):
+        """ Save the active objectives for use in PH, bundles, and calculation """
+        self.saved_objectives = dict()
+
+        for sname, scenario_instance in self.local_scenarios.items():
+            self.saved_objectives[sname] = sputils.find_active_objective(scenario_instance)
+
+
     def FormEF(self, scen_dict, EF_name=None):
         """ Make the EF for a list of scenarios.
 
@@ -773,6 +779,8 @@ class SPOpt(SPBase):
         Note:
             Objectives are scaled (normalized) by _mpisppy_probability
         """
+        # The individual scenario instances are sub-blocks of the binding
+        # instance. Needed to facilitate bundles + persistent solvers
         if len(scen_dict) == 0:
             raise RuntimeError("Empty scenario list for EF")
 
@@ -782,16 +790,6 @@ class SPOpt(SPBase):
                 print ("WARNING: EF_name="+EF_name+" not used; singleton="+sname)
                 print ("MAJOR WARNING: a bundle of size one encountered; if you try to compute bounds it might crash (Feb 2019)")
             return scenario_instance
-
-        # The individual scenario instances are sub-blocks of the binding
-        # instance. Needed to facilitate bundles + persistent solvers
-        if not hasattr(self, "saved_objs"): # First bundle
-             self.saved_objs = dict()
-
-        for sname, scenario_instance in scen_dict.items():
-            if sname not in self.local_scenarios:
-                raise RuntimeError("EF scen not in local_scenarios="+sname)
-            self.saved_objs[sname] = sputils.find_active_objective(scenario_instance)
 
         EF_instance = sputils._create_EF_from_scen_dict(scen_dict, EF_name=EF_name,
                         nonant_for_fixed_vars=False)

--- a/mpisppy/spopt.py
+++ b/mpisppy/spopt.py
@@ -49,6 +49,7 @@ class SPOpt(SPBase):
             variable_probability=variable_probability,
         )
         self._save_active_objectives()
+        self._subproblem_creation(options.get("verbose", False))
         self.current_solver_options = None
         self.extensions = extensions
         self.extension_kwargs = extension_kwargs
@@ -796,7 +797,7 @@ class SPOpt(SPBase):
         return EF_instance
 
 
-    def subproblem_creation(self, verbose=False):
+    def _subproblem_creation(self, verbose=False):
         """ Create local subproblems (not local scenarios).
 
         If bundles are specified, this function creates the bundles.

--- a/mpisppy/utils/xhat_eval.py
+++ b/mpisppy/utils/xhat_eval.py
@@ -62,7 +62,6 @@ class Xhat_Eval(mpisppy.spopt.SPOpt):
     def _lazy_create_solvers(self):
         if self._subproblems_solvers_created:
             return
-        self.subproblem_creation(self.verbose)
         self._create_solvers()
         self._subproblems_solvers_created = True
 

--- a/mpisppy/utils/xhat_eval.py
+++ b/mpisppy/utils/xhat_eval.py
@@ -88,14 +88,11 @@ class Xhat_Eval(mpisppy.spopt.SPOpt):
 
 
         if compute_val_at_nonant:
-            if self.bundling:
-                objfct = self.saved_objs[k]    
-            else:
-                objfct = sputils.find_active_objective(s)
-                if self.verbose:
-                    print ("caller", inspect.stack()[1][3])
-                    print ("E_Obj Scenario {}, prob={}, Obj={}, ObjExpr={}"\
-                           .format(k, s._mpisppy_probability, pyo.value(objfct), objfct.expr))
+            objfct = self.saved_objectives[k]
+            if self.verbose:
+                print ("caller", inspect.stack()[1][3])
+                print ("E_Obj Scenario {}, prob={}, Obj={}, ObjExpr={}"\
+                       .format(k, s._mpisppy_probability, pyo.value(objfct), objfct.expr))
             self.objs_dict[k] = pyo.value(objfct)
         return(pyomo_solve_time)
 


### PR DESCRIPTION
I want to add a new feature to `SPOpt`, but the way we create subproblems is making it awkward.

Unconditionally saves the scenario objective functions before bundle / subproblem creation.