### PR TITLE
Fix Subgradient lower bound reporting

### DIFF
--- a/mpisppy/opt/subgradient.py
+++ b/mpisppy/opt/subgradient.py
@@ -9,6 +9,7 @@
 
 import mpisppy.opt.ph
 import mpisppy.MPI as _mpi
+import mpisppy.spopt
 
 _global_rank = _mpi.COMM_WORLD.Get_rank()
 
@@ -109,4 +110,7 @@ class Subgradient(mpisppy.opt.ph.PH):
         if self._can_update_best_bound():
             self.best_bound_obj_val = self.Ebound(verbose)
 
+    def _can_update_best_bound(self):
+        # TODO: is our class hierarchy wrong?
+        return mpisppy.spopt.SPOpt._can_update_best_bound(self)
 


### PR DESCRIPTION
#556 broke Subgradient bound reporting because Subgradient inherits from PH. Subgradient does not need to check if `prox_on` or not, because the prox is disabled.

The real fix would be to make PH inherit from Subgradient, which would be a cleaner algorithmic and class hierarchy. However, this would be a significant re-factor of the code.