### PR TITLE
Dependency cleanup

### DIFF
--- a/mpisppy/convergers/primal_dual_converger.py
+++ b/mpisppy/convergers/primal_dual_converger.py
@@ -1,7 +1,6 @@
 import numpy as np
 import os
 import pandas as pd
-import matplotlib.pyplot as plt
 import mpisppy.convergers.converger
 from mpisppy import MPI
 from mpisppy.extensions.phtracker import TrackedData
@@ -141,6 +140,9 @@ class PrimalDualConverger(mpisppy.convergers.converger.Converger):
         Plot the results of the convergence checks
         by reading in csv file and plotting
         """
+        # don't create a hard dependency on matplotlib
+        import matplotlib.pyplot as plt
+
         plot_fname = self.tracker.plot_fname
         conv_data = pd.read_csv(self.tracker.fname)
 

--- a/mpisppy/extensions/phtracker.py
+++ b/mpisppy/extensions/phtracker.py
@@ -3,7 +3,6 @@
     Must use the PH object for this to work
 '''
 import ast
-import matplotlib.pyplot as plt
 import numpy as np
 import os
 import pandas as pd
@@ -408,6 +407,9 @@ class PHTracker(Extension):
     def plot_gaps(self, var):
         ''' plot the gaps; Assumes gaps are saved in a csv file
         '''
+        # only import this if needed so we
+        # don't create a hard dependency
+        import matplotlib.pyplot as plt
 
 
         df = pd.read_csv(self.track_dict[var].fname, sep=',')

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         'numpy',
         'scipy',
         'pyomo>=6.4',
+        'pandas', # should probably remove
     ],
     extras_require={
         'doc': [


### PR DESCRIPTION
Running `afew.py` on a new system today and a few dependencies surprised me.

I have relegated `matplotlib` to only be imported when a plotting function is called. I have also added a hard dependency on pandas as several built-in modules use it.

That said, I also get the following message on my system, which is part of the reason I hate having pandas as a dependency:
```
/Users/bknueven/Software/mpi-sppy/mpisppy/extensions/phtracker.py:63: FutureWarning: The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes. To retain the old behavior, exclude the relevant entries before the concat operation.
  self.df = pd.concat([self.df, new_dict], ignore_index=True)
```