### PR TITLE
Fix GHA failures

### DIFF
--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -380,13 +380,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: test_env
-          python-version: 3.9
+          python-version: 3.11
           auto-activate-base: false
       - name: Install dependencies
         run: |
+          conda install conda-forge::libstdcxx-ng
           conda install mpi4py "numpy<2" setuptools cmake
           pip install pyomo pandas xpress cplex scipy sympy dill
 


### PR DESCRIPTION
`ubuntu-latest` became Ubuntu 24.04, which broke our Pynumero builds. This PR fixes that.