### PR TITLE
Add return if we have cylinder convergence after iteration 0

### DIFF
--- a/mpisppy/phbase.py
+++ b/mpisppy/phbase.py
@@ -1017,6 +1017,7 @@ class PHBase(mpisppy.spopt.SPOpt):
             # print a screen trace for iteration 0
             if self.spcomm.is_converged():
                 global_toc("Cylinder convergence", self.cylinder_rank == 0)
+                return
 
         for self._PHIter in range(1, max_iterations+1):
             iteration_start_time = time.time()


### PR DESCRIPTION
No point in continuing `iterk_loop` in this case.