### PR TITLE
Iter0 Warmstarts

### DIFF
--- a/mpisppy/cylinders/ph_dual_spoke.py
+++ b/mpisppy/cylinders/ph_dual_spoke.py
@@ -35,8 +35,6 @@ class _PHDualSpokeBase(Spoke, PHHub):
         attach_prox = True
         self.opt.PH_Prep(attach_prox=attach_prox, attach_smooth = smoothed)
         trivial_bound = self.opt.Iter0()
-        if self.opt._can_update_best_bound():
-            self.opt.best_bound_obj_val = trivial_bound
 
         # update the rho
         self.update_rho()

--- a/mpisppy/cylinders/subgradient_bounder.py
+++ b/mpisppy/cylinders/subgradient_bounder.py
@@ -27,8 +27,6 @@ class SubgradientOuterBound(mpisppy.cylinders.spoke.OuterBoundSpoke):
         attach_prox = False
         self.opt.PH_Prep(attach_prox=attach_prox, attach_smooth = 0)
         trivial_bound = self.opt.Iter0()
-        if self.opt._can_update_best_bound():
-            self.opt.best_bound_obj_val = trivial_bound
 
         # update the rho
         self.update_rho()

--- a/mpisppy/opt/aph.py
+++ b/mpisppy/opt/aph.py
@@ -1067,8 +1067,6 @@ class APH(ph_base.PHBase):
         # End APH-specific Prep
 
         trivial_bound = self.Iter0()
-        if self._can_update_best_bound():
-            self.best_bound_obj_val = trivial_bound
 
         self.setup_Lens()
         self.setup_dispatchrecord()

--- a/mpisppy/opt/ph.py
+++ b/mpisppy/opt/ph.py
@@ -64,8 +64,6 @@ class PH(mpisppy.phbase.PHBase):
         if (verbose):
             print(f'Calling {self.__class__.__name__} Iter0 on global rank {global_rank}')
         trivial_bound = self.Iter0()
-        if self._can_update_best_bound():
-            self.best_bound_obj_val = trivial_bound
         if (verbose):
             print(f'Completed {self.__class__.__name__} Iter0 on global rank {global_rank}')
         if ('asynchronousPH' in self.options) and (self.options['asynchronousPH']):

--- a/mpisppy/phbase.py
+++ b/mpisppy/phbase.py
@@ -859,6 +859,10 @@ class PHBase(mpisppy.spopt.SPOpt):
         if "time_limit" not in self.options:
             self.options["time_limit"] = None
 
+    def _can_update_best_bound(self):
+        if not self.prox_disabled:
+            return False
+        return super()._can_update_best_bound()
 
     def Iter0(self):
         """ Create solvers and perform the initial PH solve (with no dual

--- a/mpisppy/tests/test_xbar_w_reader_writer.py
+++ b/mpisppy/tests/test_xbar_w_reader_writer.py
@@ -99,7 +99,7 @@ class Test_xbar_w_reader_writer_farmer(unittest.TestCase):
         os.remove(self.temp_xbar_file_name)
 
     def test_wreader(self):
-        self.ph_object = self._create_ph_farmer(ph_extensions=wxbarreader.WXBarReader, max_iter=1)
+        self.ph_object = self._create_ph_farmer(ph_extensions=wxbarreader.WXBarReader, max_iter=0)
         for sname, scenario in self.ph_object.local_scenarios.items():
             if sname == 'scen0':
                 self.assertAlmostEqual(scenario._mpisppy_model.W[("ROOT", 1)]._value, 70.84705093609978)
@@ -107,12 +107,15 @@ class Test_xbar_w_reader_writer_farmer(unittest.TestCase):
                 self.assertAlmostEqual(scenario._mpisppy_model.W[("ROOT", 0)]._value, -41.104251445950844)
 
     def test_xbarreader(self):
-        self.ph_object = self._create_ph_farmer(ph_extensions=wxbarreader.WXBarReader, max_iter=1)
+        self.ph_object = self._create_ph_farmer(ph_extensions=wxbarreader.WXBarReader, max_iter=0)
         for sname, scenario in self.ph_object.local_scenarios.items():
             if sname == 'scen0':
                 self.assertAlmostEqual(scenario._mpisppy_model.xbars[("ROOT", 1)]._value, 274.2239371483933)
             if sname == 'scen1':
                 self.assertAlmostEqual(scenario._mpisppy_model.xbars[("ROOT", 0)]._value, 96.88717449844287)
+
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/mpisppy/utils/wxbarreader.py
+++ b/mpisppy/utils/wxbarreader.py
@@ -100,25 +100,23 @@ class WXBarReader(mpisppy.extensions.extension.Extension):
         self.sep_files = sep_files
 
     def pre_iter0(self):
-        pass
-
+        if self.not_active:
+            return  # nothing to do.
+        if self.w_fname:
+            mpisppy.utils.wxbarutils.set_W_from_file(
+                    self.w_fname, self.PHB, self.cylinder_rank,
+                    sep_files=self.sep_files)
+            self.PHB._reenable_W() # This makes a big difference.
+        if self.x_fname:
+            mpisppy.utils.wxbarutils.set_xbar_from_file(self.x_fname, self.PHB)
+            self.PHB._reenable_prox()
 
     def post_iter0(self):
         pass
-
+        
     def miditer(self):
         ''' Called before the solveloop is called '''
-        if self.not_active:
-            return  # nothing to do.
-        if self.PHB._PHIter == 1:
-            if self.w_fname:
-                mpisppy.utils.wxbarutils.set_W_from_file(
-                        self.w_fname, self.PHB, self.cylinder_rank,
-                        sep_files=self.sep_files)
-                self.PHB._reenable_W() # This makes a big difference.
-            if self.x_fname:
-                mpisppy.utils.wxbarutils.set_xbar_from_file(self.x_fname, self.PHB)
-                self.PHB._reenable_prox()
+        pass
 
     def enditer(self):
         ''' Called after the solve loop '''


### PR DESCRIPTION
#331 fixed a bug when warm-starting PH the initial typical trivial bound would be incorrect if the proximal term was active. To fix this, the warmstart wasn't applied until iteration 1 instead, but this meant the iteration 0 solve was wasted effort.

This PR fixes the same bug but preserves the warmstart being applied at iteration 0 by checking if the proximal term was enabled before reporting the iteration 0 "bound". We also clean up some redundant checking for the `best_bound_obj_val`.