### PR TITLE
Make sure prox_approx does not loop forever

### DIFF
--- a/mpisppy/spopt.py
+++ b/mpisppy/spopt.py
@@ -176,9 +176,8 @@ class SPOpt(SPBase):
                 s._solver_plugin.options[option_key] = option_value
 
         solve_keyword_args = dict()
-        if self.cylinder_rank == 0:
-            if tee is not None and tee is True:
-                solve_keyword_args["tee"] = True
+        if tee is not None and tee is True:
+            solve_keyword_args["tee"] = True
         if (sputils.is_persistent(s._solver_plugin)):
             solve_keyword_args["save_results"] = False
         elif disable_pyomo_signal_handling:

--- a/mpisppy/utils/prox_approx.py
+++ b/mpisppy/utils/prox_approx.py
@@ -160,7 +160,9 @@ class _ProxApproxManager:
         # print(f"initial distance: {_f(this_val, x_pnt, y_pnt)**(0.5)}")
         # print(f"this_val: {this_val}")
         next_val = _newton_step(this_val, x_pnt, y_pnt)
-        while not isclose(this_val, next_val, rel_tol=1e-6, abs_tol=1e-6):
+        for _ in range(10):
+            if isclose(this_val, next_val, rel_tol=1e-6, abs_tol=1e-6):
+                break
             # print(f"newton step distance: {_f(next_val, x_pnt, y_pnt)**(0.5)}")
             # print(f"next_val: {next_val}")
             this_val = next_val


### PR DESCRIPTION
Drive by: tee all ranks because we say we're tee-ing all ranks. The caller can control who has `tee=True`