### PR TITLE
require Python >=3.9

### DIFF
--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: test_env
-          python-version: 3.8
+          python-version: 3.9
           auto-activate-base: false
       - name: Install dependencies
         run: |

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     author='David Woodruff',
     author_email='dlwoodruff@ucdavis.edu',
     packages=packages,
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     install_requires=[
         'sortedcollections',
         'numpy<2',


### PR DESCRIPTION
#476 wants to use features in Python 3.9+. Though these features are available in Python 3.8 from `__future__`, Python 3.8 reach EOL 2024-10-07.

This PR would require at least Python 3.9 for `mpi-sppy`.

