### PR TITLE
Lagranger: Be sure we don't set nonants to `nan`

### DIFF
--- a/mpisppy/cylinders/lagranger_bounder.py
+++ b/mpisppy/cylinders/lagranger_bounder.py
@@ -6,6 +6,7 @@
 import time
 import json
 import csv
+import numpy as np
 import mpisppy.cylinders.spoke
 from mpisppy.cylinders.lagrangian_bounder import _LagrangianMixin
 
@@ -58,10 +59,13 @@ class LagrangerOuterBound(_LagrangianMixin, mpisppy.cylinders.spoke.OuterBoundNo
             mpisppy.utils.wxbarutils.write_xbar_to_file(self.opt, xbar_fname)
 
     def _update_weights_and_solve(self, iternum):
-        # Work with the nonants that we have (and we might not have any yet).
         extensions = self.opt.extensions is not None
-        self.opt._put_nonant_cache(self.localnonants)
-        self.opt._restore_nonants()
+        # Work with the nonants that we have (and we might not have any yet).
+        # Only update if the nonants are not nan:
+        #   otherwise xbar / w will be undefined!
+        if not np.isnan(self.localnonants[0]):
+            self.opt._put_nonant_cache(self.localnonants)
+            self.opt._restore_nonants()
         verbose = self.opt.options["verbose"]
         self.opt.Compute_Xbar(verbose=verbose)
         self.opt.Update_W(verbose=verbose)


### PR DESCRIPTION
If Lagranger is faster than the hub to iteration 1, the nonants from the hub will be `nan`, which can cause the `W`'s to be `nan`, and then the user gets an error from the solver interface.

The PR would fix this bug.