### PR TITLE
Correct `ExtensiveForm` docstring arg order and add missing parameter

### DIFF
--- a/mpisppy/opt/ef.py
+++ b/mpisppy/opt/ef.py
@@ -31,10 +31,13 @@ class ExtensiveForm(mpisppy.spbase.SPBase):
         scenario_creator (callable):
             Scenario creator function, which takes as input a scenario
             name, and returns a Pyomo model of that scenario.
+        scenario_creator_kwargs (dict, optional):
+            Keyword arguments passed to `scenario_creator`.
+        all_nodenames (list, optional):
+            List of all node names, incl. leaves. Can be None for two-stage
+            problem.
         model_name (str, optional):
             Name of the resulting EF model object.
-        scenario_creator_kwargs (dict):
-            Keyword args passed to `scenario_creator`.
         suppress_warnings (bool, optional):
             Boolean to suppress warnings when building the EF. Default
             is False.


### PR DESCRIPTION
### Description

This pull request improves the documentation for the `ExtensiveForm` class by:
1. Correcting the order of arguments in the docstring to match the `__init__` method signature.
2. Adding the missing `all_nodenames` argument to the docstring.

### Changes Made
- Updated the `ExtensiveForm` class docstring for consistency and completeness.

### Rationale
The previous docstring was misleading due to:
- A mismatch in the order of arguments.
- The omission of the `all_nodenames` argument.

These changes enhance the clarity and usability of the documentation, making it easier for developers to understand and use the class.