### PR TITLE
Bounding the scenario dependent denominator in GradRho with a relative bounding factor

### DIFF
--- a/mpisppy/extensions/grad_rho.py
+++ b/mpisppy/extensions/grad_rho.py
@@ -35,12 +35,8 @@ class GradRho(mpisppy.extensions.dyn_rho_base.Dyn_Rho_extension_base):
         self.opt = opt
         self.alpha = cfg.grad_order_stat
         assert (self.alpha >= 0 and self.alpha <= 1), f"For grad_order_stat 0 is the min, 0.5 the average, 1 the max; {self.alpha=} is invalid."
-        self.multiplier = 1.0
-
-        if (
-            cfg.grad_rho_multiplier
-        ):
-            self.multiplier = cfg.grad_rho_multiplier
+        self.multiplier = cfg.grad_rho_multiplier
+        self.denom_bound = 1/cfg.grad_rho_relative_bound
 
         self.eval_at_xhat = cfg.eval_at_xhat
         self.indep_denom = cfg.indep_denom
@@ -66,9 +62,9 @@ class GradRho(mpisppy.extensions.dyn_rho_base.Dyn_Rho_extension_base):
         denom_max = max(scen_dep_denom.values())
 
         for ndn_i, v in s._mpisppy_data.nonant_indices.items():
-            if scen_dep_denom[ndn_i] <= self.opt.E1_tolerance:
-                scen_dep_denom[ndn_i] = max(denom_max, self.opt.E1_tolerance)
-        
+            if (scen_dep_denom[ndn_i]) <= self.denom_bound * v._value:
+                scen_dep_denom[ndn_i] = max(denom_max, self.denom_bound * v._value)
+
         return scen_dep_denom
 
     def _scen_indep_denom(self):

--- a/mpisppy/extensions/grad_rho.py
+++ b/mpisppy/extensions/grad_rho.py
@@ -63,6 +63,7 @@ class GradRho(mpisppy.extensions.dyn_rho_base.Dyn_Rho_extension_base):
 
         for ndn_i, v in s._mpisppy_data.nonant_indices.items():
             if (scen_dep_denom[ndn_i]) <= self.denom_bound * v._value:
+                # denom_max is over all nonants, so if not >0 we will stop
                 scen_dep_denom[ndn_i] = max(denom_max, self.denom_bound * v._value)
 
         return scen_dep_denom

--- a/mpisppy/utils/config.py
+++ b/mpisppy/utils/config.py
@@ -966,7 +966,6 @@ class Config(pyofig.ConfigDict):
                            description="evaluate the gradient at xhat whenever available (default False)",
                            domain=bool,
                            default=False)
-
         self.add_to_config("indep_denom",
                            description="evaluate rho using scenario independent denominator (default False)",
                            domain=bool,
@@ -995,7 +994,7 @@ class Config(pyofig.ConfigDict):
         self.add_to_config("grad_rho_relative_bound",
                            description="factor that bounds rho/cost",
                            domain=float,
-                           default=1e3)
+                           default=1e2)
 
     def dynamic_rho_args(self): # AKA adaptive
 


### PR DESCRIPTION
This PR changes the way scenario dependent denominator in GradRho is bounded:

- Earlier it was bounded using `opt.E1_tolerance`, which does not take into account magnitude scale of the non-anticipative variable.
- We now change it to bound with a relative bounding factor using the already existing `grad_rho_relative_bound` and bound it in the form `denom_bound*v.value_`  , where `denom_bound = 1/grad_rho_relative_bound` and `v.value_` is the value of the non-anticipative variable.
- This approach allows to capture the scale of magnitude with a relative bounding value with respect to each non-anticipative variable.