### PR TITLE
Fixes two minor issues in cfg_vanilla (fixes issue #580)

### DIFF
--- a/mpisppy/utils/cfg_vanilla.py
+++ b/mpisppy/utils/cfg_vanilla.py
@@ -20,7 +20,7 @@ import mpisppy.utils.sputils as sputils
 def _hasit(cfg, argname):
     # aside: Config objects act like a dict or an object TBD: so why the and?
     return cfg.get(argname) is not None and cfg[argname] is not None and \
-        cfg[argname] != False
+        cfg[argname]
 
 def shared_options(cfg):
     shoptions = {


### PR DESCRIPTION
Fixes two issues in cfg_vanilla (#580):
  - making the `_hasit()` function return false if an option is present in the config dict but set to 'False'
  - making iter0 and iterk solver options point to different dicts
