### PR TITLE
Deprecate warnings for loose bundles

### DIFF
--- a/doc/src/properbundles.rst
+++ b/doc/src/properbundles.rst
@@ -7,6 +7,9 @@ scenarios. We will refer to these as `loose bundles`. This bundling scheme
 is very flexible with respect to the numbers of scenarios in each bundle.
 There are various if-blocks in the mpisppy code to support this type of bundle.
 
+.. Warning::
+   In relase 1.0, loose bundles scheduled to be deprecated.
+
 In 2024, `proper bundles` were supported. After the extensive form
 for a proper bundle is created, the original scenarios are more or less
 forgotten and all processing takes place for the bundle. At the time

--- a/mpisppy/spbase.py
+++ b/mpisppy/spbase.py
@@ -104,7 +104,7 @@ class SPBase:
             self._assign_bundles()
             self.bundling = True
             print("WARNING: The bundles-per-rank is now called `loose bundling' and\n"
-                  "loose bundling will be deprecated in the next release\n. 
+                  "loose bundling will be deprecated in the next release\n."
                   "You should switch to the use of 'proper bundles'.\n"
                   " See the documentation and also misppy.generic_cylinders.py"
                   )

--- a/mpisppy/spbase.py
+++ b/mpisppy/spbase.py
@@ -99,9 +99,15 @@ class SPBase:
             raise RuntimeError("More ranks than scenarios")
 
         self._calculate_scenario_ranks()
+        # Put the deprecation message in the init so they should only see it once per rank
         if "bundles_per_rank" in self.options and self.options["bundles_per_rank"] > 0:
             self._assign_bundles()
             self.bundling = True
+            print("WARNING: The bundles-per-rank is now called `loose bundling' and\n"
+                  "loose bundling will be deprecated in the next release\n. 
+                  "You should switch to the use of 'proper bundles'.\n"
+                  " See the documentation and also misppy.generic_cylinders.py"
+                  )
         else:
             self.bundling = False
         self._create_scenarios(scenario_creator_kwargs)

--- a/mpisppy/utils/config.py
+++ b/mpisppy/utils/config.py
@@ -195,7 +195,7 @@ class Config(pyofig.ConfigDict):
                             default=None)
 
         self.add_to_config("bundles_per_rank",
-                            description="Loose bundles per rank (default 0 (no bundles))",
+                            description="Loose bundles per rank (default 0 (no bundles)) WILL BE DEPRECATED",
                             domain=int,
                             default=0)
 


### PR DESCRIPTION
This just gives warnings. (BTW: a fly in the ointment is that there is not yet support for generic, proper, multi-stage bundles; however, I think I provide pretty good support within a month)