### PR TITLE
Initial implementation of IntegerRelaxThenEnforce

### DIFF
--- a/doc/src/extensions.rst
+++ b/doc/src/extensions.rst
@@ -88,6 +88,21 @@ xhat
 Most of the xhat methods can be used as an extension instead of being used
 as a spoke, when that is desired (e.g. for serial applications).
 
+integer_relax_then_enforce
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This extension is for problems with integer variables. The scenario subproblems
+have the integrality restrictions initially relaxed, and then at a later point
+the subproblem integrality restrictions are re-enabled. The parameter ``ratio``
+(default = 0.5) controls how much of the progressive hedging algorithm, either
+in the iteration or time limit, is used for relaxed progressive hedging iterations.
+The extension will also re-enforce the integrality restrictions if the convergence
+threshold is within 10\%  of the convergence tolerance.
+
+This extension can be especially effective if (1) solving the relaxation
+is much easier than solving the problem with integrality constraints or (2) the
+relaxation is reasonably "tight".
+
 WXBarWriter and WXBarReader
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/examples/run_all.py
+++ b/examples/run_all.py
@@ -275,9 +275,12 @@ do_one("sizes",
 do_one("sizes", "sizes_pysp.py", 1, "3 {}".format(solver_name))
 do_one("sslp",
        "sslp_cylinders.py",
-       3,
+       4,
        "--instance-name=sslp_15_45_10 --bundles-per-rank=0 "
-       "--max-iterations=5 --default-rho=1 "
+       "--integer-relax-then-enforce "
+       "--integer-relax-then-enforce-ratio=0.95 "
+       "--lagrangian "
+       "--max-iterations=100 --default-rho=1 "
        "--reduced-costs --rc-fixer --xhatshuffle "
        "--linearize-proximal-terms "
        "--rel-gap=0.0 "

--- a/examples/sslp/sslp_cylinders.py
+++ b/examples/sslp/sslp_cylinders.py
@@ -33,6 +33,7 @@ def _parse_args():
     cfg.subgradient_args()
     cfg.reduced_costs_args()
     cfg.coeff_rho_args()
+    cfg.integer_relax_then_enforce_args()
     cfg.parse_command_line("sslp_cylinders")
     return cfg
 
@@ -90,6 +91,9 @@ def main():
 
     if cfg.coeff_rho:
         vanilla.add_coeff_rho(hub_dict, cfg)
+
+    if cfg.integer_relax_then_enforce:
+        vanilla.add_integer_relax_then_enforce(hub_dict, cfg)
 
     # FWPH spoke
     if fwph:

--- a/mpisppy/cylinders/xhatlooper_bounder.py
+++ b/mpisppy/cylinders/xhatlooper_bounder.py
@@ -72,6 +72,7 @@ class XhatLooperInnerBound(spoke.InnerBoundNonantSpoke):
                 logger.debug(f'   *got a new one! on rank {self.global_rank}')
                 logger.debug(f'   *localnonants={str(self.localnonants)}')
 
+                self.opt._restore_original_fixedness()
                 self.opt._put_nonant_cache(self.localnonants)
                 self.opt._restore_nonants()
                 upperbound, srcsname = xhatter.xhat_looper(scen_limit=scen_limit, restore_nonants=False)

--- a/mpisppy/cylinders/xhatlooper_bounder.py
+++ b/mpisppy/cylinders/xhatlooper_bounder.py
@@ -72,9 +72,10 @@ class XhatLooperInnerBound(spoke.InnerBoundNonantSpoke):
                 logger.debug(f'   *got a new one! on rank {self.global_rank}')
                 logger.debug(f'   *localnonants={str(self.localnonants)}')
 
-                self.opt._restore_original_fixedness()
                 self.opt._put_nonant_cache(self.localnonants)
-                self.opt._restore_nonants()
+                # just for sending the values to other scenarios
+                # so we don't need to tell persistent solvers
+                self.opt._restore_nonants(update_persistent=False)
                 upperbound, srcsname = xhatter.xhat_looper(scen_limit=scen_limit, restore_nonants=False)
 
                 # send a bound to the opt companion

--- a/mpisppy/cylinders/xhatshufflelooper_bounder.py
+++ b/mpisppy/cylinders/xhatshufflelooper_bounder.py
@@ -138,9 +138,10 @@ class XhatShuffleInnerBound(spoke.InnerBoundNonantSpoke):
                 logger.debug(f'   *localnonants={str(self.localnonants)}')
 
                 # update the caches
-                self.opt._restore_original_fixedness()
                 self.opt._put_nonant_cache(self.localnonants)
-                self.opt._restore_nonants()
+                # just for sending the values to other scenarios
+                # so we don't need to tell persistent solvers
+                self.opt._restore_nonants(update_persistent=False)
                 
                 scenario_cycler.begin_epoch()
 

--- a/mpisppy/cylinders/xhatshufflelooper_bounder.py
+++ b/mpisppy/cylinders/xhatshufflelooper_bounder.py
@@ -138,6 +138,7 @@ class XhatShuffleInnerBound(spoke.InnerBoundNonantSpoke):
                 logger.debug(f'   *localnonants={str(self.localnonants)}')
 
                 # update the caches
+                self.opt._restore_original_fixedness()
                 self.opt._put_nonant_cache(self.localnonants)
                 self.opt._restore_nonants()
                 

--- a/mpisppy/cylinders/xhatspecific_bounder.py
+++ b/mpisppy/cylinders/xhatspecific_bounder.py
@@ -91,9 +91,11 @@ class XhatSpecificInnerBound(spoke.InnerBoundNonantSpoke):
                               format(global_rank))
                 logging.debug('  localnonants={}'.format(str(self.localnonants)))
 
-                self.opt._restore_original_fixedness()
                 self.opt._put_nonant_cache(self.localnonants)  # don't really need all caches
-                self.opt._restore_nonants()
+                # just for sending the values to other scenarios
+                # so we don't need to tell persistent solvers
+                self.opt._restore_nonants(update_persistent=False)
+
                 innerbound = xhatter.xhat_tryit(xhat_scenario_dict, restore_nonants=False)
 
                 self.update_if_improving(innerbound)

--- a/mpisppy/cylinders/xhatspecific_bounder.py
+++ b/mpisppy/cylinders/xhatspecific_bounder.py
@@ -91,6 +91,7 @@ class XhatSpecificInnerBound(spoke.InnerBoundNonantSpoke):
                               format(global_rank))
                 logging.debug('  localnonants={}'.format(str(self.localnonants)))
 
+                self.opt._restore_original_fixedness()
                 self.opt._put_nonant_cache(self.localnonants)  # don't really need all caches
                 self.opt._restore_nonants()
                 innerbound = xhatter.xhat_tryit(xhat_scenario_dict, restore_nonants=False)

--- a/mpisppy/cylinders/xhatxbar_bounder.py
+++ b/mpisppy/cylinders/xhatxbar_bounder.py
@@ -95,6 +95,7 @@ class XhatXbarInnerBound(spoke.InnerBoundNonantSpoke):
                 logging.debug('  and its new! on global rank {}'.\
                               format(global_rank))
                 logging.debug('  localnonants={}'.format(str(self.localnonants)))
+                self.opt._restore_original_fixedness()
                 self.opt._put_nonant_cache(self.localnonants)  # don't really need all caches
                 self.opt._restore_nonants()
                 innerbound = xhatter.xhat_tryit(restore_nonants=False)

--- a/mpisppy/cylinders/xhatxbar_bounder.py
+++ b/mpisppy/cylinders/xhatxbar_bounder.py
@@ -95,9 +95,10 @@ class XhatXbarInnerBound(spoke.InnerBoundNonantSpoke):
                 logging.debug('  and its new! on global rank {}'.\
                               format(global_rank))
                 logging.debug('  localnonants={}'.format(str(self.localnonants)))
-                self.opt._restore_original_fixedness()
                 self.opt._put_nonant_cache(self.localnonants)  # don't really need all caches
-                self.opt._restore_nonants()
+                # just for sending the values to other scenarios
+                # so we don't need to tell persistent solvers
+                self.opt._restore_nonants(update_persistent=False)
                 innerbound = xhatter.xhat_tryit(restore_nonants=False)
 
                 self.update_if_improving(innerbound)

--- a/mpisppy/extensions/integer_relax_then_enforce.py
+++ b/mpisppy/extensions/integer_relax_then_enforce.py
@@ -1,0 +1,63 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+
+import time
+import pyomo.environ as pyo
+import mpisppy.extensions.extension
+from mpisppy.utils.sputils import is_persistent
+from mpisppy import global_toc
+
+class IntegerRelaxThenEnforce(mpisppy.extensions.extension.Extension):
+    """ Class for relaxing integer variables, running PH, and then
+        enforcing the integality constraints after some condition.
+    """
+
+    def __init__(self, opt):
+        super().__init__(opt)
+        self.integer_relaxer = pyo.TransformationFactory('core.relax_integer_vars')
+        options = opt.options.get("integer_relax_then_enforce_options", {})
+        # fraction of iterations or time to spend in relaxed mode
+        self.ratio = options.get("ratio", 0.5)
+
+
+    def pre_iter0(self):
+        global_toc(f"{self.__class__.__name__}: relaxing integrality constraints", self.opt.cylinder_rank == 0)
+        for s in self.opt.local_scenarios.values():
+            self.integer_relaxer.apply_to(s) 
+        self._integers_relaxed = True
+
+    def _unrelax_integers(self):
+        for sub in self.opt.local_subproblems.values():
+            for sn in sub.scen_list:
+                s = self.opt.local_scenarios[sn]
+                subproblem_solver = sub._solver_plugin
+                vlist = None
+                if is_persistent(subproblem_solver):
+                    vlist = list(v for v,d in s._relaxed_integer_vars[None].values())
+                self.integer_relaxer.apply_to(s, options={"undo":True}) 
+                if is_persistent(subproblem_solver):
+                    for v in vlist:
+                        subproblem_solver.update_var(v)
+        self._integers_relaxed = False
+
+    def miditer(self):
+        if not self._integers_relaxed:
+            return
+        # time is running out
+        if self.opt.options["time_limit"] is not None and ( time.perf_counter() - self.opt.start_time ) > (self.opt.options["time_limit"] * self.ratio):
+            global_toc(f"{self.__class__.__name__}: enforcing integrality constraints, ran so far for more than {self.opt.options['time_limit']*self.ratio} seconds", self.opt.cylinder_rank == 0)
+            self._unrelax_integers()
+        # iterations are running out
+        if self.opt._PHIter > self.opt.options["PHIterLimit"] * self.ratio:
+            global_toc(f"{self.__class__.__name__}: enforcing integrality constraints, ran so far for {self.opt._PHIter - 1} iterations", self.opt.cylinder_rank == 0)
+            self._unrelax_integers()
+        # nearly converged
+        if self.opt.conv < (self.opt.options["convthresh"] * 1.1):
+            global_toc(f"{self.__class__.__name__}: Enforcing integrality constraints, PH is nearly converged", self.opt.cylinder_rank == 0)
+            self._unrelax_integers()

--- a/mpisppy/extensions/xhatbase.py
+++ b/mpisppy/extensions/xhatbase.py
@@ -192,8 +192,9 @@ class XhatBase(mpisppy.extensions.extension.Extension):
                     sputils.reactivate_objs(s)
                 # if you hit infeas, return None
                 if not pyo.check_optimal_termination(results):
-                   self.opt._restore_nonants()
-                   return None
+                    if restore_nonants:
+                        self.opt._restore_nonants()
+                    return None
                
             # feasible xhat found, so finish up 2EF part and return
             if verbose and src_rank == self.cylinder_rank:
@@ -219,9 +220,8 @@ class XhatBase(mpisppy.extensions.extension.Extension):
 
         infeasP = self.opt.infeas_prob()
         if infeasP != 0.:
-            # restoring does no harm
-            # if this solution is infeasible
-            self.opt._restore_nonants()
+            if restore_nonants:
+                self.opt._restore_nonants()
             return None
         else:
             if verbose and src_rank == self.cylinder_rank:

--- a/mpisppy/extensions/xhatxbar.py
+++ b/mpisppy/extensions/xhatxbar.py
@@ -94,9 +94,8 @@ class XhatXbar(mpisppy.extensions.xhatbase.XhatBase):
 
         infeasP = self.opt.infeas_prob()
         if infeasP != 0.:
-            # restoring does no harm
-            # if this solution is infeasible
-            self.opt._restore_nonants()
+            if restore_nonants:
+                self.opt._restore_nonants()
             return None
         else:
             if verbose and self.cylinder_rank == 0:

--- a/mpisppy/generic_cylinders.py
+++ b/mpisppy/generic_cylinders.py
@@ -57,6 +57,7 @@ def _parse_args(m):
     cfg.ph_args()
     cfg.aph_args()
     cfg.fixer_args()    
+    cfg.integer_relax_then_enforce_args()
     cfg.gapper_args()    
     cfg.fwph_args()
     cfg.lagrangian_args()
@@ -170,6 +171,9 @@ def _do_decomp(module, cfg, scenario_creator, scenario_creator_kwargs, scenario_
         }
     if cfg.rc_fixer:
         vanilla.add_reduced_costs_fixer(hub_dict, cfg)
+
+    if cfg.integer_relax_then_enforce:
+        vanilla.add_integer_relax_then_enforce(hub_dict, cfg)
 
     if cfg.grad_rho:
         ext_classes.append(Gradient_extension)

--- a/mpisppy/spopt.py
+++ b/mpisppy/spopt.py
@@ -59,6 +59,7 @@ class SPOpt(SPBase):
         self._subproblem_creation(options.get("verbose", False))
         if options.get("presolve", False):
             self._presolver = SPPresolve(self)
+            self._presolver.presolve()
         else:
             self._presolver = None
         self.current_solver_options = None
@@ -672,7 +673,7 @@ class SPOpt(SPBase):
 
 
 
-    def _restore_nonants(self):
+    def _restore_nonants(self, update_persistent=True):
         """ Restore nonanticipative variables to their original values.
 
         This function works in conjunction with _save_nonants.
@@ -688,7 +689,7 @@ class SPOpt(SPBase):
         for k,s in self.local_scenarios.items():
 
             persistent_solver = None
-            if (sputils.is_persistent(s._solver_plugin)):
+            if (update_persistent and sputils.is_persistent(s._solver_plugin)):
                 persistent_solver = s._solver_plugin
 
             for ci, vardata in enumerate(s._mpisppy_data.nonant_indices.values()):
@@ -874,9 +875,6 @@ class SPOpt(SPBase):
 
 
     def _create_solvers(self, presolve=True):
-
-        if self._presolver is not None and presolve:
-            self._presolver.presolve()
 
         dtiming = ("display_timing" in self.options) and self.options["display_timing"]
         local_sit = [] # Local set instance time for time tracking

--- a/mpisppy/utils/cfg_vanilla.py
+++ b/mpisppy/utils/cfg_vanilla.py
@@ -38,6 +38,7 @@ from mpisppy.cylinders.hub import PHHub
 from mpisppy.cylinders.hub import APHHub
 from mpisppy.extensions.extension import MultiExtension
 from mpisppy.extensions.fixer import Fixer
+from mpisppy.extensions.integer_relax_then_enforce import IntegerRelaxThenEnforce
 from mpisppy.extensions.cross_scen_extension import CrossScenarioExtension
 from mpisppy.extensions.reduced_costs_fixer import ReducedCostsFixer
 from mpisppy.extensions.reduced_costs_rho import ReducedCostsRho
@@ -202,6 +203,13 @@ def add_fixer(hub_dict,
     hub_dict["opt_kwargs"]["options"]["fixeroptions"] = {"verbose":False,
                                               "boundtol": cfg.fixer_tol,
                                               "id_fix_list_fct": cfg.id_fix_list_fct}
+    return hub_dict
+
+def add_integer_relax_then_enforce(hub_dict,
+              cfg,
+              ):
+    hub_dict = extension_adder(hub_dict,IntegerRelaxThenEnforce)
+    hub_dict["opt_kwargs"]["options"]["integer_relax_then_enforce_options"] = {"ratio":cfg.integer_relax_then_enforce_ratio}
     return hub_dict
 
 def add_reduced_costs_rho(hub_dict, cfg):

--- a/mpisppy/utils/config.py
+++ b/mpisppy/utils/config.py
@@ -433,6 +433,18 @@ class Config(pyofig.ConfigDict):
                            domain=float,
                            default=1e-2)
 
+    def integer_relax_then_enforce_args(self):
+        self.add_to_config('integer_relax_then_enforce',
+                           description="have an integer relax then enforce extensions",
+                           domain=bool,
+                           default=False)
+
+        self.add_to_config('integer_relax_then_enforce_ratio',
+                           description="fraction of time limit or iterations (whichever is sooner) "
+                                       "to spend with relaxed integers",
+                           domain=float,
+                           default=0.5)
+
     def reduced_costs_rho_args(self):
         self.add_to_config("reduced_costs_rho",
                            description="have a ReducedCostsRho extension",


### PR DESCRIPTION
TODO:
- [x] Investigate the necessity of adding call to `SPOpt._restore_original_fixedness` to xhat cylinders
- [ ] Should we also track relative / absolute gaps as a candidate to switch? (I think *no*, if things are going well why switch?)
- [x] Add documentation
- [x] Add test(s)