### PR TITLE
Remove duplications of the function `scenario_names_creator`

### DIFF
--- a/doc/src/helper_functions.rst
+++ b/doc/src/helper_functions.rst
@@ -17,17 +17,6 @@ are documented in `the admm wrapper documentation <admmWrapper.rst#sectiondatafo
         dict (str): the dictionary of key word arguments that is used in ``scenario_creator``
 
 
-.. py:function:: scenario_names_creator(num_scens, start=0)
-
-    Creates the name of the ``num_scens`` scenarios starting from ``start``
-
-    Args:
-        num_scens (int): number of scenarios
-        start (int): starting index for the names
-
-    Returns:
-        list (str): the list of names
-
 .. py:function:: inparser_adder(cfg)
     
     Adds arguments to the config object which are specific to the problem

--- a/examples/acopf3/ccopf2wood.py
+++ b/examples/acopf3/ccopf2wood.py
@@ -114,10 +114,7 @@ def main():
     scenario_creator_kwargs["acstream"] = acstream
 
     all_scenario_names = scenario_names_creator(
-        len(scenario_creator_kwargs["etree"].rootnode.ScenarioList),
-        prefix="Scenario",
-        separator="_",
-        start=1,
+        len(scenario_creator_kwargs["etree"].rootnode.ScenarioList), prefix="Scenario_", start=1,
     )
 
     all_nodenames = scenario_creator_kwargs["etree"].All_Nodenames()

--- a/examples/acopf3/ccopf2wood.py
+++ b/examples/acopf3/ccopf2wood.py
@@ -18,6 +18,7 @@ from mpisppy.cylinders.xhatspecific_bounder import XhatSpecificInnerBound
 from mpisppy.cylinders.hub import PHHub
 # Make it all go
 from mpisppy.spin_the_wheel import WheelSpinner
+from mpisppy.utils import scenario_names_creator
 from mpisppy.utils.xhat_eval import Xhat_Eval
 
 # the problem
@@ -112,9 +113,13 @@ def main():
                                     lines)
     scenario_creator_kwargs["acstream"] = acstream
 
-    all_scenario_names=["Scenario_"+str(i)\
-                        for i in range(1,len(scenario_creator_kwargs["etree"].\
-                                             rootnode.ScenarioList)+1)]
+    all_scenario_names = scenario_names_creator(
+        len(scenario_creator_kwargs["etree"].rootnode.ScenarioList),
+        prefix="Scenario",
+        separator="_",
+        start=1,
+    )
+
     all_nodenames = scenario_creator_kwargs["etree"].All_Nodenames()
 
     options = dict()

--- a/examples/acopf3/ccopf_multistage.py
+++ b/examples/acopf3/ccopf_multistage.py
@@ -370,10 +370,7 @@ if __name__ == "__main__":
                                  lines)
     scenario_creator_kwargs["acstream"] = acstream
     scenario_names=scenario_names_creator(
-        len(scenario_creator_kwargs["etree"].rootnode.ScenarioList),
-        prefix="Scenario",
-        separator="_",
-        start=1,
+        len(scenario_creator_kwargs["etree"].rootnode.ScenarioList), prefix="Scenario_", start=1,
     )
 
     # end options

--- a/examples/acopf3/ccopf_multistage.py
+++ b/examples/acopf3/ccopf_multistage.py
@@ -13,7 +13,7 @@ import egret.models.acopf as eac
 import egret.models.ac_relaxations as eac_relax
 from egret.parsers.matpower_parser import create_ModelData
 import mpisppy.scenario_tree as scenario_tree
-import mpisppy.utils.sputils as sputils
+from mpisppy.utils import sputils, scenario_names_creator
 
 import ACtree as ET
 
@@ -369,10 +369,13 @@ if __name__ == "__main__":
                                  repair_fct,
                                  lines)
     scenario_creator_kwargs["acstream"] = acstream
-    scenario_names=["Scenario_"+str(i)\
-                    for i in range(1,len(scenario_creator_kwargs["etree"].rootnode.ScenarioList)+1)]
+    scenario_names=scenario_names_creator(
+        len(scenario_creator_kwargs["etree"].rootnode.ScenarioList),
+        prefix="Scenario",
+        separator="_",
+        start=1,
+    )
 
-    
     # end options
     ef = sputils.create_EF(scenario_names,
                              pysp2_callback,

--- a/examples/acopf3/fourstage.py
+++ b/examples/acopf3/fourstage.py
@@ -18,6 +18,7 @@ from mpisppy.cylinders.xhatspecific_bounder import XhatSpecificInnerBound
 from mpisppy.cylinders.hub import PHHub
 # Make it all go
 from mpisppy.spin_the_wheel import WheelSpinner
+from mpisppy.utils import scenario_names_creator
 from mpisppy.utils.xhat_eval import Xhat_Eval
 
 # the problem
@@ -120,9 +121,12 @@ def main():
                                     lines)
     scenario_creator_kwargs["acstream"] = acstream
 
-    all_scenario_names=["Scenario_"+str(i)\
-                        for i in range(1,len(scenario_creator_kwargs["etree"].\
-                                             rootnode.ScenarioList)+1)]
+    all_scenario_names = scenario_names_creator(
+        len(scenario_creator_kwargs["etree"].rootnode.ScenarioList),
+        prefix="Scenario",
+        separator="_",
+        start=1,
+    )
     all_nodenames = scenario_creator_kwargs["etree"].All_Nodenames()
 
     options = dict()

--- a/examples/acopf3/fourstage.py
+++ b/examples/acopf3/fourstage.py
@@ -122,10 +122,7 @@ def main():
     scenario_creator_kwargs["acstream"] = acstream
 
     all_scenario_names = scenario_names_creator(
-        len(scenario_creator_kwargs["etree"].rootnode.ScenarioList),
-        prefix="Scenario",
-        separator="_",
-        start=1,
+        len(scenario_creator_kwargs["etree"].rootnode.ScenarioList), prefix="Scenario_", start=1,
     )
     all_nodenames = scenario_creator_kwargs["etree"].All_Nodenames()
 

--- a/examples/aircond/aircond_ama.py
+++ b/examples/aircond/aircond_ama.py
@@ -16,8 +16,7 @@ WARNING:
 """
 import numpy as np
 import pyomo.common.config as pyofig
-import mpisppy.utils.amalgamator as amalgamator
-import mpisppy.utils.config as config
+from  mpisppy.utils import amalgamator, config, scenario_names_creator
 import mpisppy.tests.examples.aircond as aircond
 
 def main():
@@ -37,11 +36,11 @@ def main():
         raise RuntimeError("Do not use num_scens here, we want to solve the problem for the whole sample scenario tree")
     
     num_scens = np.prod(cfg['branching_factors'])
-    scenario_names = aircond.scenario_names_creator(num_scens, 0)
+    scenario_names = scenario_names_creator(num_scens, prefix="scen")
     
-    ama =amalgamator.Amalgamator(cfg, 
-                                 scenario_names, 
-                                 aircond.scenario_creator, 
+    ama = amalgamator.Amalgamator(cfg,
+                                 scenario_names,
+                                 aircond.scenario_creator,
                                  aircond.kw_creator)
     ama.run()
     if ama.on_hub:

--- a/examples/aircond/aircond_cylinders.py
+++ b/examples/aircond/aircond_cylinders.py
@@ -8,19 +8,18 @@
 ###############################################################################
 # NOTE: as of March 2022, consider aircondB.py as an alternative to aircond.py
 # Use bundle_pickler.py to create bundle pickles
-# NOTE: As of 3 March 2022, you can't compare pickle bundle problems with non-pickled. See _demands_creator in aircondB.py for more discusion.
+# NOTE: As of 3 March 2022, you can't compare pickle bundle problems with non-pickled. See _demands_creator in aircondB.py for more discussion.
 
 import numpy as np
 import itertools
 from mpisppy import global_toc
 from mpisppy.spin_the_wheel import WheelSpinner
+from mpisppy.utils import amalgamator, cfg_vanilla as vanilla, config, pickle_bundle, scenario_names_creator
 from mpisppy.utils.sputils import first_stage_nonant_npy_serializer, option_string_to_dict
-from mpisppy.utils import config
-import mpisppy.utils.cfg_vanilla as vanilla
+
 import mpisppy.tests.examples.aircond as aircond
 import mpisppy.tests.examples.aircondB as aircondB  # pickle bundle version
-from mpisppy.utils import pickle_bundle
-from mpisppy.utils import amalgamator
+
 
 # construct a node-scenario dictionary a priori for xhatspecific_spoke,
 # according to naming convention for this problem
@@ -38,7 +37,7 @@ def make_node_scenario_dict_balanced(BFs,leaf_nodes=True,start=1):
     """
     nodenames = make_nodenames_balanced(BFs, leaf_nodes)
     num_scens = np.prod(BFs)
-    scenario_names = aircond.scenario_names_creator(num_scens, start)
+    scenario_names = scenario_names_creator(num_scens, prefix="scen", start=start)
     
     num_stages = len(BFs)+1
     node_scenario_dict ={"ROOT": scenario_names[0]}
@@ -209,10 +208,9 @@ def main():
         refmodule = aircondB
         primal_rho_setter = None
         global_toc("WARNING: not using rho setters with proper bundles")
-        
     else:
         ScenCount = np.prod(BFs)
-        all_scenario_names = [f"scen{i}" for i in range(ScenCount)] #Scens are 0-based
+        all_scenario_names = scenario_names_creator(ScenCount, prefix="scen") #Scens are 0-based
         refmodule = aircond
         primal_rho_setter = refmodule.primal_rho_setter
 

--- a/examples/aircond/aircond_seqsampling.py
+++ b/examples/aircond/aircond_seqsampling.py
@@ -13,7 +13,7 @@ import numpy as np
 import mpisppy.tests.examples.aircond as aircond
 import mpisppy.confidence_intervals.multi_seqsampling as multi_seqsampling
 import mpisppy.confidence_intervals.confidence_config as conf_config
-from mpisppy.utils import config
+from mpisppy.utils import config, scenario_names_creator
 
 
 def main(cfg):
@@ -27,9 +27,7 @@ def main(cfg):
     BFs = cfg.branching_factors
     num_scens = np.prod(BFs)
 
-    scenario_names = ['Scenario' + str(i) for i in range(num_scens)]
-    
-    xhat_gen_kwargs = {"scenario_names": scenario_names,
+    xhat_gen_kwargs = {"scenario_names": scenario_names_creator(num_scens, prefix="Scenario"),
                         "solver_name": cfg.solver_name,
                         "solver_options": None,
                         "branching_factors" : BFs,

--- a/examples/distr/distr.py
+++ b/examples/distr/distr.py
@@ -210,18 +210,6 @@ def consensus_vars_creator(num_scens, inter_region_dict, all_scenario_names):
     return consensus_vars
 
 
-def scenario_names_creator(num_scens):
-    """Creates the name of every scenario.
-
-    Args:
-        num_scens (int): number of scenarios
-
-    Returns:
-        list (str): the list of names
-    """
-    return [f"Region{i+1}" for i in range(num_scens)]
-
-
 def kw_creator(all_nodes_dict, cfg, inter_region_dict, data_params):
     """
     Args:

--- a/examples/distr/distr_admm_cylinders.py
+++ b/examples/distr/distr_admm_cylinders.py
@@ -12,9 +12,7 @@ import distr_data
 import distr
 
 from mpisppy.spin_the_wheel import WheelSpinner
-import mpisppy.utils.sputils as sputils
-from mpisppy.utils import config
-import mpisppy.utils.cfg_vanilla as vanilla
+from mpisppy.utils import cfg_vanilla as vanilla, config, scenario_names_creator, sputils
 from mpisppy import MPI
 import time
 
@@ -83,7 +81,7 @@ def main():
     ph_converger = None
 
     options = {}
-    all_scenario_names = distr.scenario_names_creator(num_scens=cfg.num_scens)
+    all_scenario_names = scenario_names_creator(cfg.num_scens, prefix="Region", start=1)
     scenario_creator = distr.scenario_creator
     scenario_creator_kwargs = distr.kw_creator(all_nodes_dict, cfg, inter_region_dict, data_params)  
     consensus_vars = distr.consensus_vars_creator(cfg.num_scens, inter_region_dict, all_scenario_names)

--- a/examples/distr/distr_ef.py
+++ b/examples/distr/distr_ef.py
@@ -15,8 +15,7 @@ import distr
 import distr_data
 import pyomo.environ as pyo
 
-import mpisppy.utils.sputils as sputils
-from mpisppy.utils import config
+from mpisppy.utils import config, scenario_names_creator, sputils
 from mpisppy import MPI
 global_rank = MPI.COMM_WORLD.Get_rank()
 
@@ -72,7 +71,7 @@ def main():
         data_params = {"max revenue": 1200}
 
     options = {}
-    all_scenario_names = distr.scenario_names_creator(num_scens=cfg.num_scens)
+    all_scenario_names = scenario_names_creator(cfg.num_scens, prefix="Region", start=1)
     scenario_creator = distr.scenario_creator
     scenario_creator_kwargs = distr.kw_creator(all_nodes_dict, cfg, inter_region_dict, data_params)  
     consensus_vars = distr.consensus_vars_creator(cfg.num_scens, inter_region_dict, all_scenario_names)

--- a/examples/farmer/CI/farmer.py
+++ b/examples/farmer/CI/farmer.py
@@ -213,15 +213,6 @@ def scenario_creator(
 
 # begin helper functions
 #=========
-def scenario_names_creator(num_scens,start=None):
-    # (only for Amalgamator): return the full list of num_scens scenario names
-    # if start!=None, the list starts with the 'start' labeled scenario
-    if (start is None) :
-        start=0
-    return [f"scen{i}" for i in range(start,start+num_scens)]
-        
-
-#=========
 def inparser_adder(cfg):
     # add options unique to farmer
     cfg.num_scens_required()

--- a/examples/farmer/CI/farmer_ef.py
+++ b/examples/farmer/CI/farmer_ef.py
@@ -13,9 +13,7 @@
 
 import sys
 import farmer
-import mpisppy.utils.sputils as sputils
-import mpisppy.utils.solver_spec as solver_spec
-from mpisppy.utils import config
+from mpisppy.utils import config, scenario_names_creator, sputils, solver_spec
 import pyomo.environ as pyo
 
 
@@ -32,13 +30,13 @@ def main_no_cfg():
     scen_count = int(sys.argv[2])
     use_integer = int(sys.argv[3])
     solver_name = sys.argv[4]
-    
+
     scenario_creator_kwargs = {
         "use_integer": use_integer,
         "crops_multiplier": crops_multiplier,
     }
 
-    scenario_names = ['Scenario' + str(i) for i in range(scen_count)]
+    scenario_names = scenario_names_creator(scen_count, prefix='Scenario')
 
     ef = sputils.create_EF(
         scenario_names,
@@ -66,7 +64,7 @@ def main_with_cfg():
     cfg.parse_command_line("farmer_ef")
 
     ef = sputils.create_EF(
-        farmer.scenario_names_creator(cfg.num_scens),
+        scenario_names_creator(cfg.num_scens, prefix="scen"),
         farmer.scenario_creator,
         scenario_creator_kwargs=farmer.kw_creator(cfg),
     )

--- a/examples/farmer/CI/farmer_rho_demo.py
+++ b/examples/farmer/CI/farmer_rho_demo.py
@@ -19,8 +19,7 @@ import farmer
 from mpisppy.spin_the_wheel import WheelSpinner
 import mpisppy.utils.sputils as sputils
 
-from mpisppy.utils import config
-import mpisppy.utils.cfg_vanilla as vanilla
+from mpisppy.utils import cfg_vanilla as vanilla, config, scenario_names_creator
 
 from mpisppy.extensions.extension import MultiExtension
 
@@ -84,7 +83,7 @@ def main():
         if not cfg.use_norm_rho_updater:
             raise RuntimeError("--use-norm-rho-converger requires --use-norm-rho-updater")
         elif cfg.grad_rho:
-            raise RuntimeError("You cannot have--use-norm-rho-converger and --grad-rho-setter")            
+            raise RuntimeError("You cannot have--use-norm-rho-converger and --grad-rho-setter")
         else:
             ph_converger = NormRhoConverger
     else:
@@ -92,7 +91,7 @@ def main():
     
     scenario_creator = farmer.scenario_creator
     scenario_denouement = farmer.scenario_denouement
-    all_scenario_names = farmer.scenario_names_creator(cfg.num_scens)
+    all_scenario_names = scenario_names_creator(cfg.num_scens, prefix='scen')
     scenario_creator_kwargs = {
         'use_integer': False,
         "crops_multiplier": crops_multiplier,

--- a/examples/farmer/CI/farmer_seqsampling.py
+++ b/examples/farmer/CI/farmer_seqsampling.py
@@ -16,9 +16,7 @@
 
 import numpy as np
 import farmer
-from mpisppy.utils import config
-import mpisppy.utils.sputils as sputils
-import mpisppy.utils.amalgamator as amalgamator
+from mpisppy.utils import amalgamator, config, scenario_names_creator, sputils
 import mpisppy.confidence_intervals.seqsampling as seqsampling
 import mpisppy.confidence_intervals.confidence_config as confidence_config
 
@@ -94,7 +92,7 @@ def main(cfg):
     solver_name = cfg.EF_solver_name
     crops_multiplier = cfg.crops_multiplier
     
-    scenario_names = ['Scenario' + str(i) for i in range(scen_count)]
+    scenario_names = scenario_names_creator(scen_count, prefix='Scenario')
     
     xhat_gen_kwargs = {"scenario_names": scenario_names,
                        "solver_name": solver_name,

--- a/examples/farmer/agnostic/agnostic_ampl_cylinders.py
+++ b/examples/farmer/agnostic/agnostic_ampl_cylinders.py
@@ -9,11 +9,10 @@
 # Started by dlw Aug 2023
 
 import farmer_ampl_agnostic
+from mpisppy.agnostic import agnostic
+from mpisppy.utils import cfg_vanilla as vanilla, config, scenario_names_creator, sputils
 from mpisppy.spin_the_wheel import WheelSpinner
-import mpisppy.utils.cfg_vanilla as vanilla
-import mpisppy.utils.config as config
-import mpisppy.agnostic.agnostic as agnostic
-import mpisppy.utils.sputils as sputils
+
 
 def _farmer_parse_args():
     # create a config object and parse JUST FOR TESTING
@@ -23,8 +22,8 @@ def _farmer_parse_args():
 
     cfg.popular_args()
     cfg.two_sided_args()
-    cfg.ph_args()    
-    cfg.aph_args()    
+    cfg.ph_args()
+    cfg.aph_args()
     cfg.xhatlooper_args()
     cfg.fwph_args()
     cfg.lagrangian_args()
@@ -43,7 +42,7 @@ if __name__ == "__main__":
 
     scenario_creator = Ag.scenario_creator
     scenario_denouement = farmer_ampl_agnostic.scenario_denouement   # should we go though Ag?
-    all_scenario_names = ['scen{}'.format(sn) for sn in range(cfg.num_scens)]
+    all_scenario_names = scenario_names_creator(cfg.num_scens, prefix="scen")
 
     # Things needed for vanilla cylinders
     beans = (cfg, scenario_creator, scenario_denouement, all_scenario_names)

--- a/examples/farmer/agnostic/agnostic_gurobipy_cylinders.py
+++ b/examples/farmer/agnostic/agnostic_gurobipy_cylinders.py
@@ -10,10 +10,8 @@
 
 import farmer_gurobipy_agnostic
 from mpisppy.spin_the_wheel import WheelSpinner
-import mpisppy.utils.cfg_vanilla as vanilla
-import mpisppy.utils.config as config
-import mpisppy.agnostic.agnostic as agnostic
-import mpisppy.utils.sputils as sputils
+from mpisppy.agnostic import agnostic
+from mpisppy.utils import cfg_vanilla as vanilla, config, scenario_names_creator, sputils
 
 def _farmer_parse_args():
     # create a config object and parse JUST FOR TESTING
@@ -43,7 +41,7 @@ if __name__ == "__main__":
 
     scenario_creator = Ag.scenario_creator
     scenario_denouement = farmer_gurobipy_agnostic.scenario_denouement   # should we go though Ag?
-    all_scenario_names = ['scen{}'.format(sn) for sn in range(cfg.num_scens)]
+    all_scenario_names = scenario_names_creator(cfg.num_scens, prefix="scen")
 
     # Things needed for vanilla cylinders
     beans = (cfg, scenario_creator, scenario_denouement, all_scenario_names)

--- a/examples/farmer/agnostic/agnostic_pyomo_cylinders.py
+++ b/examples/farmer/agnostic/agnostic_pyomo_cylinders.py
@@ -11,10 +11,9 @@
 
 import farmer_pyomo_agnostic
 from mpisppy.spin_the_wheel import WheelSpinner
-import mpisppy.utils.cfg_vanilla as vanilla
-import mpisppy.utils.config as config
-import mpisppy.agnostic.agnostic as agnostic
-import mpisppy.utils.sputils as sputils
+from mpisppy.agnostic import agnostic
+from mpisppy.utils import cfg_vanilla as vanilla, sputils, scenario_names_creator, config
+
 
 def _farmer_parse_args():
     # create a config object and parse JUST FOR TESTING
@@ -24,8 +23,8 @@ def _farmer_parse_args():
 
     cfg.popular_args()
     cfg.two_sided_args()
-    cfg.ph_args()    
-    cfg.aph_args()    
+    cfg.ph_args()
+    cfg.aph_args()
     cfg.xhatlooper_args()
     cfg.fwph_args()
     cfg.lagrangian_args()
@@ -44,7 +43,7 @@ if __name__ == "__main__":
 
     scenario_creator = Ag.scenario_creator
     scenario_denouement = farmer_pyomo_agnostic.scenario_denouement   # should we go though Ag?
-    all_scenario_names = ['scen{}'.format(sn) for sn in range(cfg.num_scens)]
+    all_scenario_names = scenario_names_creator(cfg.num_scens, prefix="scen")
 
     # Things needed for vanilla cylinders
     beans = (cfg, scenario_creator, scenario_denouement, all_scenario_names)

--- a/examples/farmer/agnostic/agnostic_pyomo_ph.py
+++ b/examples/farmer/agnostic/agnostic_pyomo_ph.py
@@ -10,9 +10,8 @@
 # Started by dlw Aug 2023
 
 import farmer_pyomo_agnostic
-import mpisppy.utils.cfg_vanilla as vanilla
-import mpisppy.utils.config as config
-import mpisppy.agnostic.agnostic as agnostic
+from mpisppy.agnostic import agnostic
+from mpisppy.utils import cfg_vanilla as vanilla, config, scenario_names_creator
 
 def _farmer_parse_args():
     # create a config object and parse JUST FOR TESTING
@@ -22,8 +21,8 @@ def _farmer_parse_args():
 
     cfg.popular_args()
     cfg.two_sided_args()
-    cfg.ph_args()    
-    cfg.aph_args()    
+    cfg.ph_args()
+    cfg.aph_args()
     cfg.xhatlooper_args()
     cfg.fwph_args()
     cfg.lagrangian_args()
@@ -42,7 +41,7 @@ if __name__ == "__main__":
 
     scenario_creator = Ag.scenario_creator
     scenario_denouement = farmer_pyomo_agnostic.scenario_denouement   # should we go though Ag?
-    all_scenario_names = ['scen{}'.format(sn) for sn in range(cfg.num_scens)]
+    all_scenario_names = scenario_names_creator(cfg.num_scens, prefix="scen")
 
     # Things needed for vanilla cylinders
     beans = (cfg, scenario_creator, scenario_denouement, all_scenario_names)

--- a/examples/farmer/agnostic/farmer.py
+++ b/examples/farmer/agnostic/farmer.py
@@ -234,16 +234,6 @@ def pysp_instance_creation_callback(
 # begin functions not needed by farmer_cylinders
 # (but needed by special codes such as confidence intervals)
 #=========
-def scenario_names_creator(num_scens,start=None):
-    # (only for Amalgamator): return the full list of num_scens scenario names
-    # if start!=None, the list starts with the 'start' labeled scenario
-    if (start is None) :
-        start=0
-    return [f"scen{i}" for i in range(start,start+num_scens)]
-        
-
-
-#=========
 def inparser_adder(cfg):
     # add options unique to farmer
     cfg.num_scens_required()

--- a/examples/farmer/agnostic/farmer_ampl_agnostic.py
+++ b/examples/farmer/agnostic/farmer_ampl_agnostic.py
@@ -83,12 +83,6 @@ def scenario_creator(
     }
 
     return gd
-    
-#=========
-def scenario_names_creator(num_scens,start=None):
-    if (start is None) :
-        start=0
-    return [f"scen{i}" for i in range(start,start+num_scens)]
 
 
 #=========

--- a/examples/farmer/agnostic/farmer_gurobipy_agnostic.py
+++ b/examples/farmer/agnostic/farmer_gurobipy_agnostic.py
@@ -124,12 +124,6 @@ def scenario_creator(scenario_name, use_integer=False, sense=GRB.MINIMIZE, crops
     return gd
 
 #==========
-def scenario_names_creator(num_scens,start=None):
-    if (start is None):
-        start=0
-    return [f"scen{i}" for i in range(start,start+num_scens)]
-
-#==========
 def inparser_adder(cfg):
     # add options unique to farmer
     cfg.num_scens_required()

--- a/examples/farmer/agnostic/farmer_pyomo_agnostic.py
+++ b/examples/farmer/agnostic/farmer_pyomo_agnostic.py
@@ -61,10 +61,6 @@ def scenario_creator(
         "BFs": None
         }
     return gd
-    
-#=========
-def scenario_names_creator(num_scens,start=None):
-    return farmer.scenario_names_creator(num_scens,start)
 
 
 #=========

--- a/examples/farmer/archive/cs_farmer.py
+++ b/examples/farmer/archive/cs_farmer.py
@@ -27,6 +27,7 @@ from mpisppy.cylinders.hub import PHHub
 from mpisppy.cylinders.cross_scen_spoke import CrossScenarioCutSpoke
 from mpisppy.opt.lshaped import LShapedMethod
 
+from mpisppy.utils import scenario_names_creator
 from mpisppy.utils.xhat_eval import Xhat_Eval
 
 
@@ -68,7 +69,7 @@ if __name__ == "__main__":
     scenario_creator = farmer.scenario_creator
     scenario_denouement = farmer.scenario_denouement
 
-    all_scenario_names = ['scen{}'.format(sn) for sn in range(scen_count)]
+    all_scenario_names = scenario_names_creator(scen_count, prefix='scen')
     rho_setter = farmer._rho_setter if hasattr(farmer, '_rho_setter') else None
     scenario_creator_kwargs = {
         'use_integer': True,

--- a/examples/farmer/archive/farmer.py
+++ b/examples/farmer/archive/farmer.py
@@ -234,16 +234,6 @@ def pysp_instance_creation_callback(
 # begin functions not needed by farmer_cylinders
 # (but needed by special codes such as confidence intervals)
 #=========
-def scenario_names_creator(num_scens,start=None):
-    # (only for Amalgamator): return the full list of num_scens scenario names
-    # if start!=None, the list starts with the 'start' labeled scenario
-    if (start is None) :
-        start=0
-    return [f"scen{i}" for i in range(start,start+num_scens)]
-        
-
-
-#=========
 def inparser_adder(cfg):
     # add options unique to farmer
     cfg.num_scens_required()

--- a/examples/farmer/archive/farmer_cylinders.py
+++ b/examples/farmer/archive/farmer_cylinders.py
@@ -16,15 +16,12 @@ import farmer
 
 # Make it all go
 from mpisppy.spin_the_wheel import WheelSpinner
-import mpisppy.utils.sputils as sputils
 
-from mpisppy.utils import config
-import mpisppy.utils.cfg_vanilla as vanilla
+from mpisppy.utils import cfg_vanilla as vanilla, config, scenario_names_creator, sputils
 
 from mpisppy.extensions.norm_rho_updater import NormRhoUpdater
 from mpisppy.convergers.norm_rho_converger import NormRhoConverger
 from mpisppy.convergers.primal_dual_converger import PrimalDualConverger
-from mpisppy.utils.cfg_vanilla import extension_adder
 
 import pyomo.environ as pyo
 
@@ -91,7 +88,7 @@ def main():
 
     scenario_creator = farmer.scenario_creator
     scenario_denouement = farmer.scenario_denouement
-    all_scenario_names = ['scen{}'.format(sn) for sn in range(num_scen)]
+    all_scenario_names = scenario_names_creator(num_scen, prefix='scen')
     scenario_creator_kwargs = {
         'use_integer': False,
         "crops_multiplier": crops_multiplier,
@@ -126,7 +123,7 @@ def main():
 
     ## hack in adaptive rho
     if cfg.use_norm_rho_updater:
-        extension_adder(hub_dict, NormRhoUpdater)
+        vanilla.extension_adder(hub_dict, NormRhoUpdater)
         hub_dict['opt_kwargs']['options']['norm_rho_options'] = {'verbose': True}
 
 

--- a/examples/farmer/archive/farmer_ph.py
+++ b/examples/farmer/archive/farmer_ph.py
@@ -11,6 +11,7 @@
 
 from mpisppy.opt.ph import PH
 from mpisppy.convergers.primal_dual_converger import PrimalDualConverger
+from mpisppy.utils import scenario_names_creator
 import farmer
 from mpisppy.extensions.xhatclosest import XhatClosest
 import sys
@@ -59,7 +60,7 @@ def main():
     }
     scenario_creator = farmer.scenario_creator
     scenario_denouement = farmer.scenario_denouement
-    all_scenario_names = ['scen{}'.format(sn) for sn in range(num_scen)]
+    all_scenario_names = scenario_names_creator(num_scen, prefix='scen')
     scenario_creator_kwargs = {
         'use_integer': use_int,
         "crops_multiplier": crops_multiplier,

--- a/examples/farmer/farmer.py
+++ b/examples/farmer/farmer.py
@@ -213,15 +213,6 @@ def scenario_creator(
 
 # begin helper functions
 #=========
-def scenario_names_creator(num_scens,start=None):
-    # (only for Amalgamator): return the full list of num_scens scenario names
-    # if start!=None, the list starts with the 'start' labeled scenario
-    if (start is None) :
-        start=0
-    return [f"scen{i}" for i in range(start,start+num_scens)]
-        
-
-#=========
 def inparser_adder(cfg):
     # add options unique to farmer
     cfg.num_scens_required()

--- a/examples/farmer/farmer_lshapedhub.py
+++ b/examples/farmer/farmer_lshapedhub.py
@@ -13,7 +13,7 @@ import farmer
 
 # Make it all go
 from mpisppy.spin_the_wheel import WheelSpinner
-from mpisppy.utils import config
+from mpisppy.utils import config, scenario_names_creator
 import mpisppy.utils.cfg_vanilla as vanilla
 from mpisppy.cylinders.hub import LShapedHub
 from mpisppy.opt.lshaped import LShapedMethod
@@ -52,7 +52,7 @@ def main():
 
     scenario_creator = farmer.scenario_creator
     scenario_denouement = farmer.scenario_denouement
-    all_scenario_names = [f"scen{sn}" for sn in range(num_scen)]
+    all_scenario_names = scenario_names_creator(num_scen, prefix="scen")
     scenario_creator_kwargs = {
         "use_integer": False,
         "crops_multiplier": crops_mult,

--- a/examples/farmer/schur/schur_complement.py
+++ b/examples/farmer/schur/schur_complement.py
@@ -10,6 +10,7 @@ import farmer
 from mpisppy.opt import ef, sc
 import logging
 from mpisppy import MPI
+from mpisppy.utils import scenario_names_creator
 import sys
 import pyomo.environ as pyo
 
@@ -26,7 +27,7 @@ mpirun -np N python -m mpi4py schur_complement.py N
 
 
 def solve_with_extensive_form(scen_count):
-    scenario_names = ['Scenario' + str(i) for i in range(scen_count)]
+    scenario_names = scenario_names_creator(scen_count, prefix="Scenario")
     options = dict()
     options['solver'] = 'cplex_direct'
     scenario_kwargs = dict()
@@ -44,7 +45,7 @@ def solve_with_extensive_form(scen_count):
 
 
 def solve_with_sc(scen_count, linear_solver=None):
-    scenario_names = ['Scenario' + str(i) for i in range(scen_count)]
+    scenario_names = scenario_names_creator(scen_count, prefix="Scenario")
     options = dict()
     if linear_solver is not None:
         options['linalg'] = dict()

--- a/examples/hydro/hydro.py
+++ b/examples/hydro/hydro.py
@@ -31,7 +31,7 @@ import mpisppy.opt.aph
 import mpisppy.scenario_tree as scenario_tree
 import pyomo.environ as pyo
 from mpisppy.extensions.xhatspecific import XhatSpecific
-import mpisppy.utils.sputils as sputils
+from mpisppy.utils import scenario_names_creator, sputils
 
 ##
 ## Setting up a Model
@@ -296,9 +296,7 @@ if __name__ == "__main__":
     # branching factor (3 stages is hard-wired)
     BFs = options["branching_factors"]
     ScenCount = BFs[0] * BFs[1]
-    all_scenario_names = list()
-    for sn in range(ScenCount):
-        all_scenario_names.append("Scen"+str(sn+1))
+    all_scenario_names = scenario_names_creator(ScenCount, prefix="Scen", start=1)
     # end hardwire
 
     # This is multi-stage, so we need to supply node names

--- a/examples/hydro/hydro.py
+++ b/examples/hydro/hydro.py
@@ -261,13 +261,6 @@ def inparser_adder(cfg):
 
 
 #=========
-def scenario_names_creator(num_scens,start=0):
-    # return the full list of num_scens scenario names
-    # (We hope this doesn't get used much for a multistage problem)
-    return [f"Scen{i+1}" for i in range(start, start+num_scens)]
-
-
-#=========
 def kw_creator(cfg):
     # (for Amalgamator): linked to the scenario_creator and inparser_adder
     kwargs = {"branching_factors": cfg.branching_factors,

--- a/examples/hydro/hydro_cylinders.py
+++ b/examples/hydro/hydro_cylinders.py
@@ -54,7 +54,7 @@ def main():
 
     ScenCount = BFs[0] * BFs[1]
     scenario_creator_kwargs = {"branching_factors": BFs}
-    all_scenario_names = scenario_names_creator(ScenCount, prefix="Scen", start=1)
+    all_scenario_names = scenario_names_creator(ScenCount, prefix="scen", start=1)
     scenario_creator = hydro.scenario_creator
     scenario_denouement = hydro.scenario_denouement
     rho_setter = None

--- a/examples/hydro/hydro_cylinders.py
+++ b/examples/hydro/hydro_cylinders.py
@@ -11,11 +11,8 @@
 
 import hydro
 
-import mpisppy.utils.sputils as sputils
-
 from mpisppy.spin_the_wheel import WheelSpinner
-from mpisppy.utils import config
-import mpisppy.utils.cfg_vanilla as vanilla
+from mpisppy.utils import cfg_vanilla as vanilla, config, scenario_names_creator, sputils
 
 
 write_solution = True
@@ -57,7 +54,7 @@ def main():
 
     ScenCount = BFs[0] * BFs[1]
     scenario_creator_kwargs = {"branching_factors": BFs}
-    all_scenario_names = [f"Scen{i+1}" for i in range(ScenCount)]
+    all_scenario_names = scenario_names_creator(ScenCount, prefix="Scen", start=1)
     scenario_creator = hydro.scenario_creator
     scenario_denouement = hydro.scenario_denouement
     rho_setter = None

--- a/examples/hydro/hydro_ef.py
+++ b/examples/hydro/hydro_ef.py
@@ -10,12 +10,11 @@ import sys
 import hydro
 import pyomo.environ as pyo
 from mpisppy.opt.ef import ExtensiveForm
-import mpisppy.utils.sputils as sputils
+from mpisppy.utils import scenario_names_creator, sputils
 
 options = {"solver": sys.argv[1]}
 num_scenarios = 9
 BFs = [3, 3]
-all_scenario_names = [f"Scen{i+1}" for i in range(num_scenarios)]
 
 # This is multi-stage, so we need to supply node names
 all_nodenames = sputils.create_nodenames_from_branching_factors(BFs)
@@ -23,7 +22,7 @@ all_nodenames = sputils.create_nodenames_from_branching_factors(BFs)
 options["branching_factors"] = BFs
 ef = ExtensiveForm(
     options,
-    all_scenario_names,
+    scenario_names_creator(num_scenarios, prefix="Scen", start=1),
     hydro.scenario_creator,
     scenario_creator_kwargs={"branching_factors": BFs},
     all_nodenames=all_nodenames

--- a/examples/hydro/hydro_ef.py
+++ b/examples/hydro/hydro_ef.py
@@ -22,7 +22,7 @@ all_nodenames = sputils.create_nodenames_from_branching_factors(BFs)
 options["branching_factors"] = BFs
 ef = ExtensiveForm(
     options,
-    scenario_names_creator(num_scenarios, prefix="Scen", start=1),
+    scenario_names_creator(num_scenarios, prefix="scen", start=1),
     hydro.scenario_creator,
     scenario_creator_kwargs={"branching_factors": BFs},
     all_nodenames=all_nodenames

--- a/examples/netdes/drivertest.py
+++ b/examples/netdes/drivertest.py
@@ -20,6 +20,7 @@ from mpisppy.cylinders.xhatlooper_bounder import XhatLooperInnerBound
 from mpisppy.cylinders.hub import PHHub
 # Make it all go
 from mpisppy.spin_the_wheel import WheelSpinner
+from mpisppy.utils import scenario_names_creator
 from mpisppy.utils.xhat_eval import Xhat_Eval
 
 
@@ -33,7 +34,7 @@ if __name__=="__main__":
     # Use netdes as an example
     inst = "network-10-20-L-01"
     num_scen = int(inst.split("-")[-3])
-    scenario_names = [f"Scen{i}" for i in range(num_scen)]
+    scenario_names = scenario_names_creator(num_scen, prefix="Scen")
     path = f"{netdes.__file__[:-10]}/data/{inst}.dat"
     scenario_creator = netdes.scenario_creator
     scenario_creator_kwargs = {"path": path}

--- a/examples/netdes/netdes.py
+++ b/examples/netdes/netdes.py
@@ -94,15 +94,6 @@ def _get_scenario_ix(sname):
     return int(sname[i:])
 
 ########## helper functions ########
-
-#=========
-def scenario_names_creator(num_scens,start=None):
-    # if start!=None, the list starts with the 'start' labeled scenario
-    if (start is None) :
-        start=0
-    return [f"Scenario{i}" for i in range(start,start+num_scens)]
-
-
 #=========
 def inparser_adder(cfg):
     # add options unique to sizes
@@ -111,11 +102,11 @@ def inparser_adder(cfg):
     cfg.add_to_config("instance_name",
                         description="netdes instance name (e.g., network-10-20-L-01)",
                         domain=str,
-                        default=None)                
+                        default=None)
     cfg.add_to_config("netdes_data_path",
                         description="path to detdes data (e.g., ./data)",
                         domain=str,
-                        default=None)                
+                        default=None)
 
 
 #=========

--- a/examples/netdes/netdes_cylinders.py
+++ b/examples/netdes/netdes_cylinders.py
@@ -9,8 +9,7 @@
 import netdes
 
 from mpisppy.spin_the_wheel import WheelSpinner
-from mpisppy.utils import config
-import mpisppy.utils.cfg_vanilla as vanilla
+from mpisppy.utils import cfg_vanilla as vanilla, config, scenario_names_creator
 from mpisppy.extensions.cross_scen_extension import CrossScenarioExtension
 
 write_solution = True
@@ -34,7 +33,7 @@ def _parse_args():
     cfg.add_to_config("instance_name",
                         description="netdes instance name (e.g., network-10-20-L-01)",
                         domain=str,
-                        default=None)                
+                        default=None)
     cfg.parse_command_line("netdes_cylinders")
     return cfg
     
@@ -61,8 +60,8 @@ def main():
 
     path = f"{netdes.__file__[:-10]}/data/{inst}.dat"
     scenario_creator = netdes.scenario_creator
-    scenario_denouement = netdes.scenario_denouement    
-    all_scenario_names = [f"Scen{i}" for i in range(num_scen)]
+    scenario_denouement = netdes.scenario_denouement
+    all_scenario_names = scenario_names_creator(num_scen, prefix="Scen")
     scenario_creator_kwargs = {"path": path}
 
     # Things needed for vanilla cylinders

--- a/examples/netdes/netdes_ef.py
+++ b/examples/netdes/netdes_ef.py
@@ -9,6 +9,7 @@
 ''' Solve the EF of the network problems
 '''
 from mpisppy.opt.ef import ExtensiveForm
+from mpisppy.utils import scenario_names_creator
 from netdes import scenario_creator
 import pyomo.environ as pyo
 import sys
@@ -23,7 +24,7 @@ def main():
         print("Invalid input.")
         quit()
     num_scen = int(inst.split("-")[-3])
-    scenario_names = [f"Scen{i}" for i in range(num_scen)]
+    scenario_names = scenario_names_creator(num_scen, prefix="Scen")
     path = f"./data/{inst}.dat"
     options = {"solver": "gurobi"}
     ef = ExtensiveForm(

--- a/examples/netdes/netdes_ph.py
+++ b/examples/netdes/netdes_ph.py
@@ -12,6 +12,7 @@ from netdes import scenario_creator, scenario_denouement
 from mpisppy.opt.ph import PH
 from mpisppy.convergers.primal_dual_converger import PrimalDualConverger
 from mpisppy.extensions.xhatclosest import XhatClosest
+from mpisppy.utils import scenario_names_creator
 import os
 import sys
 
@@ -28,7 +29,7 @@ def main():
     # solver_name = 'gurobi'
     fname = "data" + os.sep + sys.argv[1] + ".dat"
     num_scen = int(fname.split('-')[2])
-    scenario_names = ['Scen' + str(i) for i in range(num_scen)]
+    scenario_names = scenario_names_creator(num_scen, prefix="Scen")
     scenario_creator_kwargs = {"path": fname}
 
     ''' Now solve with PH to see what happens (very little, I imagine) '''

--- a/examples/netdes/netdes_with_class.py
+++ b/examples/netdes/netdes_with_class.py
@@ -28,11 +28,11 @@ def inparser_adder(cfg):
     cfg.add_to_config("instance_name",
                         description="netdes instance name (e.g., network-10-20-L-01)",
                         domain=str,
-                        default=None)                
+                        default=None)
     cfg.add_to_config("netdes_data_path",
                         description="path to detdes data (e.g., ./data)",
                         domain=str,
-                        default=None)                
+                        default=None)
 
 
 def get_mpisppy_helper_object(cfg):
@@ -126,15 +126,6 @@ class NetDes:
 
 
     ########## helper functions ########
-
-    #=========
-    def scenario_names_creator(self, num_scens,start=None):
-        # if start!=None, the list starts with the 'start' labeled scenario
-        if (start is None) :
-            start=0
-        return [f"Scenario{i}" for i in range(start,start+num_scens)]
-
-
     #=========
     def kw_creator(self, cfg):
         # linked to the scenario_creator and inparser_adder

--- a/examples/sizes/sizes.py
+++ b/examples/sizes/sizes.py
@@ -36,16 +36,6 @@ def scenario_denouement(rank, scenario_name, scenario):
     pass
 
 ########## helper functions ########
-
-#=========
-def scenario_names_creator(num_scens,start=None):
-    # if start!=None, the list starts with the 'start' labeled scenario
-    # note that the scenarios for the sizes problem are one-based
-    if (start is None) :
-        start=1
-    return [f"Scenario{i}" for i in range(start, start+num_scens)]
-
-
 #=========
 def inparser_adder(cfg):
     # add options unique to sizes

--- a/examples/sizes/sizes_cylinders.py
+++ b/examples/sizes/sizes_cylinders.py
@@ -8,10 +8,10 @@
 ###############################################################################
 import sizes
 
-from mpisppy.utils import config
+from mpisppy.utils import cfg_vanilla as vanilla, config, scenario_names_creator
 from mpisppy.spin_the_wheel import WheelSpinner
 from mpisppy.extensions.fixer import Fixer
-import mpisppy.utils.cfg_vanilla as vanilla
+
 
 def _parse_args():
     cfg = config.Config()
@@ -52,7 +52,7 @@ def main():
     scenario_creator_kwargs = {"scenario_count": num_scen}
     scenario_creator = sizes.scenario_creator
     scenario_denouement = sizes.scenario_denouement
-    all_scenario_names = [f"Scenario{i+1}" for i in range(num_scen)]
+    all_scenario_names = scenario_names_creator(num_scen, prefix="Scenario", start=1)
     rho_setter = sizes._rho_setter
     
     if fixer:

--- a/examples/sizes/sizes_expression.py
+++ b/examples/sizes/sizes_expression.py
@@ -36,16 +36,6 @@ def scenario_denouement(rank, scenario_name, scenario):
     pass
 
 ########## helper functions ########
-
-#=========
-def scenario_names_creator(num_scens,start=None):
-    # if start!=None, the list starts with the 'start' labeled scenario
-    # note that the scenarios for the sizes problem are one-based
-    if (start is None) :
-        start=1
-    return [f"Scenario{i}" for i in range(start, start+num_scens)]
-
-
 #=========
 def inparser_adder(cfg):
     # add options unique to sizes

--- a/examples/sizes/special_cylinders.py
+++ b/examples/sizes/special_cylinders.py
@@ -11,8 +11,7 @@ import special_sizes as sizes
 
 from mpisppy.spin_the_wheel import WheelSpinner
 from mpisppy.extensions.fixer import Fixer
-from mpisppy.utils import config
-import mpisppy.utils.cfg_vanilla as vanilla
+from mpisppy.utils import cfg_vanilla as vanilla, config, scenario_names_creator
 
 def _parse_args():
     cfg = config.Config()
@@ -51,7 +50,7 @@ def main():
     scenario_creator_kwargs = {"scenario_count": num_scen}
     scenario_creator = sizes.scenario_creator
     scenario_denouement = sizes.scenario_denouement
-    all_scenario_names = [f"Scenario{i+1}" for i in range(num_scen)]
+    all_scenario_names = scenario_names_creator(num_scen, prefix="Scenario", start=1)
     rho_setter = sizes._rho_setter
     variable_probability = sizes._variable_probability
 

--- a/examples/sslp/sslp.py
+++ b/examples/sslp/sslp.py
@@ -61,16 +61,6 @@ def scenario_denouement(rank, scenario_name, scenario):
 
 
 ########## helper functions ########
-
-#=========
-def scenario_names_creator(num_scens,start=None):
-    # one-based scenarios
-    # if start!=None, the list starts with the 'start' labeled scenario
-    if (start is None) :
-        start=1
-    return [f"Scenario{i}" for i in range(start, start+num_scens)]
-
-
 #=========
 def inparser_adder(cfg):
     # add options unique to sizes

--- a/examples/sslp/sslp_cylinders.py
+++ b/examples/sslp/sslp_cylinders.py
@@ -11,8 +11,7 @@ import sslp
 from mpisppy.spin_the_wheel import WheelSpinner
 from mpisppy.extensions.fixer import Fixer
 from mpisppy.extensions.primal_dual_rho import PrimalDualRho
-from mpisppy.utils import config
-import mpisppy.utils.cfg_vanilla as vanilla
+from mpisppy.utils import cfg_vanilla as vanilla, config, scenario_names_creator
 
 def _parse_args():
     cfg = config.Config()
@@ -70,7 +69,7 @@ def main():
     scenario_creator_kwargs = {"data_dir": f"{sslp.__file__[:-8]}/data/{inst}/scenariodata", "surrogate":cfg.surrogate_nonant}
     scenario_creator = sslp.scenario_creator
     scenario_denouement = sslp.scenario_denouement    
-    all_scenario_names = [f"Scenario{i+1}" for i in range(num_scen)]
+    all_scenario_names = scenario_names_creator(num_scen, prefix="Scenario", start=1)
 
     if fixer:
         ph_ext = Fixer

--- a/examples/uc/cs_uc.py
+++ b/examples/uc/cs_uc.py
@@ -13,6 +13,7 @@ import mpisppy.MPI as mpi
 
 # Hub and spoke SPBase classes
 from mpisppy.opt.ph import PH
+from mpisppy.utils import scenario_names_creator
 from mpisppy.utils.xhat_eval import Xhat_Eval
 
 # Hub and spoke SPCommunicator classes
@@ -78,7 +79,7 @@ if __name__ == "__main__":
         _usage()
 
     assert (ScenCount in [3, 5, 10, 25, 50])
-    all_scenario_names = ['Scenario{}'.format(sn + 1) for sn in range(ScenCount)]
+    all_scenario_names = scenario_names_creator(ScenCount, prefix="Scenario", start=1)
     # sent to the scenario creator
     scenario_creator_kwargs = {
         "scenario_count": ScenCount,

--- a/examples/uc/gradient_uc_cylinders.py
+++ b/examples/uc/gradient_uc_cylinders.py
@@ -23,8 +23,7 @@ from mpisppy.extensions.fixer import Fixer
 from mpisppy.extensions.mipgapper import Gapper
 from mpisppy.extensions.xhatclosest import XhatClosest
 from mpisppy.extensions.grad_rho import GradRho
-from mpisppy.utils import config
-import mpisppy.utils.cfg_vanilla as vanilla
+from mpisppy.utils import cfg_vanilla as vanilla, config, scenario_names_creator
 from mpisppy.extensions.cross_scen_extension import CrossScenarioExtension
 
 def _parse_args():
@@ -94,7 +93,7 @@ def main():
     }
     scenario_creator = uc.scenario_creator
     scenario_denouement = uc.scenario_denouement
-    all_scenario_names = [f"Scenario{i+1}" for i in range(num_scen)]
+    all_scenario_names = scenario_names_creator(num_scen, prefix="Scenario", start=1)
     if cfg.use_cost_based_rho:
         rho_setter = uc._rho_setter
     else:

--- a/examples/uc/uc3wood.py
+++ b/examples/uc/uc3wood.py
@@ -27,6 +27,7 @@ from mpisppy.extensions.fixer import Fixer
 from mpisppy.extensions.mipgapper import Gapper
 # Make it all go
 from mpisppy.spin_the_wheel import WheelSpinner
+from mpisppy.utils import scenario_names_creator
 from mpisppy.utils.xhat_eval import Xhat_Eval
 from mpisppy.log import setup_logger
 
@@ -73,7 +74,7 @@ if __name__ == "__main__":
         _usage()
         
     assert(ScenCount in [3,5,10,25,50])
-    all_scenario_names = ['Scenario{}'.format(sn+1) for sn in range(ScenCount)]
+    all_scenario_names = scenario_names_creator(ScenCount, prefix="Scenario", start=1)
     # sent to the scenario creator
     scenario_creator_kwargs = {
         "scenario_count": ScenCount,

--- a/examples/uc/uc4wood.py
+++ b/examples/uc/uc4wood.py
@@ -30,6 +30,7 @@ from mpisppy.extensions.extension import MultiExtension
 from mpisppy.extensions.fixer import Fixer
 from mpisppy.extensions.mipgapper import Gapper
 # Make it all go
+from mpisppy.utils import scenario_names_creator
 from mpisppy.spin_the_wheel import WheelSpinner
 from mpisppy.log import setup_logger
 
@@ -76,7 +77,7 @@ if __name__ == "__main__":
         _usage()
         
     assert(ScenCount in [3,5,10,25,50])
-    all_scenario_names = ['Scenario{}'.format(sn+1) for sn in range(ScenCount)]
+    all_scenario_names = scenario_names_creator(ScenCount, prefix="Scenario", start=1)
     scenario_creator_kwargs = {
         "scenario_count": ScenCount,
         "path": str(ScenCount) + "scenarios_r1",

--- a/examples/uc/uc_cylinders.py
+++ b/examples/uc/uc_cylinders.py
@@ -22,8 +22,7 @@ from mpisppy.extensions.extension import MultiExtension
 from mpisppy.extensions.fixer import Fixer
 from mpisppy.extensions.mipgapper import Gapper
 from mpisppy.extensions.xhatclosest import XhatClosest
-from mpisppy.utils import config
-import mpisppy.utils.cfg_vanilla as vanilla
+from mpisppy.utils import cfg_vanilla as vanilla, config, scenario_names_creator
 from mpisppy.extensions.cross_scen_extension import CrossScenarioExtension
 
 def _parse_args():
@@ -90,7 +89,7 @@ def main():
     }
     scenario_creator = uc.scenario_creator
     scenario_denouement = uc.scenario_denouement
-    all_scenario_names = [f"Scenario{i+1}" for i in range(num_scen)]
+    all_scenario_names = scenario_names_creator(num_scen, prefix="Scenario", start=1)
     rho_setter = uc._rho_setter
 
     # Things needed for vanilla cylinders

--- a/examples/uc/uc_funcs.py
+++ b/examples/uc/uc_funcs.py
@@ -267,11 +267,6 @@ def scenario_tree_solution_writer( solution_dir, sname, scenario, bundling ):
     mds.write(file_name)
 
 #=========
-def scenario_names_creator(scnt,start=0):
-    # (only for Amalgamator): return the full list of names
-    return [F"Scenario{i+1}" for i in range(start,scnt+start)]
-
-#=========
 def inparser_adder(cfg):
     # (only for Amalgamator): add command options unique to uc
     cfg.num_scens_required()

--- a/examples/uc/uc_lshaped.py
+++ b/examples/uc/uc_lshaped.py
@@ -12,8 +12,7 @@ import uc_funcs as uc
 
 # Make it all go
 from mpisppy.spin_the_wheel import WheelSpinner
-from mpisppy.utils import config
-import mpisppy.utils.cfg_vanilla as vanilla
+from mpisppy.utils import cfg_vanilla as vanilla, config, scenario_names_creator
 from mpisppy.cylinders.hub import LShapedHub
 from mpisppy.opt.lshaped import LShapedMethod
 
@@ -48,7 +47,7 @@ def main():
     scenario_creator_kwargs = {
         "path": f"./{num_scen}scenarios_r1/"
     }
-    all_scenario_names = [f"Scenario{i+1}" for i in range(num_scen)]
+    all_scenario_names = scenario_names_creator(num_scen, prefix="Scenario", start=1)
 
     # Things needed for vanilla cylinders
     beans = (cfg, scenario_creator, scenario_denouement, all_scenario_names)

--- a/mpisppy/agnostic/agnostic_cylinders.py
+++ b/mpisppy/agnostic/agnostic_cylinders.py
@@ -15,10 +15,10 @@ I think it can be a pretty general cylinders program?
 """
 import sys
 from mpisppy.spin_the_wheel import WheelSpinner
-import mpisppy.utils.cfg_vanilla as vanilla
-import mpisppy.utils.config as config
-import mpisppy.agnostic.agnostic as agnostic
-import mpisppy.utils.sputils as sputils
+from mpisppy.agnostic import agnostic
+from mpisppy.utils import cfg_vanilla as vanilla, config, scenario_names_creator, sputils
+
+
 
 def _setup_args(m):
     # m is the model file module
@@ -47,19 +47,19 @@ def _setup_args(m):
                       default=None,
                       argparse=True)
     cfg.add_to_config(name="solution_base_name",
-                      description="The string used fo a directory of ouput along with a csv and an npv file (default None, which means no soltion output)",
+                      description="The string used for a directory of output along with a csv and an npv file (default None, which means no solution output)",
                       domain=str,
                       default=None)
     cfg.popular_args()
     cfg.two_sided_args()
-    cfg.ph_args()    
-    cfg.aph_args()    
+    cfg.ph_args()
+    cfg.aph_args()
     cfg.xhatlooper_args()
     cfg.fwph_args()
     cfg.lagrangian_args()
     cfg.lagranger_args()
     cfg.xhatshuffle_args()
-    return cfg    
+    return cfg
 
 def _parse_args(m):
     # m is the model file module
@@ -116,7 +116,7 @@ def main(model_fname, module, cfg):
     assert hasattr(module, "scenario_denouement"), "The model file must have a scenario_denouement function"
     scenario_denouement = module.scenario_denouement   # should we go though Ag?
     # note that if you are bundling, cfg.num_scens will be a fib (numbuns)
-    all_scenario_names = module.scenario_names_creator(cfg.num_scens)
+    all_scenario_names = scenario_names_creator(cfg.num_scens)
 
     # Things needed for vanilla cylinders
     beans = (cfg, scenario_creator, scenario_denouement, all_scenario_names)

--- a/mpisppy/agnostic/ampl_guest.py
+++ b/mpisppy/agnostic/ampl_guest.py
@@ -45,7 +45,7 @@ import mpisppy.utils.sputils as sputils
 import pyomo.environ as pyo
 
 from mpisppy import MPI  # for debuggig
-from mpisppy.utils import nice_join
+from mpisppy.utils import nice_join, scenario_names_creator
 fullcomm = MPI.COMM_WORLD
 global_rank = fullcomm.Get_rank()
 
@@ -105,8 +105,8 @@ class AMPL_guest():
 
 
     #=========
-    def scenario_names_creator(self, num_scens,start=None):
-        return self.model_module.scenario_names_creator(num_scens,start)
+    def scenario_names_creator(self, num_scens, start=None):
+        return scenario_names_creator(num_scens, start=start)
 
 
     #=========

--- a/mpisppy/agnostic/examples/farmer.py
+++ b/mpisppy/agnostic/examples/farmer.py
@@ -234,16 +234,6 @@ def pysp_instance_creation_callback(
 # begin functions not needed by farmer_cylinders
 # (but needed by special codes such as confidence intervals)
 #=========
-def scenario_names_creator(num_scens,start=None):
-    # (only for Amalgamator): return the full list of num_scens scenario names
-    # if start!=None, the list starts with the 'start' labeled scenario
-    if (start is None) :
-        start=0
-    return [f"scen{i}" for i in range(start,start+num_scens)]
-        
-
-
-#=========
 def inparser_adder(cfg):
     # add options unique to farmer
     cfg.num_scens_required()

--- a/mpisppy/agnostic/examples/farmer_ampl_model.py
+++ b/mpisppy/agnostic/examples/farmer_ampl_model.py
@@ -81,17 +81,13 @@ def scenario_creator(scenario_name, ampl_file_name,
         print("big troubles!!; we can't find the objective function")
         raise
     return ampl, "uniform", areaVarDatas, obj_fct
-    
-#=========
-def scenario_names_creator(num_scens,start=None):
-    return farmer.scenario_names_creator(num_scens,start)
 
 
 #=========
 def inparser_adder(cfg):
     farmer.inparser_adder(cfg)
 
-    
+
 #=========
 def kw_creator(cfg):
     # creates keywords for scenario creator

--- a/mpisppy/agnostic/examples/farmer_gams_model.py
+++ b/mpisppy/agnostic/examples/farmer_gams_model.py
@@ -69,17 +69,12 @@ def scenario_creator(scenario_name, mi, job, cfg=None):
 
     return mi
 
-        
-#=========
-def scenario_names_creator(num_scens,start=None):
-    return farmer.scenario_names_creator(num_scens,start)
-
 
 #=========
 def inparser_adder(cfg):
     farmer.inparser_adder(cfg)
 
-    
+
 #=========
 def kw_creator(cfg):
     # creates keywords for scenario creator

--- a/mpisppy/agnostic/examples/farmer_gurobipy_model.py
+++ b/mpisppy/agnostic/examples/farmer_gurobipy_model.py
@@ -48,10 +48,6 @@ def scenario_creator(scenario_name, use_integer=False, sense=GRB.MINIMIZE, crops
     return gd
 
 #==========
-def scenario_names_creator(num_scens,start=None):
-    return farmer.scenario_names_creator(num_scens,start)
-
-#==========
 def inparser_adder(cfg):
     return farmer.inparser_adder(cfg)
 

--- a/mpisppy/agnostic/examples/steel_ampl_model.py
+++ b/mpisppy/agnostic/examples/steel_ampl_model.py
@@ -41,7 +41,7 @@ def scenario_creator(scenario_name, ampl_file_name, cfg=None):
     ampl = AMPL()
     ampl.read(ampl_file_name)
     ampl.read_data(cfg.ampl_data_file)
-    scennum = sputils.extract_num(scenario_name)     
+    scennum = sputils.extract_num(scenario_name)
     seedoffset = cfg.seed
     #steelstream.seed(scennum+seedoffset)
     np.random.seed(scennum + seedoffset)
@@ -93,12 +93,6 @@ def kw_creator(cfg):
 def sample_tree_scen_creator(sname, stage, sample_branching_factors, seed,
                              given_scenario=None, **scenario_creator_kwargs):
     raise RuntimeError("sample_tree_scen_creator not implemented for the steel example")
-    
-def scenario_names_creator(num_scens,start=None):
-    # (only for Amalgamator): return the full list of num_scens scenario names
-    # if start!=None, the list starts with the 'start' labeled scenario
-    if (start is None) :
-        start=0
-    return [f"scen{i}" for i in range(start,start+num_scens)]
+
 def scenario_denouement(rank, scenario_name, scenario):
     pass

--- a/mpisppy/agnostic/examples/transport_gams_model.py
+++ b/mpisppy/agnostic/examples/transport_gams_model.py
@@ -63,13 +63,6 @@ def scenario_creator(scenario_name, mi, job, cfg=None):
 
 
 #=========
-def scenario_names_creator(num_scens,start=None):
-    if (start is None) :
-        start=0
-    return [f"scen{i}" for i in range(start,start+num_scens)]
-
-
-#=========
 def inparser_adder(cfg):
     # add options unique to transport
     cfg.num_scens_required()

--- a/mpisppy/agnostic/gams_guest.py
+++ b/mpisppy/agnostic/gams_guest.py
@@ -23,7 +23,7 @@ import tempfile
 import re
 
 import pyomo.environ as pyo
-import mpisppy.utils.sputils as sputils
+from mpisppy.utils import scenario_names_creator, sputils
 
 from mpisppy import MPI  # for debugging
 fullcomm = MPI.COMM_WORLD
@@ -104,7 +104,7 @@ class GAMS_guest():
 
     #=========
     def scenario_names_creator(self, num_scens,start=None):
-        return self.model_module.scenario_names_creator(num_scens,start)
+        return scenario_names_creator(num_scens, start=start)
 
 
     #=========

--- a/mpisppy/agnostic/pyomo_guest.py
+++ b/mpisppy/agnostic/pyomo_guest.py
@@ -31,7 +31,7 @@ provide hooks to:
   be handy for testing. All that needs to be done, is to attach
   the nonant varlist as _nonant_vars to the scenario when it is created.
 """
-import mpisppy.utils.sputils as sputils
+from mpisppy.utils import scenario_names_creator, sputils
 import pyomo.environ as pyo
 from pyomo.opt import SolutionStatus, TerminationCondition
 
@@ -79,7 +79,7 @@ class Pyomo_guest():
 
     #=========
     def scenario_names_creator(self, num_scens,start=None):
-        return self.model_module.scenario_names_creator(num_scens,start)
+        return scenario_names_creator(num_scens, start=start)
 
 
     #=========

--- a/mpisppy/confidence_intervals/ciutils.py
+++ b/mpisppy/confidence_intervals/ciutils.py
@@ -15,7 +15,7 @@ import numpy as np
 import mpisppy.MPI as mpi
 import pyomo.environ as pyo
 
-import mpisppy.utils.sputils as sputils
+from mpisppy.utils import scenario_names_creator, sputils
 from mpisppy import global_toc
 import mpisppy.utils.xhat_eval as xhat_eval
 import mpisppy.utils.amalgamator as ama
@@ -176,8 +176,7 @@ def _fct_check(module, fct):
 def pyomo_opt_sense(module_name, cfg):
     """ update cfg to have the optimization sense"""
     module = importlib.import_module(module_name)
-    _fct_check(module, "scenario_names_creator")
-    sn = module.scenario_names_creator(1)  # an arbitrary scenario name
+    sn = scenario_names_creator(1)  # an arbitrary scenario name
     _fct_check(module, "kw_creator")
     kw = module.kw_creator(cfg)
     m = module.scenario_creator(sn[0], **kw)

--- a/mpisppy/confidence_intervals/mmw_ci.py
+++ b/mpisppy/confidence_intervals/mmw_ci.py
@@ -15,7 +15,7 @@ import scipy.stats
 import importlib
 from mpisppy import global_toc
     
-import mpisppy.utils.amalgamator as ama
+from mpisppy.utils import amalgamator as ama, scenario_names_creator
 import mpisppy.confidence_intervals.ciutils as ciutils
 
 fullcomm = mpi.COMM_WORLD
@@ -92,7 +92,7 @@ class MMWConfidenceIntervals():
                 "cfg should have an attribute 'EF-2stage' or 'EF-mstage' set to True")
         
         #Check if refmodel and args have all needed attributes
-        everything = ["scenario_names_creator", "scenario_creator", "kw_creator"]
+        everything = ["scenario_creator", "kw_creator"]
         if self.multistage:
             everything[0] = "sample_tree_scen_creator"
     
@@ -147,7 +147,7 @@ class MMWConfidenceIntervals():
         for i in range(num_batches) :
             scenstart = None if self.multistage else start
             gap_options = {'seed':start,'branching_factors':sampling_branching_factors} if self.multistage else None
-            scenario_names = self.refmodel.scenario_names_creator(batch_size,start=scenstart)
+            scenario_names = scenario_names_creator(batch_size, start=scenstart)
             estim = ciutils.gap_estimators(self.xhat_one, self.refmodelname,
                                            solving_type=self.type,
                                            scenario_names=scenario_names,

--- a/mpisppy/confidence_intervals/multi_seqsampling.py
+++ b/mpisppy/confidence_intervals/multi_seqsampling.py
@@ -273,7 +273,6 @@ if __name__ == "__main__":
     # For use by confidence interval develepors who need a quick test.
     solver_name = "cplex"
     #An example of sequential sampling for the aircond model
-    import mpisppy.tests.examples.aircond
     bfs = [3,3,2]
     num_scens = np.prod(bfs)
     scenario_names = scenario_names_creator(num_scens)

--- a/mpisppy/confidence_intervals/sample_tree.py
+++ b/mpisppy/confidence_intervals/sample_tree.py
@@ -12,8 +12,7 @@ import numpy as np
 import mpisppy.MPI as mpi
 import importlib
 
-import mpisppy.utils.sputils as sputils
-import mpisppy.utils.amalgamator as amalgamator
+from mpisppy.utils import amalgamator, scenario_names_creator, sputils
 import mpisppy.confidence_intervals.ciutils as ciutils
 
 fullcomm = mpi.COMM_WORLD
@@ -62,7 +61,7 @@ class SampleSubtree():
 
         self.refmodel = importlib.import_module(mname)
         #Checking that refmodel has all the needed attributes
-        attrs = ["sample_tree_scen_creator","kw_creator","scenario_names_creator"]
+        attrs = ["sample_tree_scen_creator","kw_creator"]
         for attr in attrs:
             if not hasattr(self.refmodel, attr):
                 raise RuntimeError(f"The construction of a sample subtree failed because the reference model has no {attr} function.")
@@ -146,8 +145,7 @@ class SampleSubtree():
             if "kwargs" in ama_options:
                 ama_options["branching_factors"] = ama_options["kwargs"]["branching_factors"]
             """
-        scen_names = self.refmodel.scenario_names_creator(self.numscens,
-                                                          start=self.seed)
+        scen_names = scenario_names_creator(self.numscens, start=self.seed)
         denouement = self.refmodel.scenario_denouement if hasattr(self.refmodel, 'scenario_denouement') else None
         
         self.ama = amalgamator.Amalgamator(cfg, scen_names,

--- a/mpisppy/generic_cylinders.py
+++ b/mpisppy/generic_cylinders.py
@@ -11,6 +11,7 @@
 import sys
 import os
 import copy
+import glob
 import numpy as np
 import pyomo.environ as pyo
 import pyomo.common.config as pyofig
@@ -110,7 +111,10 @@ def _name_lists(cfg, bundle_wrapper=None):
             "For now, stage2EFsolvern is required for multistage xhat"
     else:
         all_nodenames = None
-        num_scens = cfg.get("num_scens", 0)
+        num_scens = cfg.get("num_scens")
+        if num_scens is None:
+            mps_files = glob.glob(os.path.join(cfg.get("mps_files_directory"), "*.mps"))
+            num_scens = len(mps_files)
 
     # proper bundles should be almost magic
     if cfg.unpickle_bundles_dir or cfg.scenarios_per_bundle is not None:
@@ -118,7 +122,7 @@ def _name_lists(cfg, bundle_wrapper=None):
         all_scenario_names = bundle_wrapper.bundle_names_creator(num_buns, cfg=cfg)
         all_nodenames = None  # This is seldom used; also, proper bundles result in two stages
     else:
-        all_scenario_names = scenario_names_creator(num_scens)
+        all_scenario_names = scenario_names_creator(num_scens, prefix='scen')
 
     return all_scenario_names, all_nodenames
 

--- a/mpisppy/generic_cylinders.py
+++ b/mpisppy/generic_cylinders.py
@@ -110,7 +110,7 @@ def _name_lists(cfg, bundle_wrapper=None):
             "For now, stage2EFsolvern is required for multistage xhat"
     else:
         all_nodenames = None
-        num_scens = cfg.get("num_scens")  # maybe None is OK
+        num_scens = cfg.get("num_scens", 0)
 
     # proper bundles should be almost magic
     if cfg.unpickle_bundles_dir or cfg.scenarios_per_bundle is not None:

--- a/mpisppy/opt/ph.py
+++ b/mpisppy/opt/ph.py
@@ -11,6 +11,7 @@
 import mpisppy.phbase
 import shutil
 import mpisppy.MPI as mpi
+from  mpisppy.utils import scenario_names_creator
 
 # decorator snarfed from stack overflow - allows per-rank profile output file generation.
 def profile(filename=None, comm=mpi.COMM_WORLD):
@@ -101,7 +102,7 @@ if __name__ == "__main__":
     PHopt["iterk_solver_options"] = {"mipgap": 0.001}
 
     ScenCount = 50
-    all_scenario_names = ['scen' + str(i) for i in range(ScenCount)]
+    all_scenario_names = scenario_names_creator(ScenCount, prefix="scen")
     # end hardwire
 
     scenario_creator = refmodel.scenario_creator

--- a/mpisppy/tests/examples/aircond.py
+++ b/mpisppy/tests/examples/aircond.py
@@ -367,16 +367,7 @@ def sample_tree_scen_creator(sname, stage, sample_branching_factors, seed,
                                                 starting_stage=stage)
     
     return model
-                
 
-#=========
-def scenario_names_creator(num_scens,start=None):
-    # (only for Amalgamator): return the full list of num_scens scenario names
-    # if start!=None, the list starts with the 'start' labeled scenario
-    if (start is None) :
-        start=0
-    return [f"scen{i}" for i in range(start,start+num_scens)]
-        
 
 #=========
 def inparser_adder(cfg):

--- a/mpisppy/tests/examples/aircondB.py
+++ b/mpisppy/tests/examples/aircondB.py
@@ -184,15 +184,6 @@ def sample_tree_scen_creator(sname, stage, sample_branching_factors, seed,
                 
 
 #=========
-def scenario_names_creator(num_scens,start=None):
-    # (only for Amalgamator): return the full list of num_scens scenario names
-    # if start!=None, the list starts with the 'start' labeled scenario
-    if (start is None) :
-        start=0
-    return [f"scen{i}" for i in range(start,start+num_scens)]
-        
-
-#=========
 def inparser_adder(cfg):
     base_aircond.inparser_adder(cfg)
     # special "proper" bundle arguments

--- a/mpisppy/tests/examples/apl1p.py
+++ b/mpisppy/tests/examples/apl1p.py
@@ -180,15 +180,6 @@ def scenario_creator(sname, num_scens=None):
 
 
 #=========
-def scenario_names_creator(num_scens,start=None):
-    # (only for Amalgamator): return the full list of num_scens scenario names
-    # if start!=None, the list starts with the 'start' labeled scenario
-    if (start is None) :
-        start=0
-    return [f"scen{i}" for i in range(start,start+num_scens)]
-        
-
-#=========
 def inparser_adder(inparser):
     # (only for Amalgamator): add command options unique to apl1p
     pass

--- a/mpisppy/tests/examples/distr/distr.py
+++ b/mpisppy/tests/examples/distr/distr.py
@@ -378,19 +378,6 @@ def consensus_vars_creator(num_scens):
         consensus_vars[region_target].append(vstr)
     return consensus_vars
 
-
-def scenario_names_creator(num_scens):
-    """Creates the name of every scenario.
-
-    Args:
-        num_scens (int): number of scenarios
-
-    Returns:
-        list (str): the list of names
-    """
-    return [f"Region{i+1}" for i in range(num_scens)]
-
-
 def kw_creator(cfg):
     """
     Args:
@@ -399,8 +386,7 @@ def kw_creator(cfg):
     Returns:
         dict (str): the kwargs that are used in distr.scenario_creator, here {"num_scens": num_scens}
     """
-    kwargs = {"num_scens" : cfg.get('num_scens', None),
-              }
+    kwargs = {"num_scens" : cfg.get('num_scens', None)}
     if kwargs["num_scens"] not in [2, 3, 4]:
         RuntimeError (f"unexpected number of regions {cfg.num_scens}, whould be in  [2, 3, 4]")
     return kwargs

--- a/mpisppy/tests/examples/farmer.py
+++ b/mpisppy/tests/examples/farmer.py
@@ -241,16 +241,6 @@ def pysp_instance_creation_callback(
 # begin functions not needed by farmer_cylinders
 # (but needed by special codes such as confidence intervals)
 #=========
-def scenario_names_creator(num_scens,start=None):
-    # (only for Amalgamator): return the full list of num_scens scenario names
-    # if start!=None, the list starts with the 'start' labeled scenario
-    if (start is None) :
-        start=0
-    return [f"scen{i}" for i in range(start,start+num_scens)]
-        
-
-
-#=========
 def inparser_adder(cfg):
     # add options unique to farmer
     cfg.num_scens_required()

--- a/mpisppy/tests/examples/gbd/gbd.py
+++ b/mpisppy/tests/examples/gbd/gbd.py
@@ -10,12 +10,11 @@
 #From original Ferguson and Dantzig 1956
 #Extended scenarios as done in Seq Sampling by B&M
 
+import json
 import pyomo.environ as pyo
 import numpy as np
 import mpisppy.scenario_tree as scenario_tree
-import mpisppy.utils.sputils as sputils
-import mpisppy.utils.amalgamator as amalgamator
-import json
+from mpisppy.utils import amalgamator, sputils, scenario_names_creator
 
 # Use this random stream:
 gbdstream= np.random.RandomState()  # pylint: disable=no-member
@@ -200,15 +199,6 @@ def scenario_creator(sname, num_scens=None):
 
 
 #=========
-def scenario_names_creator(num_scens,start=None):
-    # (only for Amalgamator): return the full list of num_scens scenario names
-    # if start!=None, the list starts with the 'start' labeled scenario
-    if (start is None) :
-        start=0
-    return [f"scen{i}" for i in range(start,start+num_scens)]
-        
-
-#=========
 def inparser_adder(inparser):
     # (only for Amalgamator): add command options unique to gbd
     pass
@@ -274,7 +264,7 @@ if __name__ == "__main__":
     solver_name = 'gurobi_direct'
     solver_options=None
     
-    scenario_names = scenario_names_creator(num_scens,start=6000)
+    scenario_names = scenario_names_creator(num_scens, prefix="scen", start=6000)
 
     ama_options = { "EF-2stage": True,
                     "EF_solver_name": solver_name,

--- a/mpisppy/tests/examples/w_test_data/farmer_get.py
+++ b/mpisppy/tests/examples/w_test_data/farmer_get.py
@@ -12,10 +12,8 @@ import farmer
 
 # Make it all go
 from mpisppy.spin_the_wheel import WheelSpinner
-import mpisppy.utils.sputils as sputils
+from mpisppy.utils import cfg_vanilla as vanilla, config, scenario_names_creator, sputils
 
-from mpisppy.utils import config
-import mpisppy.utils.cfg_vanilla as vanilla
 
 from mpisppy.extensions.norm_rho_updater import NormRhoUpdater
 from mpisppy.convergers.norm_rho_converger import NormRhoConverger
@@ -83,7 +81,7 @@ def main():
     
     scenario_creator = farmer.scenario_creator
     scenario_denouement = farmer.scenario_denouement
-    all_scenario_names = ['scen{}'.format(sn) for sn in range(num_scen)]
+    all_scenario_names = scenario_names_creator(num_scen, prefix='scen')
     scenario_creator_kwargs = {
         'use_integer': False,
         "crops_multiplier": crops_multiplier,

--- a/mpisppy/tests/examples/w_test_data/farmer_set.py
+++ b/mpisppy/tests/examples/w_test_data/farmer_set.py
@@ -12,10 +12,7 @@ import farmer
 
 # Make it all go
 from mpisppy.spin_the_wheel import WheelSpinner
-import mpisppy.utils.sputils as sputils
-
-from mpisppy.utils import config
-import mpisppy.utils.cfg_vanilla as vanilla
+from mpisppy.utils import cfg_vanilla as vanilla, config, scenario_names_creator, sputils
 
 from mpisppy.extensions.norm_rho_updater import NormRhoUpdater
 from mpisppy.convergers.norm_rho_converger import NormRhoConverger
@@ -85,7 +82,7 @@ def main():
     
     scenario_creator = farmer.scenario_creator
     scenario_denouement = farmer.scenario_denouement
-    all_scenario_names = ['scen{}'.format(sn) for sn in range(num_scen)]
+    all_scenario_names = scenario_names_creator(num_scen, prefix='scen')
     scenario_creator_kwargs = {
         'use_integer': False,
         "crops_multiplier": crops_multiplier,

--- a/mpisppy/tests/test_admmWrapper.py
+++ b/mpisppy/tests/test_admmWrapper.py
@@ -8,9 +8,8 @@
 ###############################################################################
 # TBD: make these tests less fragile
 import unittest
-import mpisppy.utils.admmWrapper as admmWrapper
 import mpisppy.tests.examples.distr.distr as distr
-from mpisppy.utils import config, scenario_names_creator
+from mpisppy.utils import admmWrapper, config, scenario_names_creator
 from mpisppy.tests.utils import get_solver
 from mpisppy import MPI
 import subprocess
@@ -36,7 +35,7 @@ class TestAdmmWrapper(unittest.TestCase):
     def _make_admm(self, num_scens,verbose=False):
         cfg = self._cfg_creator(num_scens)
         options = {}
-        all_scenario_names = scenario_names_creator(cfg.num_scens)
+        all_scenario_names = scenario_names_creator(cfg.num_scens, prefix="Region", start=1)
         scenario_creator = distr.scenario_creator
         scenario_creator_kwargs = distr.kw_creator(cfg)
         consensus_vars = distr.consensus_vars_creator(cfg.num_scens)

--- a/mpisppy/tests/test_admmWrapper.py
+++ b/mpisppy/tests/test_admmWrapper.py
@@ -10,7 +10,7 @@
 import unittest
 import mpisppy.utils.admmWrapper as admmWrapper
 import mpisppy.tests.examples.distr.distr as distr
-from mpisppy.utils import config
+from mpisppy.utils import config, scenario_names_creator
 from mpisppy.tests.utils import get_solver
 from mpisppy import MPI
 import subprocess
@@ -36,7 +36,7 @@ class TestAdmmWrapper(unittest.TestCase):
     def _make_admm(self, num_scens,verbose=False):
         cfg = self._cfg_creator(num_scens)
         options = {}
-        all_scenario_names = distr.scenario_names_creator(num_scens=cfg.num_scens)
+        all_scenario_names = scenario_names_creator(cfg.num_scens)
         scenario_creator = distr.scenario_creator
         scenario_creator_kwargs = distr.kw_creator(cfg)
         consensus_vars = distr.consensus_vars_creator(cfg.num_scens)
@@ -56,7 +56,7 @@ class TestAdmmWrapper(unittest.TestCase):
         for i in range(3,5):
             self._make_admm(i)
 
-    def test_variable_probability(self):        
+    def test_variable_probability(self):
         admm = self._make_admm(3)
         q = dict()
         for sname, s in admm.local_scenarios.items():

--- a/mpisppy/tests/test_agnostic.py
+++ b/mpisppy/tests/test_agnostic.py
@@ -13,10 +13,9 @@ import unittest
 import math
 import mpisppy.opt.ph
 from mpisppy.tests.utils import get_solver
-import mpisppy.utils.config as config
-import mpisppy.agnostic.agnostic as agnostic
-import mpisppy.agnostic.agnostic_cylinders as agnostic_cylinders
-import mpisppy.utils.sputils as sputils
+from mpisppy.utils import config, sputils, scenario_names_creator
+from mpisppy.agnostic import agnostic, agnostic_cylinders
+
 
 sys.path.insert(0, "../../examples/farmer/agnostic")
 import farmer_pyomo_agnostic
@@ -34,7 +33,7 @@ try:
     import farmer_gurobipy_agnostic
     have_gurobipy = True
 except ModuleNotFoundError:
-    have_gurobipy = False    
+    have_gurobipy = False
 
 __version__ = 0.2
 
@@ -101,7 +100,7 @@ class Test_Agnostic_pyomo(unittest.TestCase):
         phoptions = _get_ph_base_options()
         ph = mpisppy.opt.ph.PH(
             phoptions,
-            farmer_pyomo_agnostic.scenario_names_creator(num_scens=3),
+            scenario_names_creator(3),
             Ag.scenario_creator,
             farmer_pyomo_agnostic.scenario_denouement,
             scenario_creator_kwargs=None,   # agnostic.py takes care of this
@@ -116,7 +115,7 @@ class Test_Agnostic_pyomo(unittest.TestCase):
         s1 = Ag.scenario_creator("scen1")  # average case
         phoptions = _get_ph_base_options()
         phoptions["Ag"] = Ag  # this is critical
-        scennames = farmer_pyomo_agnostic.scenario_names_creator(num_scens=3)
+        scennames = scenario_names_creator(3)
         ph = mpisppy.opt.ph.PH(
             phoptions,
             scennames,
@@ -150,7 +149,7 @@ class Test_Agnostic_AMPL(unittest.TestCase):
         phoptions = _get_ph_base_options()
         phoptions["Ag"] = Ag  # this is critical
         phoptions["solver_name"] = "gurobi"  # need an ampl solver
-        scennames = farmer_ampl_agnostic.scenario_names_creator(num_scens=3)
+        scennames = scenario_names_creator(3)
         ph = mpisppy.opt.ph.PH(
             phoptions,
             scennames,
@@ -224,7 +223,7 @@ class Test_Agnostic_gurobipy(unittest.TestCase):
         phoptions = _get_ph_base_options()
         ph = mpisppy.opt.ph.PH(
             phoptions,
-            farmer_gurobipy_agnostic.scenario_names_creator(num_scens=3),
+            scenario_names_creator(3),
             Ag.scenario_creator,
             farmer_gurobipy_agnostic.scenario_denouement,
             scenario_creator_kwargs=None,  # agnostic.py takes care of this
@@ -240,7 +239,7 @@ class Test_Agnostic_gurobipy(unittest.TestCase):
         s1 = Ag.scenario_creator("scen1")  # average case
         phoptions = _get_ph_base_options()
         phoptions["Ag"] = Ag  # this is critical
-        scennames = farmer_gurobipy_agnostic.scenario_names_creator(num_scens=3)
+        scennames = scenario_names_creator(3)
         ph = mpisppy.opt.ph.PH(
             phoptions,
             scennames,

--- a/mpisppy/tests/test_conf_int_aircond.py
+++ b/mpisppy/tests/test_conf_int_aircond.py
@@ -18,17 +18,15 @@ import unittest
 
 
 from mpisppy.tests.utils import get_solver, round_pos_sig
-import mpisppy.utils.sputils as sputils
+from mpisppy.utils import amalgamator as ama, config, scenario_names_creator, sputils
 import mpisppy.tests.examples.aircond as aircond
 
 import mpisppy.confidence_intervals.mmw_ci as MMWci
-import mpisppy.utils.amalgamator as ama
 from mpisppy.utils.xhat_eval import Xhat_Eval
 import mpisppy.confidence_intervals.seqsampling as seqsampling
 import mpisppy.confidence_intervals.multi_seqsampling as multi_seqsampling
 import mpisppy.confidence_intervals.confidence_config as confidence_config
 import mpisppy.confidence_intervals.ciutils as ciutils
-from mpisppy.utils import config
 import pyomo.common.config as pyofig
 
 __version__ = 0.4
@@ -46,7 +44,7 @@ class Test_confint_aircond(unittest.TestCase):
     def setUpClass(self):
         self.refmodelname ="mpisppy.tests.examples.aircond"  # amalgamator compatible
         # TBD: maybe this code should create the file
-        self.xhatpath = "farmer_cyl_nonants.spy.npy"      
+        self.xhatpath = "farmer_cyl_nonants.spy.npy"
 
     def _get_base_options(self):
         # Base option has batch options
@@ -79,7 +77,7 @@ class Test_confint_aircond(unittest.TestCase):
 
     def _get_xhat_gen_options(self, BFs):
         num_scens = np.prod(BFs)
-        scenario_names = aircond.scenario_names_creator(num_scens)
+        scenario_names = scenario_names_creator(num_scens)
         xhat_gen_options = {"scenario_names": scenario_names,
                             "solver_name": solver_name,
                             "solver_options": None,
@@ -107,14 +105,14 @@ class Test_confint_aircond(unittest.TestCase):
     def tearDown(self):
          os.remove(self.xhat_path)
 
-        
+
     def _eval_creator(self):
         xh_options = self._get_xhatEval_options()
         
         MMW_options, scenario_creator_kwargs = self._get_base_options()
         branching_factors= global_BFs
-        scen_count = np.prod(branching_factors)
-        all_scenario_names = aircond.scenario_names_creator(scen_count)
+        scen_count = int(np.prod(branching_factors))
+        all_scenario_names = scenario_names_creator(scen_count)
         all_nodenames = sputils.create_nodenames_from_branching_factors(branching_factors)
         ev = Xhat_Eval(xh_options,
                        all_scenario_names,
@@ -233,7 +231,7 @@ class Test_confint_aircond(unittest.TestCase):
 
         num_scens = np.prod(branching_factors)
         scenario_creator_kwargs['num_scens'] = num_scens
-        all_scenario_names = aircond.scenario_names_creator(num_scens)
+        all_scenario_names = scenario_names_creator(num_scens)
 
         k = all_scenario_names[0]
         obj = ev.evaluate_one(full_xhat,k,ev.local_scenarios[k])
@@ -262,8 +260,8 @@ class Test_confint_aircond(unittest.TestCase):
     def test_gap_estimators(self):
         options, scenario_creator_kwargs = self._get_base_options()
         branching_factors= global_BFs
-        scen_count = np.prod(branching_factors)
-        scenario_names = aircond.scenario_names_creator(scen_count, start=1000)
+        scen_count = int(np.prod(branching_factors))
+        scenario_names = scenario_names_creator(scen_count, start=1000)
         sample_options = {"seed": 0,
                           "branching_factors": global_BFs}
         estim = ciutils.gap_estimators(self.xhat,

--- a/mpisppy/tests/test_conf_int_farmer.py
+++ b/mpisppy/tests/test_conf_int_farmer.py
@@ -27,7 +27,7 @@ import mpisppy.utils.amalgamator as ama
 from mpisppy.utils.xhat_eval import Xhat_Eval
 import mpisppy.confidence_intervals.seqsampling as seqsampling
 import mpisppy.confidence_intervals.ciutils as ciutils
-from mpisppy.utils import config
+from mpisppy.utils import config, scenario_names_creator
 import mpisppy.confidence_intervals.confidence_config as confidence_config
 
 fullcomm = mpi.COMM_WORLD
@@ -153,8 +153,7 @@ class Test_confint_farmer(unittest.TestCase):
         self.assertEqual(obj, -130000)
     
 
-    @unittest.skipIf(not solver_available,
-                     "no solver is available")      
+    @unittest.skipIf(not solver_available, "no solver is available")
     def test_xhat_eval_creator(self):
         options = self._get_xhatEval_options()
         
@@ -162,22 +161,21 @@ class Test_confint_farmer(unittest.TestCase):
         scenario_creator_kwargs = MMW_options['kwargs']
         scenario_creator_kwargs['num_scens'] = MMW_options['batch_size']
         ev = Xhat_Eval(options,
-                       farmer.scenario_names_creator(100),
+                       scenario_names_creator(100),
                        farmer.scenario_creator,
                        scenario_denouement=None,
                        scenario_creator_kwargs=scenario_creator_kwargs
                        )
         assert ev is not None
         
-    @unittest.skipIf(not solver_available,
-                     "no solver is available")      
+    @unittest.skipIf(not solver_available, "no solver is available")
     def test_xhat_eval_evaluate(self):
         options = self._get_xhatEval_options()
         MMW_options = self._get_base_options()
         scenario_creator_kwargs = MMW_options['kwargs']
         scenario_creator_kwargs['num_scens'] = MMW_options['batch_size']
         ev = Xhat_Eval(options,
-                   farmer.scenario_names_creator(100),
+                   scenario_names_creator(100),
                    farmer.scenario_creator,
                    scenario_denouement=None,
                    scenario_creator_kwargs=scenario_creator_kwargs
@@ -187,15 +185,14 @@ class Test_confint_farmer(unittest.TestCase):
         obj = round_pos_sig(ev.evaluate(xhat),2)
         self.assertEqual(obj, -1300000.0)
  
-    @unittest.skipIf(not solver_available,
-                     "no solver is available")  
+    @unittest.skipIf(not solver_available, "no solver is available")
     def test_xhat_eval_evaluate_one(self):
         options = self._get_xhatEval_options()
         MMW_options = self._get_base_options()
         xhat = ciutils.read_xhat(self.xhat_path)
         scenario_creator_kwargs = MMW_options['kwargs']
         scenario_creator_kwargs['num_scens'] = MMW_options['batch_size']
-        scenario_names = farmer.scenario_names_creator(100)
+        scenario_names = scenario_names_creator(100)
         ev = Xhat_Eval(options,
                    scenario_names,
                    farmer.scenario_creator,
@@ -207,8 +204,7 @@ class Test_confint_farmer(unittest.TestCase):
         obj = round_pos_sig(obj,2)
         self.assertEqual(obj, -48000.0)
       
-    @unittest.skipIf(not solver_available,
-                     "no solver is available")  
+    @unittest.skipIf(not solver_available, "no solver is available")
     def test_MMW_running(self):
         cfg = self._get_base_options()
         xhat = ciutils.read_xhat(self.xhat_path)
@@ -223,10 +219,9 @@ class Test_confint_farmer(unittest.TestCase):
         bound = round_pos_sig(r['gap_inner_bound'],2)
         self.assertEqual((s,bound), (1.5,96.0))
    
-    @unittest.skipIf(not solver_available,
-                     "no solver is available")
+    @unittest.skipIf(not solver_available, "no solver is available")
     def test_gap_estimators(self):
-        scenario_names = farmer.scenario_names_creator(50,start=1000)
+        scenario_names = scenario_names_creator(50, start=1000)
         estim = ciutils.gap_estimators(self.xhat,
                                        self.refmodelname,
                                        cfg=self._get_base_options(),

--- a/mpisppy/tests/test_gradient_rho.py
+++ b/mpisppy/tests/test_gradient_rho.py
@@ -49,7 +49,7 @@ class Test_gradient_farmer(unittest.TestCase):
         self.cfg.num_scens = 3
         scenario_creator = farmer.scenario_creator
         scenario_denouement = farmer.scenario_denouement
-        all_scenario_names = scenario_names_creator(self.cfg.num_scens)
+        all_scenario_names = scenario_names_creator(self.cfg.num_scens, prefix="scen")
         scenario_creator_kwargs = farmer.kw_creator(self.cfg)
         beans = (self.cfg, scenario_creator, scenario_denouement, all_scenario_names)
         hub_dict = vanilla.ph_hub(*beans, scenario_creator_kwargs=scenario_creator_kwargs)

--- a/mpisppy/tests/test_gradient_rho.py
+++ b/mpisppy/tests/test_gradient_rho.py
@@ -16,7 +16,7 @@ version matter a lot, so we often just do smoke tests.
 import unittest
 from mpisppy.utils import config
 
-import mpisppy.utils.cfg_vanilla as vanilla
+from mpisppy.utils import cfg_vanilla as vanilla, scenario_names_creator
 import mpisppy.tests.examples.farmer as farmer
 from mpisppy.spin_the_wheel import WheelSpinner
 from mpisppy.tests.utils import get_solver
@@ -49,11 +49,11 @@ class Test_gradient_farmer(unittest.TestCase):
         self.cfg.num_scens = 3
         scenario_creator = farmer.scenario_creator
         scenario_denouement = farmer.scenario_denouement
-        all_scenario_names = farmer.scenario_names_creator(self.cfg.num_scens)
+        all_scenario_names = scenario_names_creator(self.cfg.num_scens)
         scenario_creator_kwargs = farmer.kw_creator(self.cfg)
         beans = (self.cfg, scenario_creator, scenario_denouement, all_scenario_names)
         hub_dict = vanilla.ph_hub(*beans, scenario_creator_kwargs=scenario_creator_kwargs)
-        hub_dict['opt_kwargs']['options']['cfg'] = self.cfg                            
+        hub_dict['opt_kwargs']['options']['cfg'] = self.cfg
         list_of_spoke_dict = list()
         wheel = WheelSpinner(hub_dict, list_of_spoke_dict)
         wheel.spin()

--- a/mpisppy/tests/test_scenario_names_creator.py
+++ b/mpisppy/tests/test_scenario_names_creator.py
@@ -1,0 +1,50 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+
+from unittest import TestCase
+
+from mpisppy.utils import scenario_names_creator
+
+
+class TestScenarioNamesCeator(TestCase):
+    def test_scenario_names_creator_default(self):
+        self.assertEqual(
+            scenario_names_creator(3),
+            ["scenario0", "scenario1", "scenario2"],
+            "Should be a list with 'scenario0', 'scenario1' and 'scenario2'",
+        )
+
+    def test_scenario_names_creator_defining_prefix(self):
+        self.assertEqual(
+            scenario_names_creator(3, prefix="s"),
+            ["s0", "s1", "s2"],
+            "Should be a list with 's0', 's1' and 's2'",
+        )
+
+    def test_scenario_names_creator_defining_seperator(self):
+        self.assertEqual(
+            scenario_names_creator(3, separator="_"),
+            ["scenario_0", "scenario_1", "scenario_2"],
+            "Should be a list with 'scenario_0', 'scenario_1' and 'scenario_2'",
+        )
+
+    def test_scenario_names_creator_setting_start_value(self):
+        self.assertEqual(
+            scenario_names_creator(3, start=1),
+            ["scenario1", "scenario2", "scenario3"],
+            "Should be a list with 'scenario1', 'scenario2' and 'scenario3'",
+        )
+
+    def test_scenario_names_creator_start_value_is_None(self):
+        # to avoid migration errors from earlier implementations start is also allowed to be None
+        self.assertEqual(
+            scenario_names_creator(3, start=None),
+            ["scenario0", "scenario1", "scenario2"],
+            "Should be a list with 'scenario10', 'scenario1' and 'scenario2'",
+        )

--- a/mpisppy/tests/test_scenario_names_creator.py
+++ b/mpisppy/tests/test_scenario_names_creator.py
@@ -27,13 +27,6 @@ class TestScenarioNamesCeator(TestCase):
             "Should be a list with 's0', 's1' and 's2'",
         )
 
-    def test_scenario_names_creator_defining_seperator(self):
-        self.assertEqual(
-            scenario_names_creator(3, separator="_"),
-            ["scenario_0", "scenario_1", "scenario_2"],
-            "Should be a list with 'scenario_0', 'scenario_1' and 'scenario_2'",
-        )
-
     def test_scenario_names_creator_setting_start_value(self):
         self.assertEqual(
             scenario_names_creator(3, start=1),

--- a/mpisppy/tests/test_with_cylinders.py
+++ b/mpisppy/tests/test_with_cylinders.py
@@ -13,9 +13,8 @@ mpiexec -np 2 python -m mpi4py test_with_cylinders.py
 """
 
 import unittest
-from mpisppy.utils import config
+from mpisppy.utils import cfg_vanilla as vanilla, config, scenario_names_creator
 
-import mpisppy.utils.cfg_vanilla as vanilla
 import mpisppy.tests.examples.farmer as farmer
 from mpisppy.spin_the_wheel import WheelSpinner
 from mpisppy.tests.utils import get_solver
@@ -50,7 +49,7 @@ class Test_farmer_with_cylinders(unittest.TestCase):
         self.cfg.max_iterations = iters
         scenario_creator = farmer.scenario_creator
         scenario_denouement = farmer.scenario_denouement
-        all_scenario_names = farmer.scenario_names_creator(self.cfg.num_scens)
+        all_scenario_names = scenario_names_creator(self.cfg.num_scens)
         scenario_creator_kwargs = farmer.kw_creator(self.cfg)
         beans = (self.cfg, scenario_creator, scenario_denouement, all_scenario_names)
         hub_dict = vanilla.ph_hub(*beans, scenario_creator_kwargs=scenario_creator_kwargs)

--- a/mpisppy/tests/test_xbar_w_reader_writer.py
+++ b/mpisppy/tests/test_xbar_w_reader_writer.py
@@ -16,14 +16,12 @@ version matter a lot, so we often just do smoke tests.
 import os
 import unittest
 import csv
-from mpisppy.utils import config
+from mpisppy.utils import cfg_vanilla as vanilla, config, scenario_names_creator, wxbarreader, wxbarwriter
 
-import mpisppy.utils.cfg_vanilla as vanilla
 import mpisppy.tests.examples.farmer as farmer
 from mpisppy.spin_the_wheel import WheelSpinner
 from mpisppy.tests.utils import get_solver
-import mpisppy.utils.wxbarreader as wxbarreader
-import mpisppy.utils.wxbarwriter as wxbarwriter
+
 
 __version__ = 0.2
 
@@ -31,7 +29,7 @@ solver_available,solver_name, persistent_available, persistent_solver_name= get_
 
 def _create_cfg():
     cfg = config.Config()
-    wxbarreader.add_options_to_config(cfg)        
+    wxbarreader.add_options_to_config(cfg)
     wxbarwriter.add_options_to_config(cfg)
     cfg.add_branching_factors()
     cfg.num_scens_required()
@@ -55,7 +53,7 @@ class Test_xbar_w_reader_writer_farmer(unittest.TestCase):
         self.cfg.num_scens = 3
         scenario_creator = farmer.scenario_creator
         scenario_denouement = farmer.scenario_denouement
-        all_scenario_names = farmer.scenario_names_creator(self.cfg.num_scens)
+        all_scenario_names = scenario_names_creator(self.cfg.num_scens)
         scenario_creator_kwargs = farmer.kw_creator(self.cfg)
         self.cfg.max_iterations = max_iter
         beans = (self.cfg, scenario_creator, scenario_denouement, all_scenario_names)

--- a/mpisppy/tests/test_xbar_w_reader_writer.py
+++ b/mpisppy/tests/test_xbar_w_reader_writer.py
@@ -53,7 +53,7 @@ class Test_xbar_w_reader_writer_farmer(unittest.TestCase):
         self.cfg.num_scens = 3
         scenario_creator = farmer.scenario_creator
         scenario_denouement = farmer.scenario_denouement
-        all_scenario_names = scenario_names_creator(self.cfg.num_scens)
+        all_scenario_names = scenario_names_creator(self.cfg.num_scens, prefix="scen")
         scenario_creator_kwargs = farmer.kw_creator(self.cfg)
         self.cfg.max_iterations = max_iter
         beans = (self.cfg, scenario_creator, scenario_denouement, all_scenario_names)

--- a/mpisppy/utils/__init__.py
+++ b/mpisppy/utils/__init__.py
@@ -7,7 +7,7 @@
 # full copyright and license information.
 ###############################################################################
 
-from .strings import nice_join
+from .strings import nice_join, scenario_names_creator
 
 
-__all__ = ["nice_join"]
+__all__ = ["nice_join", "scenario_names_creator"]

--- a/mpisppy/utils/amalgamator.py
+++ b/mpisppy/utils/amalgamator.py
@@ -13,12 +13,9 @@ import inspect
 import pyomo.environ as pyo
 import copy
 import pyomo.common.config as pyofig
-from mpisppy.utils import config
-import mpisppy.utils.solver_spec as solver_spec
+from mpisppy.utils import cfg_vanilla as vanilla, config, scenario_names_creator, solver_spec, sputils
 
 from mpisppy.spin_the_wheel import WheelSpinner
-import mpisppy.utils.sputils as sputils
-import mpisppy.utils.cfg_vanilla as vanilla
 from mpisppy import global_toc
 
 from mpisppy.extensions.fixer import Fixer
@@ -126,10 +123,7 @@ def find_spokes(cylinders, is_multi=False):
 #==========
 def check_module_ama(module):
     # Complain if the module lacks things needed.
-    everything = ["scenario_names_creator",
-                 "scenario_creator",
-                 "inparser_adder",
-                 "kw_creator"]  # start and denouement can be missing.
+    everything = ["scenario_creator", "inparser_adder", "kw_creator"]  # start and denouement can be missing.
     you_can_have_it_all = True
     for ething in everything:
         if not hasattr(module, ething):
@@ -169,7 +163,7 @@ def from_module(mname, cfg, extraargs_fct=None, use_command_line=True):
                                  use_command_line=use_command_line)
     cfg.add_and_assign('_mpisppy_probability', description="Uniform prob.", domain=float, default=None, value= 1/cfg['num_scens'], complain=False)
     start = cfg['start'] if 'start' in cfg else 0
-    sn = m.scenario_names_creator(cfg['num_scens'], start=start)
+    sn = scenario_names_creator(cfg['num_scens'], start=start)
     dn = m.scenario_denouement if hasattr(m, "scenario_denouement") else None
     ama = Amalgamator(cfg,
                       sn,

--- a/mpisppy/utils/mps_module.py
+++ b/mpisppy/utils/mps_module.py
@@ -26,12 +26,9 @@ note to dlw from dlw:
 
 """
 import os
-import re
-import glob
 import json
 import mpisppy.scenario_tree as scenario_tree
-import mpisppy.utils.sputils as sputils
-import mpisppy.utils.mps_reader as mps_reader
+from mpisppy.utils import mps_reader, sputils
 # assume you can get the path from config, set in kw_creator as a side-effect
 mps_files_directory = None
 
@@ -86,31 +83,6 @@ def scenario_creator(sname, cfg=None):
     model._mpisppy_node_list = treeNodes
     return model
 
-
-#=========
-def scenario_names_creator(num_scens, start=None):
-    # validate the directory and use it to get names (that have to be numbered)
-    # IMPORTANT: start is zero-based even if the names are one-based!
-    mps_files = [os.path.basename(f)
-                for f in glob.glob(os.path.join(mps_files_directory, "*.mps"))]
-    mps_files.sort()
-    if start is None:
-        start = 0
-    if num_scens is None:
-        num_scens = len(mps_files) - start
-    first = re.search(r"\d+$",mps_files[0][:-4])  # first scenario number
-    try:
-        first = int(first.group())
-    except Exception as e:
-        raise RuntimeError(f'mps files in {mps_files_directory} must end with an integer'
-                           f'found file {mps_files[0]} (error was: {e})')
-    if first != 0:
-        print("WARNING: non-zero-based senario names might cause trouble"
-              f" found {first=} for dir {mps_files_directory}")
-    assert start+num_scens <= len(mps_files),\
-        f"Trying to create scenarios names with {start=}, {num_scens=} but {len(mps_files)=}"
-    retval = [fn[:-4] for fn in mps_files[start:start+num_scens]]
-    return retval
 
 #=========
 def inparser_adder(cfg):

--- a/mpisppy/utils/proper_bundler.py
+++ b/mpisppy/utils/proper_bundler.py
@@ -11,8 +11,8 @@
 
 import os
 import numpy as np
-import mpisppy.utils.sputils as sputils
-import mpisppy.utils.pickle_bundle as pickle_bundle
+from mpisppy.utils import pickle_bundle, scenario_names_creator, sputils
+
 
 # Development notes:
 # 2 stage Cases:
@@ -53,7 +53,7 @@ class ProperBundler():
     def scenario_names_creator(self, num_scens, start=None, cfg=None):
         # no need to wrap?
         assert cfg is not None, "ProperBundler needs cfg for scenario names"
-        return cfg.model.scenario_names_creator(num_scens, start=start)
+        return scenario_names_creator(num_scens, start=start)
 
     def set_bunBFs(self, cfg):
         # utility for bundle objects. Might throw if it doesn't like the branching factors.
@@ -82,7 +82,7 @@ class ProperBundler():
         bsize = cfg.scenarios_per_bundle  # typing aid
         self.set_bunBFs(cfg)
         # We need to know if scenarios (not bundles) are one-based.
-        inum = sputils.extract_num(self.module.scenario_names_creator(1)[0])
+        inum = sputils.extract_num(scenario_names_creator(1)[0])
         names = [f"Bundle_{bn*bsize+inum}_{(bn+1)*bsize-1+inum}" for bn in range(start+num_buns)]
         return names
 
@@ -114,8 +114,7 @@ class ProperBundler():
             firstnum = int(sname.split("_")[1])  # sname is a bundle name
             lastnum = int(sname.split("_")[2])
             # snames are scenario names
-            snames = self.module.scenario_names_creator(lastnum-firstnum+1,
-                                                        firstnum)
+            snames = scenario_names_creator(lastnum-firstnum+1, start=firstnum)
             kws = self.original_kwargs
             if self.bunBFs is not None:
                 # The original scenario creator needs to handle these

--- a/mpisppy/utils/sputils.py
+++ b/mpisppy/utils/sputils.py
@@ -28,6 +28,7 @@ from pyomo.opt import SolutionStatus, TerminationCondition
 from pyomo.core.base.indexed_component_slice import IndexedComponent_slice
 
 from mpisppy import tt_timer
+from mpisppy.utils import scenario_names_creator
 
 global_rank = MPI.COMM_WORLD.Get_rank()
 
@@ -729,7 +730,7 @@ def scens_to_ranks(scen_count, n_proc, rank, branching_factors = None):
         # indecision as of May 2020 (delete this comment DLW)
         # just make sure things are consistent with what xhat will do...
         # TBD: streamline
-        all_scenario_names = ["ID"+str(i) for i in range(scen_count)]
+        all_scenario_names = scenario_names_creator(scen_count, prefix="ID")
         tree = _ScenTree(branching_factors, all_scenario_names)
         scenario_names_to_ranks, slices, = tree.scen_name_to_rank(n_proc, rank)
         return slices, scenario_names_to_ranks

--- a/mpisppy/utils/strings.py
+++ b/mpisppy/utils/strings.py
@@ -47,26 +47,23 @@ def nice_join(
         return f"{separator.join(seq[:-1])} {conjunction} {seq[-1]}"
 
 
-def scenario_names_creator(
-    n: int, prefix: str = "scenario", separator: str = "", start: int | None = 0
-) -> list[str]:
-    """Creates a list of scenario names using the pattern `{prefix}{separator}{number}` for a single
-    scenario name. The scenario names are distinguished using consecutive numbers.
+def scenario_names_creator(n: int, prefix: str = "scenario", start: int | None = 0) -> list[str]:
+    """Creates a list of scenario names using the pattern `{prefix}{number}` for a single scenario
+    name. The scenario names are distinguished using consecutive numbers.
 
     Args:
         n (int): number of wanted scenarios names
         prefix (str, "scenario"): string to start the scenario name
-        separator (str, ""): string to separate the prefix from the consecutive number
         start (int | None, 0): number to use for the first scenario name
 
     Examples:
 
         >>> from mpisppy.utils import scenario_names_creator
 
-        >>> scenario_names_creator(3, prefix="scen", separator="_", start=1)
+        >>> scenario_names_creator(3, prefix="scen_", start=1)
         ["scen_1", "scen_2", "scen_3"]
     """
-    # to avoid migration errors from earlier implementations start is also allowed to be None
+    # start is also allowed to be None to avoid migration errors from earlier implementations
     if start is None:
         start = 0
-    return [f"{prefix}{separator}{i}" for i in range(start, start + n)]
+    return [f"{prefix}{i}" for i in range(start, start + n)]

--- a/mpisppy/utils/strings.py
+++ b/mpisppy/utils/strings.py
@@ -45,3 +45,28 @@ def nice_join(
         return separator.join(seq)
     else:
         return f"{separator.join(seq[:-1])} {conjunction} {seq[-1]}"
+
+
+def scenario_names_creator(
+    n: int, prefix: str = "scenario", separator: str = "", start: int | None = 0
+) -> list[str]:
+    """Creates a list of scenario names using the pattern `{prefix}{separator}{number}` for a single
+    scenario name. The scenario names are distinguished using consecutive numbers.
+
+    Args:
+        n (int): number of wanted scenarios names
+        prefix (str, "scenario"): string to start the scenario name
+        separator (str, ""): string to separate the prefix from the consecutive number
+        start (int | None, 0): number to use for the first scenario name
+
+    Examples:
+
+        >>> from mpisppy.utils import scenario_names_creator
+
+        >>> scenario_names_creator(3, prefix="scen", separator="_", start=1)
+        ["scen_1", "scen_2", "scen_3"]
+    """
+    # to avoid migration errors from earlier implementations start is also allowed to be None
+    if start is None:
+        start = 0
+    return [f"{prefix}{separator}{i}" for i in range(start, start + n)]

--- a/mpisppy/utils/wtracker.py
+++ b/mpisppy/utils/wtracker.py
@@ -20,6 +20,7 @@ import numpy as np
 import pandas as pd
 import mpisppy.opt.ph
 import mpisppy.MPI as MPI
+from mpisppy.utils import scenario_names_creator
 
 class WTracker():
     """
@@ -233,7 +234,7 @@ if __name__ == "__main__":
     options["PHIterLimit"] = 1
     ph = mpisppy.opt.ph.PH(
         options,
-        farmer.scenario_names_creator(3),
+        scenario_names_creator(3),
         farmer.scenario_creator,
         farmer.scenario_denouement,
         scenario_creator_kwargs=farmer.kw_creator(options),

--- a/paperruns/larger_uc/uc_cylinders.py
+++ b/paperruns/larger_uc/uc_cylinders.py
@@ -20,8 +20,7 @@ from mpisppy.utils.sputils import spin_the_wheel
 from mpisppy.extensions.extension import MultiExtension
 from mpisppy.extensions.fixer import Fixer
 from mpisppy.extensions.mipgapper import Gapper
-from mpisppy.utils import baseparsers
-from mpisppy.utils import vanilla
+from mpisppy.utils import baseparsers, cfg_vanilla as vanilla, scenario_names_creator
 from mpisppy.extensions.cross_scen_extension import CrossScenarioExtension
 
 
@@ -38,7 +37,7 @@ def _parse_args():
                         help="json file with mipgap schedule (default None)",
                         dest="ph_mipgaps_json",
                         type=str,
-                        default=None)                
+                        default=None)
     
     args = parser.parse_args()
     return args
@@ -69,7 +68,7 @@ def main():
     }
     scenario_creator = uc.scenario_creator
     scenario_denouement = uc.scenario_denouement
-    all_scenario_names = [f"Scenario{i+1}" for i in range(num_scen)]
+    all_scenario_names = scenario_names_creator(num_scen, prefix="Scenario", start=1)
     rho_setter = uc._rho_setter
     
     # Things needed for vanilla cylinders


### PR DESCRIPTION
The main goal of this PR is to simplify the code base and remove multiple definitions of the functions `scenario_names_creator`.

I tried to replace as many code as possible with the new function and removed quite a few lines of code. I tried to keep all the scenario names the same as before.