### PR TITLE
Xbar-W reader writer options processing re-work

### DIFF
--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -405,7 +405,7 @@ jobs:
         run: |
           cd mpisppy/tests
           python test_gradient_rho.py
-          python test_w_writer.py
+          python test_xbar_w_reader_writer.py
 
   test-headers:
     name: header test

--- a/examples/farmer/farmer_cylinders.py
+++ b/examples/farmer/farmer_cylinders.py
@@ -112,6 +112,8 @@ def main():
                                   ph_converger=ph_converger,
                                   rho_setter = rho_setter)
 
+    hub_dict['opt_kwargs']['options']['cfg'] = cfg                    
+
     if cfg.primal_dual_converger:
         hub_dict['opt_kwargs']['options']\
             ['primal_dual_converger_options'] = {

--- a/mpisppy/generic_cylinders.py
+++ b/mpisppy/generic_cylinders.py
@@ -358,7 +358,7 @@ def _do_decomp(module, cfg, scenario_creator, scenario_creator_kwargs, scenario_
     # if the user dares, let them mess with the hubdict prior to solve
     if cfg.hub_and_spoke_dict_callback is not None:
         module = sputils.module_name_to_module(cfg.hub_and_spoke_dict_callback)
-        module.hub_and_spoke_dict_callback(hubdict, list_of_spoke_dict)
+        module.hub_and_spoke_dict_callback(hub_dict, list_of_spoke_dict)
 
     wheel = WheelSpinner(hub_dict, list_of_spoke_dict)
     wheel.spin()

--- a/mpisppy/generic_cylinders.py
+++ b/mpisppy/generic_cylinders.py
@@ -212,10 +212,10 @@ def _do_decomp(module, cfg, scenario_creator, scenario_creator_kwargs, scenario_
     if cfg.scenario_lpfiles:
         ext_classes.append(Scenario_lpfiles)
 
-    if cfg.W_reader:
+    if cfg.W_and_xbar_reader:
         ext_classes.append(WXBarReader)
 
-    if cfg.W_writer:
+    if cfg.W_and_xbar_writer:
         ext_classes.append(WXBarWriter)
 
     if cfg.user_defined_extensions is not None:

--- a/mpisppy/generic_cylinders.py
+++ b/mpisppy/generic_cylinders.py
@@ -95,6 +95,12 @@ def _parse_args(m):
                       description="Space-delimited module names for user extensions",
                       domain=pyofig.ListOf(str),
                       default=None)
+    # TBD - think about adding directory for json options files
+
+    cfg.add_to_config("hubdict_callback",
+                      description="[FOR EXPERTS ONLY] Module that contains the function hubdict_callback that will be passed the hubdict prior to spin-the-wheel (last chance for intervention)",
+                      domain=str,
+                      default=None)    
     
     cfg.parse_command_line(f"mpi-sppy for {cfg.module_name}")
     
@@ -348,7 +354,11 @@ def _do_decomp(module, cfg, scenario_creator, scenario_creator_kwargs, scenario_
         list_of_spoke_dict.append(xhatxbar_spoke)
     if cfg.reduced_costs:
         list_of_spoke_dict.append(reduced_costs_spoke)
-        
+
+    # if the user dares, let them mess with the hubdict prior to solve
+    if cfg.hubdict_callback is not None:
+        module = sputils.module_name_to_module(cfg.hubdict_callback)
+        module.hubdict_callback(hubdict)
 
     wheel = WheelSpinner(hub_dict, list_of_spoke_dict)
     wheel.spin()

--- a/mpisppy/generic_cylinders.py
+++ b/mpisppy/generic_cylinders.py
@@ -97,8 +97,8 @@ def _parse_args(m):
                       default=None)
     # TBD - think about adding directory for json options files
 
-    cfg.add_to_config("hubdict_callback",
-                      description="[FOR EXPERTS ONLY] Module that contains the function hubdict_callback that will be passed the hubdict prior to spin-the-wheel (last chance for intervention)",
+    cfg.add_to_config("hub_and_spoke_dict_callback",
+                      description="[FOR EXPERTS ONLY] Module that contains the function hub_and_spoke_dict_callback that will be passed the hubdict and list of spokedicts prior to spin-the-wheel (last chance for intervention)",
                       domain=str,
                       default=None)    
     
@@ -356,9 +356,9 @@ def _do_decomp(module, cfg, scenario_creator, scenario_creator_kwargs, scenario_
         list_of_spoke_dict.append(reduced_costs_spoke)
 
     # if the user dares, let them mess with the hubdict prior to solve
-    if cfg.hubdict_callback is not None:
-        module = sputils.module_name_to_module(cfg.hubdict_callback)
-        module.hubdict_callback(hubdict)
+    if cfg.hub_and_spoke_dict_callback is not None:
+        module = sputils.module_name_to_module(cfg.hub_and_spoke_dict_callback)
+        module.hub_and_spoke_dict_callback(hubdict, list_of_spoke_dict)
 
     wheel = WheelSpinner(hub_dict, list_of_spoke_dict)
     wheel.spin()

--- a/mpisppy/generic_cylinders.py
+++ b/mpisppy/generic_cylinders.py
@@ -163,7 +163,7 @@ def _do_decomp(module, cfg, scenario_creator, scenario_creator_kwargs, scenario_
 
     # the intent of the following is to transition to strictly
     # cfg-based option passing, as opposed to dictionary-based processing.
-    hub_dict['opt_kwargs']['options'] = {'cfg': cfg}                
+    hub_dict['opt_kwargs']['options']['cfg'] = cfg                
         
     # Extend and/or correct the vanilla dictionary
     ext_classes = list()

--- a/mpisppy/generic_cylinders.py
+++ b/mpisppy/generic_cylinders.py
@@ -199,10 +199,10 @@ def _do_decomp(module, cfg, scenario_creator, scenario_creator_kwargs, scenario_
     if cfg.scenario_lpfiles:
         ext_classes.append(Scenario_lpfiles)
 
-    if cdf.W_reader:
+    if cfg.W_reader:
         ext_classes.append(WXBarReader)
 
-    if cdf.W_writer:
+    if cfg.W_writer:
         ext_classes.append(WXBarWriter)
 
     if cfg.sep_rho:

--- a/mpisppy/phbase.py
+++ b/mpisppy/phbase.py
@@ -239,8 +239,6 @@ class PHBase(mpisppy.spopt.SPOpt):
                 Function to set rho values throughout the PH algorithm.
             variable_probability (callable, optional):
                 Function to set variable specific probabilities.
-            cfg (config object, optional?)  controls (mainly from user)
-                (Maybe this should move up to spbase)
 
     """
     def __init__(

--- a/mpisppy/tests/test_gradient_rho.py
+++ b/mpisppy/tests/test_gradient_rho.py
@@ -57,7 +57,7 @@ class Test_gradient_farmer(unittest.TestCase):
         scenario_creator_kwargs = farmer.kw_creator(self.cfg)
         beans = (self.cfg, scenario_creator, scenario_denouement, all_scenario_names)
         hub_dict = vanilla.ph_hub(*beans, scenario_creator_kwargs=scenario_creator_kwargs)
-        hub_dict['opt_kwargs']['options']['cfg'] = cfg                            
+        hub_dict['opt_kwargs']['options']['cfg'] = self.cfg                            
         list_of_spoke_dict = list()
         wheel = WheelSpinner(hub_dict, list_of_spoke_dict)
         wheel.spin()

--- a/mpisppy/tests/test_gradient_rho.py
+++ b/mpisppy/tests/test_gradient_rho.py
@@ -57,6 +57,7 @@ class Test_gradient_farmer(unittest.TestCase):
         scenario_creator_kwargs = farmer.kw_creator(self.cfg)
         beans = (self.cfg, scenario_creator, scenario_denouement, all_scenario_names)
         hub_dict = vanilla.ph_hub(*beans, scenario_creator_kwargs=scenario_creator_kwargs)
+        hub_dict['opt_kwargs']['options']['cfg'] = cfg                            
         list_of_spoke_dict = list()
         wheel = WheelSpinner(hub_dict, list_of_spoke_dict)
         wheel.spin()

--- a/mpisppy/tests/test_xbar_w_reader_writer.py
+++ b/mpisppy/tests/test_xbar_w_reader_writer.py
@@ -44,7 +44,7 @@ def _create_cfg():
 
 #*****************************************************************************
 
-class Test_w_writer_farmer(unittest.TestCase):
+class Test_xbar_w_reader_writer_farmer(unittest.TestCase):
     """ Test the gradient code using farmer."""
 
     def _create_ph_farmer(self, ph_extensions=None, max_iter=100):

--- a/mpisppy/tests/test_xbar_w_reader_writer.py
+++ b/mpisppy/tests/test_xbar_w_reader_writer.py
@@ -25,7 +25,7 @@ from mpisppy.tests.utils import get_solver
 import mpisppy.utils.wxbarreader as wxbarreader
 import mpisppy.utils.wxbarwriter as wxbarwriter
 
-__version__ = 0.1
+__version__ = 0.2
 
 solver_available,solver_name, persistent_available, persistent_solver_name= get_solver()
 
@@ -61,10 +61,12 @@ class Test_xbar_w_reader_writer_farmer(unittest.TestCase):
         beans = (self.cfg, scenario_creator, scenario_denouement, all_scenario_names)
         hub_dict = vanilla.ph_hub(*beans, scenario_creator_kwargs=scenario_creator_kwargs, ph_extensions=ph_extensions)
         hub_dict['opt_kwargs']['options']['cfg'] = self.cfg
-        if ph_extensions==wxbarwriter.WXBarWriter: #tbd
+        if ph_extensions==wxbarwriter.WXBarWriter:
+            self.cfg.W_and_xbar_writer = True
             self.cfg.W_fname = self.temp_w_file_name
             self.cfg.Xbar_fname = self.temp_xbar_file_name
         if ph_extensions==wxbarreader.WXBarReader:
+            self.cfg.W_and_xbar_reader = True
             self.cfg.init_W_fname = self.w_file_name
             self.cfg.init_Xbar_fname = self.xbar_file_name
         list_of_spoke_dict = list()

--- a/mpisppy/utils/config.py
+++ b/mpisppy/utils/config.py
@@ -959,11 +959,11 @@ class Config(pyofig.ConfigDict):
                             default=0)
 
     def wxbar_read_write_args(self):
-        import mpisppy.utils.wxbarreader
+        import mpisppy.utils.wxbarreader as wxbarreader
         print("DEPRECATION WARNING: wxbar_read_write_args should be moved to wxbarreader.add_options_to_config")
         wxbarreader.add_options_to_config(self)
 
-        import mpisppy.utils.wxbarwriter
+        import mpisppy.utils.wxbarwriter as wxbarwriter
         print("DEPRECATION WARNING: wxbar_read_write_args should be moved to wxbarwriter.add_options_to_config")
         wxbarwriter.add_options_to_config(self)        
 

--- a/mpisppy/utils/config.py
+++ b/mpisppy/utils/config.py
@@ -958,32 +958,14 @@ class Config(pyofig.ConfigDict):
                             domain=int,
                             default=0)
 
-
     def wxbar_read_write_args(self):
-        self.add_to_config("init_W_fname",
-                                description="Path of initial W file (default None)",
-                                domain=str,
-                                default=None)
-        self.add_to_config("init_Xbar_fname",
-                                description="Path of initial Xbar file (default None)",
-                                domain=str,
-                                default=None)
-        self.add_to_config("init_separate_W_files",
-                                description="If True, W is read from separate files (default False)",
-                                domain=bool,
-                                default=False)
-        self.add_to_config("W_fname",
-                                description="Path of final W file (default None)",
-                                domain=str,
-                                default=None)
-        self.add_to_config("Xbar_fname",
-                                description="Path of final Xbar file (default None)",
-                                domain=str,
-                                default=None)
-        self.add_to_config("separate_W_files",
-                                description="If True, writes W to separate files (default False)",
-                                domain=bool,
-                                default=False)
+        import mpisppy.utils.wxbarreader
+        print("DEPRECATION WARNING: wxbar_read_write_args should be moved to wxbarreader.add_options_to_config")
+        wxbarreader.add_options_to_config(self)
+
+        import mpisppy.utils.wxbarwriter
+        print("DEPRECATION WARNING: wxbar_read_write_args should be moved to wxbarwriter.add_options_to_config")
+        wxbarwriter.add_options_to_config(self)        
 
     def proper_bundle_config(self):
         self.add_to_config('pickle_bundles_dir',

--- a/mpisppy/utils/config.py
+++ b/mpisppy/utils/config.py
@@ -960,11 +960,9 @@ class Config(pyofig.ConfigDict):
 
     def wxbar_read_write_args(self):
         import mpisppy.utils.wxbarreader as wxbarreader
-        print("DEPRECATION WARNING: wxbar_read_write_args should be moved to wxbarreader.add_options_to_config")
         wxbarreader.add_options_to_config(self)
 
         import mpisppy.utils.wxbarwriter as wxbarwriter
-        print("DEPRECATION WARNING: wxbar_read_write_args should be moved to wxbarwriter.add_options_to_config")
         wxbarwriter.add_options_to_config(self)        
 
     def proper_bundle_config(self):

--- a/mpisppy/utils/gradient.py
+++ b/mpisppy/utils/gradient.py
@@ -15,7 +15,6 @@ import importlib
 import csv
 import copy
 
-from mpisppy.utils import config
 import mpisppy.utils.cfg_vanilla as vanilla
 from mpisppy.utils.wxbarwriter import WXBarWriter
 from mpisppy.spin_the_wheel import WheelSpinner

--- a/mpisppy/utils/gradient.py
+++ b/mpisppy/utils/gradient.py
@@ -190,29 +190,6 @@ class Find_Grad():
 ###################################################################################
 
 
-def _parser_setup():
-    """ Set up config object and return it, but don't parse 
-
-    Returns:
-       cfg (Config): config object
-
-    Notes:
-       parsers for the non-model-specific arguments; but the model_module_name will be pulled off first
-
-    """
-
-    cfg = config.Config()
-    cfg.add_branching_factors()
-    cfg.num_scens_required()
-    cfg.popular_args()
-    cfg.two_sided_args()
-    cfg.ph_args()
-    
-    cfg.gradient_args()
-
-    return cfg
-
-
 def grad_cost_and_rho(mname, original_cfg):
     """ Creates a ph object from cfg and using the module 'mname' functions. Then computes the corresponding grad cost and rho.
 
@@ -244,6 +221,7 @@ def grad_cost_and_rho(mname, original_cfg):
     if hasattr(model_module, '_variable_probability'):
         variable_probability = model_module._variable_probability
     beans = (cfg, scenario_creator, scenario_denouement, all_scenario_names)
+    # Note: the callers need to set w_writer cfg options
     hub_dict = vanilla.ph_hub(*beans,
                               scenario_creator_kwargs=scenario_creator_kwargs,
                               ph_extensions=WXBarWriter,

--- a/mpisppy/utils/gradient.py
+++ b/mpisppy/utils/gradient.py
@@ -248,6 +248,7 @@ def grad_cost_and_rho(mname, original_cfg):
                               scenario_creator_kwargs=scenario_creator_kwargs,
                               ph_extensions=WXBarWriter,
                               variable_probability=variable_probability)
+    hub_dict['opt_kwargs']['options']['cfg'] = cfg                
     list_of_spoke_dict = list()
     wheel = WheelSpinner(hub_dict, list_of_spoke_dict)
     wheel.spin() #TODO: steal only what's needed in  WheelSpinner

--- a/mpisppy/utils/wxbarreader.py
+++ b/mpisppy/utils/wxbarreader.py
@@ -41,8 +41,8 @@ rank = MPI.COMM_WORLD.Get_rank()
 
 def add_options_to_config(cfg):
 
-    cfg.add_to_config("W_reader",
-                      description="Enables the w reader (default False)",
+    cfg.add_to_config("W_and_xbar_reader",
+                      description="Enables the w and xbar reader (default False)",
                       domain=bool,
                       default=False)
     cfg.add_to_config("init_W_fname",
@@ -65,7 +65,8 @@ class WXBarReader(mpisppy.extensions.extension.Extension):
 
         assert 'cfg' in ph.options
         self.cfg = ph.options['cfg']
-        assert 'W_reader' in self.cfg
+        if self.cfg.get("W_and_xbar_return") is None or not cfg.W_and_xbar_reader:
+            return  # nothing to do here
 
         ''' Do a bunch of checking if files exist '''
         w_fname, x_fname, sep_files = self.cfg.init_W_fname, self.cfg.init_Xbar_fname, self.cfg.init_separate_W_files

--- a/mpisppy/utils/wxbarreader.py
+++ b/mpisppy/utils/wxbarreader.py
@@ -39,18 +39,38 @@ import mpisppy.MPI as MPI
 n_proc = MPI.COMM_WORLD.Get_size()
 rank = MPI.COMM_WORLD.Get_rank()
 
+def add_options_to_config(cfg):
+
+    cfg.add_to_config("W_reader",
+                      description="Enables the w reader (default False)",
+                      domain=bool,
+                      default=False)
+    cfg.add_to_config("init_W_fname",
+                      description="Path of initial W file (default None)",
+                      domain=str,
+                      default=None)
+    cfg.add_to_config("init_Xbar_fname",
+                      description="Path of initial Xbar file (default None)",
+                      domain=str,
+                      default=None)
+    cfg.add_to_config("init_separate_W_files",
+                      description="If True, W is read from separate files (default False)",
+                      domain=bool,
+                      default=False)
+
 class WXBarReader(mpisppy.extensions.extension.Extension):
     """ Extension class for reading W values
     """
     def __init__(self, ph):
 
-        ''' Do a bunch of checking if files exist '''
-        w_fname, x_fname, sep_files = None, None, False
-        if ('init_separate_W_files' in ph.options):
-            sep_files = ph.options['init_separate_W_files']
+        assert 'cfg' in ph.options
+        self.cfg = ph.options['cfg']
+        assert 'W_reader' in self.cfg
 
-        if ('init_W_fname' in ph.options):
-            w_fname = ph.options['init_W_fname']
+        ''' Do a bunch of checking if files exist '''
+        w_fname, x_fname, sep_files = self.cfg.init_W_fname, self.cfg.init_Xbar_fname, self.cfg.init_separate_W_files
+
+        if w_fname is not None:
             if (not os.path.exists(w_fname)):
                 if (rank == 0):
                     if (sep_files):
@@ -59,8 +79,7 @@ class WXBarReader(mpisppy.extensions.extension.Extension):
                         print('Cannot find file', w_fname)
                 quit()
 
-        if ('init_Xbar_fname' in ph.options):
-            x_fname = ph.options['init_Xbar_fname']
+        if x_fname is not None:
             if (not os.path.exists(x_fname)):
                 if (rank == 0):
                     print('Cannot find file', x_fname)

--- a/mpisppy/utils/wxbarreader.py
+++ b/mpisppy/utils/wxbarreader.py
@@ -65,8 +65,11 @@ class WXBarReader(mpisppy.extensions.extension.Extension):
 
         assert 'cfg' in ph.options
         self.cfg = ph.options['cfg']
-        if self.cfg.get("W_and_xbar_return") is None or not cfg.W_and_xbar_reader:
+        if self.cfg.get("W_and_xbar_reader") is None or not self.cfg.W_and_xbar_reader:
+            self.not_active = True
             return  # nothing to do here
+        else:
+            self.not_active = False
 
         ''' Do a bunch of checking if files exist '''
         w_fname, x_fname, sep_files = self.cfg.init_W_fname, self.cfg.init_Xbar_fname, self.cfg.init_separate_W_files
@@ -105,6 +108,8 @@ class WXBarReader(mpisppy.extensions.extension.Extension):
 
     def miditer(self):
         ''' Called before the solveloop is called '''
+        if self.not_active:
+            return  # nothing to do.
         if self.PHB._PHIter == 1:
             if self.w_fname:
                 mpisppy.utils.wxbarutils.set_W_from_file(

--- a/mpisppy/utils/wxbarwriter.py
+++ b/mpisppy/utils/wxbarwriter.py
@@ -38,19 +38,35 @@ import mpisppy.MPI as MPI
 n_proc = MPI.COMM_WORLD.Get_size()
 rank = MPI.COMM_WORLD.Get_rank()
 
+def add_options_to_config(cfg):
+    cfg.add_to_config("W_writer",
+                      description="Enables the w writer (default False)",
+                      domain=bool,
+                      default=False)
+    cfg.add_to_config("W_fname",
+                      description="Path of final W file (default None)",
+                      domain=str,
+                      default=None)
+    cfg.add_to_config("Xbar_fname",
+                      description="Path of final Xbar file (default None)",
+                      domain=str,
+                      default=None)
+    cfg.add_to_config("separate_W_files",
+                      description="If True, writes W to separate files (default False)",
+                      domain=bool,
+                      default=False)            
+
 class WXBarWriter(mpisppy.extensions.extension.Extension):
     """ Extension class for writing the W values
     """
     def __init__(self, ph):
-        # Check a bunch of files
-        w_fname, w_grad_fname, x_fname, sep_files = None, None, None, False
 
-        if ('W_fname' in ph.options): # W_fname is a path if separate_W_files=True
-            w_fname = ph.options['W_fname']
-        if ('Xbar_fname' in ph.options):
-            x_fname = ph.options['Xbar_fname']
-        if ('separate_W_files' in ph.options):
-            sep_files = ph.options['separate_W_files']
+        assert 'cfg' in ph.options
+        self.cfg = ph.options['cfg']
+        assert 'W_writer' in self.cfg
+        
+        # Check a bunch of files
+        w_fname, x_fname, sep_files = self.cfg.W_fname, self.cfg.Xbar_fname, self.cfg.separate_W_files
 
         if (x_fname is None and w_fname is None and rank==0):
             print('Warning: no output files provided to WXBarWriter. '
@@ -71,7 +87,6 @@ class WXBarWriter(mpisppy.extensions.extension.Extension):
         self.PHB = ph
         self.cylinder_rank = rank
         self.w_fname = w_fname
-        self.w_grad_fname = w_grad_fname
         self.x_fname = x_fname
         self.sep_files = sep_files # Write separate files for each 
                                    # scenario's dual weights
@@ -98,12 +113,6 @@ class WXBarWriter(mpisppy.extensions.extension.Extension):
             fname = self.w_fname
             mpisppy.utils.wxbarutils.write_W_to_file(self.PHB, fname,
                 sep_files=self.sep_files)
-        if (self.w_grad_fname):
-            # TODO: finish implementing?
-            #grad_fname = 'grad_fname.csv'
-            #mpisppy.utils.wxbarutils.write_W_grad_to_file(self.PHB, grad_fname,
-            #sep_files=self.sep_files)
-            pass
         if (self.x_fname):
             mpisppy.utils.wxbarutils.write_xbar_to_file(self.PHB, self.x_fname)
 

--- a/mpisppy/utils/wxbarwriter.py
+++ b/mpisppy/utils/wxbarwriter.py
@@ -63,6 +63,11 @@ class WXBarWriter(mpisppy.extensions.extension.Extension):
 
         assert 'cfg' in ph.options
         self.cfg = ph.options['cfg']
+        if self.cfg.get("W_and_xbar_writer") is None or not self.cfg.W_and_xbar_writer:
+            self.not_active = True
+            return  # nothing to do here
+        else:
+            self.not_active = False
         
         # Check a bunch of files
         w_fname, x_fname, sep_files = self.cfg.W_fname, self.cfg.Xbar_fname, self.cfg.separate_W_files
@@ -100,14 +105,19 @@ class WXBarWriter(mpisppy.extensions.extension.Extension):
         pass
 
     def enditer(self):
-       """ if (self.w_fname):
-            fname = f'fname{self.PHB._PHIter}.csv'
-            mpisppy.utils.wxbarutils.write_W_to_file(self.PHB, w_fname,
-                sep_files=self.sep_files)"""
-       pass
+        if self.not_active:
+            return  # nothing to do.
+        else:
+            pass
+        #if (self.w_fname):
+        #     fname = f'fname{self.PHB._PHIter}.csv'
+        #     mpisppy.utils.wxbarutils.write_W_to_file(self.PHB, w_fname,
+        #         sep_files=self.sep_files)
 
 
     def post_everything(self):
+        if self.not_active:
+            return  # nothing to do.
         if (self.w_fname):
             fname = self.w_fname
             mpisppy.utils.wxbarutils.write_W_to_file(self.PHB, fname,

--- a/mpisppy/utils/wxbarwriter.py
+++ b/mpisppy/utils/wxbarwriter.py
@@ -39,8 +39,8 @@ n_proc = MPI.COMM_WORLD.Get_size()
 rank = MPI.COMM_WORLD.Get_rank()
 
 def add_options_to_config(cfg):
-    cfg.add_to_config("W_writer",
-                      description="Enables the w writer (default False)",
+    cfg.add_to_config("W_and_xbar_writer",
+                      description="Enables the w and xbar writer(default False)",
                       domain=bool,
                       default=False)
     cfg.add_to_config("W_fname",
@@ -63,7 +63,6 @@ class WXBarWriter(mpisppy.extensions.extension.Extension):
 
         assert 'cfg' in ph.options
         self.cfg = ph.options['cfg']
-        assert 'W_writer' in self.cfg
         
         # Check a bunch of files
         w_fname, x_fname, sep_files = self.cfg.W_fname, self.cfg.Xbar_fname, self.cfg.separate_W_files

--- a/mpisppy/utils/wxbarwriter.py
+++ b/mpisppy/utils/wxbarwriter.py
@@ -64,10 +64,10 @@ class WXBarWriter(mpisppy.extensions.extension.Extension):
         assert 'cfg' in ph.options
         self.cfg = ph.options['cfg']
         if self.cfg.get("W_and_xbar_writer") is None or not self.cfg.W_and_xbar_writer:
-            self.not_active = True
+            self.active = False
             return  # nothing to do here
         else:
-            self.not_active = False
+            self.active = True
         
         # Check a bunch of files
         w_fname, x_fname, sep_files = self.cfg.W_fname, self.cfg.Xbar_fname, self.cfg.separate_W_files
@@ -105,7 +105,7 @@ class WXBarWriter(mpisppy.extensions.extension.Extension):
         pass
 
     def enditer(self):
-        if self.not_active:
+        if not self.active:
             return  # nothing to do.
         else:
             pass
@@ -116,7 +116,7 @@ class WXBarWriter(mpisppy.extensions.extension.Extension):
 
 
     def post_everything(self):
-        if self.not_active:
+        if not self.active:
             return  # nothing to do.
         if (self.w_fname):
             fname = self.w_fname


### PR DESCRIPTION
Intended as an exemplar for improving options processing and reading in mpisppy. 

Objective is to move options definition and processing into "leaf" classes, to improve encapsulation. 

This PR only does this for XBar-W reader/writer extensions, as a concise place to start.

Also actually makes use of these extensions in generic_cylinders.py - previously the options were specified, but never used.