### PR TITLE
Reimplement subgradient bounder to use subgradient opt class

### DIFF
--- a/mpisppy/phbase.py
+++ b/mpisppy/phbase.py
@@ -1085,11 +1085,12 @@ class PHBase(mpisppy.spopt.SPOpt):
                 self.spcomm.sync_nonants()
                 self.spcomm.sync_bounds()
                 self.spcomm.sync_extensions()
-                if self.spcomm.is_converged():
-                    global_toc("Cylinder convergence", self.cylinder_rank == 0)
-                    break
             elif hasattr(self.spcomm, "sync"):
                 self.spcomm.sync()
+
+            if self.spcomm and self.spcomm.is_converged():
+                global_toc("Cylinder convergence", self.cylinder_rank == 0)
+                break
 
             if have_extensions:
                 self.extobject.enditer_after_sync()

--- a/mpisppy/utils/cfg_vanilla.py
+++ b/mpisppy/utils/cfg_vanilla.py
@@ -742,6 +742,7 @@ def subgradient_spoke(
         ph_extensions=ph_extensions,
         extension_kwargs=extension_kwargs,
     )
+    subgradient_spoke["opt_class"] = Subgradient
     if cfg.subgradient_iter0_mipgap is not None:
         subgradient_spoke["opt_kwargs"]["options"]["iter0_solver_options"]\
             ["mipgap"] = cfg.subgradient_iter0_mipgap
@@ -751,6 +752,14 @@ def subgradient_spoke(
     if cfg.subgradient_rho_multiplier is not None:
         subgradient_spoke["opt_kwargs"]["options"]["subgradient_rho_multiplier"]\
             = cfg.subgradient_rho_multiplier
+
+    options = subgradient_spoke["opt_kwargs"]["options"]
+    # make sure this spoke doesn't hit the time or iteration limit
+    options["time_limit"] = None
+    options["PHIterLimit"] = cfg.max_iterations * 1_000_000
+    options["display_progress"] = False
+    options["display_convergence_detail"] = False
+
     add_ph_tracking(subgradient_spoke, cfg, spoke=True)
 
     return subgradient_spoke


### PR DESCRIPTION
An astute student informed me that the rho setter was not working with the subgradient spoke. He was of course, correct.

So I've reimplemented the subgradient spoke in the PR to use the newer subgradient opt algorithm, which should pick up all regular PH features.