### PR TITLE
Enhancements for proper bundles

### DIFF
--- a/doc/src/properbundles.rst
+++ b/doc/src/properbundles.rst
@@ -77,8 +77,7 @@ file ``aircond_cylinders.py`` in the aircond example directory
 provides an example.  The latter part of the ``allways.bash`` script
 demonstrates how to run it.
 
-There is support for multi-stage bundles in mpi-sppy, but the scenario
-probabilities must be uniform and the bundles must span the same number
+There is support for multi-stage bundles in mpi-sppy, but the bundles must span the same number
 of entire second stage nodes.
 
 Notes

--- a/examples/sslp/sslp.py
+++ b/examples/sslp/sslp.py
@@ -83,6 +83,11 @@ def inparser_adder(cfg):
                         description="path to sslp data (e.g., ./data)",
                         domain=str,
                         default=None)                
+    cfg.add_to_config("surrogate_nonant",
+                      description="use a surrogate nonant summing the total number of servers",
+                      domain=bool,
+                      default=False,
+                     )
 
 
 #=========
@@ -99,7 +104,7 @@ def kw_creator(cfg):
     else:
         cfg.add_and_assign("num_scens","number of scenarios", int, None, ns)
     data_dir = os.path.join(cfg.sslp_data_path, inst, "scenariodata")
-    kwargs = {"data_dir": data_dir}
+    kwargs = {"data_dir": data_dir, "surrogate": cfg.surrogate_nonant}
     return kwargs
 
 

--- a/mpisppy/utils/proper_bundler.py
+++ b/mpisppy/utils/proper_bundler.py
@@ -130,6 +130,8 @@ class ProperBundler():
             nonant_ef_suppl_list = []
             surrogate_nonant_list = []
             for idx, v in bundle.ref_vars.items():
+                # surrogate nonants are added back to the nonant_list by attach_root_node,
+                # after they have been noted in surrogate_vardatas
                 if idx[0] == "ROOT" and idx not in bundle.ref_surrogate_vars:
                     nonantlist.append(v)
             for idx, v in bundle.ref_suppl_vars.items():

--- a/mpisppy/utils/proper_bundler.py
+++ b/mpisppy/utils/proper_bundler.py
@@ -122,21 +122,24 @@ class ProperBundler():
                                        scenario_creator_kwargs=kws,
                                        EF_name=sname,
                                        suppress_warnings=True,                                       
-                                       nonant_for_fixed_vars = False)
+                                       nonant_for_fixed_vars = False,
+                                       total_number_of_scenarios = cfg.num_scens,
+            )
 
-            nonantlist = [v for idx, v in bundle.ref_vars.items() if idx[0] =="ROOT"]
-            # if the original scenarios were uniform, this needs to be also
-            # (EF formation will recompute for the bundle if uniform)
+            nonantlist = []
+            nonant_ef_suppl_list = []
+            surrogate_nonant_list = []
+            for idx, v in bundle.ref_vars.items():
+                if idx[0] == "ROOT" and idx not in bundle.ref_surrogate_vars:
+                    nonantlist.append(v)
+            for idx, v in bundle.ref_suppl_vars.items():
+                if idx[0] == "ROOT" and idx not in bundle.ref_surrogate_vars:
+                    nonant_ef_suppl_list.append(v)
+            surrogate_nonant_list = [v for idx, v in bundle.ref_surrogate_vars.items() if idx[0] =="ROOT"]
+            sputils.attach_root_node(bundle, 0, nonantlist, nonant_ef_suppl_list, surrogate_nonant_list)
+
             # Get an arbitrary scenario.
-            scen = self.module.scenario_creator(snames[0], **self.original_kwargs)
-            if scen._mpisppy_probability == "uniform":
-                bprob = "uniform"
-            else:
-                raise RuntimeError("Proper bundles created by proper_bundle.py require uniform probability (consider creating problem-specific bundles)")
-                bprob = bundle._mpisppy_probability
-            sputils.attach_root_node(bundle, 0, nonantlist)
-            bundle._mpisppy_probability = bprob
-
+            scen = bundle.component(snames[0])
             if len(scen._mpisppy_node_list) > 1 and self.bunBFs is None:
                 raise RuntimeError("You are creating proper bundles for a\n"
                       "multi-stage problem, but without cfg.branching_factors.\n"


### PR DESCRIPTION
- Support non-uniform probabilities in proper bundles
- Support surrogate non-anticipative variables in proper bundles
- Proper bundles now doesn't build the first scenario twice
- Add `surrogate_nonant` option for SSLP when using generic_cylinders.py
- Correctly compute nonant cost coefficients when proper bundles are used