### PR TITLE
Remove final Lagrangian solve

### DIFF
--- a/mpisppy/cylinders/lagrangian_bounder.py
+++ b/mpisppy/cylinders/lagrangian_bounder.py
@@ -81,13 +81,7 @@ class LagrangianOuterBound(mpisppy.cylinders.spoke.OuterBoundWSpoke):
                 self.dk_iter += 1
 
     def finalize(self):
-        '''
-        Do one final lagrangian pass with the final
-        PH weights. Useful for when PH convergence
-        and/or iteration limit is the cause of termination
-        '''
-        self.final_bound = self._set_weights_and_solve()
-        self.bound = self.final_bound
+        self.final_bound = self.bound
         if self.opt.extensions is not None and \
             hasattr(self.opt.extobject, 'post_everything'):
             self.opt.extobject.post_everything()

--- a/mpisppy/tests/test_with_cylinders.py
+++ b/mpisppy/tests/test_with_cylinders.py
@@ -145,7 +145,7 @@ class Test_farmer_with_cylinders(unittest.TestCase):
         wheel.spin()
         if wheel.global_rank == 1:
             #print(f"{wheel.spcomm.bound= }")
-            self.assertAlmostEqual(wheel.spcomm.bound, -115405.55555,1)
+            self.assertAlmostEqual(wheel.spcomm.bound, -109499.5160897, 1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This can take a significant amount of time, such that finalization is waiting on the Lagrangian bounder.

The benefit seems marginal at best -- if we've already decided to stop, let's just wrap it up.