### PR TITLE
Support numpy 2.x

### DIFF
--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -300,7 +300,7 @@ jobs:
           auto-activate-base: false
       - name: Install dependencies
         run: |
-          conda install mpi4py "numpy<2" setuptools
+          conda install mpi4py "numpy" setuptools
           pip install pyomo pandas xpress cplex scipy sympy dill PyYAML Pympler networkx pandas packaging
 
       - name: setup the program
@@ -352,7 +352,7 @@ jobs:
           auto-activate-base: false
       - name: Install dependencies
         run: |
-          conda install mpi4py "numpy<2" setuptools
+          conda install mpi4py "numpy" setuptools
           pip install pyomo pandas xpress cplex scipy sympy dill packaging
 
       - name: setup the program
@@ -420,7 +420,7 @@ jobs:
         run: |
           # Core runtime + MPI stack (must match mpi4py)
           conda install -y conda-forge::libstdcxx-ng
-          conda install -y -c conda-forge openmpi mpi4py "numpy<2" setuptools cmake
+          conda install -y -c conda-forge openmpi mpi4py "numpy" setuptools cmake
 
           # Python deps needed by the tests
           pip install pyomo pandas xpress cplex scipy sympy dill packaging
@@ -448,7 +448,7 @@ jobs:
           auto-activate-base: false
       - name: Install dependencies
         run: |
-          conda install mpi4py "numpy<2" setuptools
+          conda install mpi4py "numpy" setuptools
           pip install pyomo addheader pyyaml pytest
 
       - name: setup the program
@@ -507,7 +507,7 @@ jobs:
           auto-activate-base: false
       - name: Install dependencies
         run: |
-          conda install mpi4py "numpy<2" setuptools
+          conda install mpi4py "numpy" setuptools
           pip install pyomo pandas xpress cplex scipy packaging
 
       - name: setup the program

--- a/mpisppy/utils/listener_util/listener_util.py
+++ b/mpisppy/utils/listener_util/listener_util.py
@@ -323,7 +323,7 @@ class Synchronizer(object):
 
             logging.debug('  releasing lock on Rank %d' % rank)
             synchronizer.data_lock.release()
-            logging.debug('  sleep for %f on Rank %d' % (sleep_touse, rank))
+            logging.debug('  sleep for %f on Rank %d' % (sleep_touse[0], rank))
             try:
                 time.sleep(sleep_touse[0])
             except:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ readme = "README.md"
 license = { file = "LICENSE.md" }
 requires-python = ">=3.9"
 dependencies = [
-    "numpy<2",
+    "numpy",
     "scipy",
     "pandas",
     "sortedcollections",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     python_requires='>=3.9',
     install_requires=[
         'sortedcollections',
-        'numpy<2',
+        'numpy',
         'scipy',
         'pyomo>=6.4',
     ],


### PR DESCRIPTION
Numpy is no longer providing wheels for the newest Python versions (3.13, 3.14). I thought I would remove the restriction on `numpy<2` and see if the tests work. There was one thing I found and fixed in `listener_util.py` when running `run_all.py`. 

The only issue I had was with `python test_xbar_w_reader_writer.py` which produces different results:

```
======================================================================
FAIL: test_wwriter (__main__.Test_xbar_w_reader_writer_farmer.test_wwriter)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/james/dev/mpi-sppy/mpisppy/tests/test_xbar_w_reader_writer.py", line 88, in test_wwriter
    self.assertAlmostEqual(float(rows[1][2]), 70.84705093609978, places=5)
    ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: 70.84783553970811 != 70.84705093609978 within 5 places (0.0007846036083378749 difference)

======================================================================
FAIL: test_xbarwriter (__main__.Test_xbar_w_reader_writer_farmer.test_xbarwriter)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/james/dev/mpi-sppy/mpisppy/tests/test_xbar_w_reader_writer.py", line 97, in test_xbarwriter
    self.assertAlmostEqual(float(rows[1][1]), 274.2239371483933, places=5)
    ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: 274.22500403650344 != 274.2239371483933 within 5 places (0.0010668881101310035 difference)

----------------------------------------------------------------------
```

However, there's probably different / more tests that I did not complete.