### PR TITLE
Add solution status check to flag GAMS infeasible solves

### DIFF
--- a/mpisppy/utils/sputils.py
+++ b/mpisppy/utils/sputils.py
@@ -76,6 +76,7 @@ def build_vardatalist(model, varlist=None):
 def not_good_enough_results(results):
     return (results is None) or (len(results.solution) == 0) or \
         (results.solution(0).status == SolutionStatus.infeasible) or \
+        (results.solution(0).status == SolutionStatus.unknown) or \
         (results.solver.termination_condition == TerminationCondition.infeasible) or \
         (results.solver.termination_condition == TerminationCondition.infeasibleOrUnbounded) or \
         (results.solver.termination_condition == TerminationCondition.unbounded)


### PR DESCRIPTION
When using GAMS' solvers, there are certain infeasible solves with an `unknown` solution status return which is not flagged in the current implementation of the solution check used in xhatbase. This PR addresses that issue to avoid infeasible xhat solutions from certain ranks being considered valid by checking for the `unknown` solution status returned by GAMS. 