### PR TITLE
Replace deprecated Pyomo 'undo' with 'reverse' for relax_integer_vars

### DIFF
--- a/mpisppy/extensions/integer_relax_then_enforce.py
+++ b/mpisppy/extensions/integer_relax_then_enforce.py
@@ -28,17 +28,18 @@ class IntegerRelaxThenEnforce(mpisppy.extensions.extension.Extension):
 
     def pre_iter0(self):
         global_toc(f"{self.__class__.__name__}: relaxing integrality constraints", self.opt.cylinder_rank == 0)
-        for s in self.opt.local_scenarios.values():
-            self.integer_relaxer.apply_to(s) 
+        self._reverse_tokens = {}
+        for sname, s in self.opt.local_scenarios.items():
+            self._reverse_tokens[sname] = self.integer_relaxer.apply_to(s)
         self._integers_relaxed = True
 
     def _unrelax_integers(self):
-        for sub in self.opt.local_scenarios.values():
+        for sname, sub in self.opt.local_scenarios.items():
             subproblem_solver = sub._solver_plugin
             vlist = None
             if is_persistent(subproblem_solver):
                 vlist = list(v for v,d in sub._relaxed_integer_vars[None].values())
-            self.integer_relaxer.apply_to(sub, options={"reverse":True})
+            self.integer_relaxer.apply_to(sub, options={"reverse": self._reverse_tokens[sname]})
             if is_persistent(subproblem_solver):
                 for v in vlist:
                     subproblem_solver.update_var(v)

--- a/mpisppy/extensions/integer_relax_then_enforce.py
+++ b/mpisppy/extensions/integer_relax_then_enforce.py
@@ -38,7 +38,7 @@ class IntegerRelaxThenEnforce(mpisppy.extensions.extension.Extension):
             vlist = None
             if is_persistent(subproblem_solver):
                 vlist = list(v for v,d in sub._relaxed_integer_vars[None].values())
-            self.integer_relaxer.apply_to(sub, options={"undo":True})
+            self.integer_relaxer.apply_to(sub, options={"reverse":True})
             if is_persistent(subproblem_solver):
                 for v in vlist:
                     subproblem_solver.update_var(v)

--- a/mpisppy/utils/nonant_sensitivities.py
+++ b/mpisppy/utils/nonant_sensitivities.py
@@ -29,7 +29,7 @@ def nonant_sensitivies(s):
     for var in s.component_data_objects(pyo.Var):
         solution_cache[var] = var._value
     relax_int = pyo.TransformationFactory('core.relax_integer_vars')
-    relax_int.apply_to(s)
+    reverse_token = relax_int.apply_to(s)
 
     assert hasattr(s, "_relaxed_integer_vars")
 
@@ -82,7 +82,7 @@ def nonant_sensitivies(s):
         sensitivity = grad_vec_kkt_inv @ -e_x
         nonant_sensis[ndn_i] = sensitivity
 
-    relax_int.apply_to(s, options={"reverse":True})
+    relax_int.apply_to(s, options={"reverse": reverse_token})
     assert not hasattr(s, "_relaxed_integer_vars")
     del s.ipopt_zL_out
     del s.ipopt_zU_out

--- a/mpisppy/utils/nonant_sensitivities.py
+++ b/mpisppy/utils/nonant_sensitivities.py
@@ -82,7 +82,7 @@ def nonant_sensitivies(s):
         sensitivity = grad_vec_kkt_inv @ -e_x
         nonant_sensis[ndn_i] = sensitivity
 
-    relax_int.apply_to(s, options={"undo":True})
+    relax_int.apply_to(s, options={"reverse":True})
     assert not hasattr(s, "_relaxed_integer_vars")
     del s.ipopt_zL_out
     del s.ipopt_zU_out

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         'sortedcollections',
         'numpy',
         'scipy',
-        'pyomo>=6.4',
+        'pyomo>=6.9.3',
     ],
     extras_require={
         'doc': [


### PR DESCRIPTION
## Summary
- Pyomo 6.9.3 deprecated the `undo` option in the `core.relax_integer_vars` transformation in favor of `reverse`
- Updated both occurrences: `integer_relax_then_enforce.py` and `nonant_sensitivities.py`

## Test plan
- [x] Run `run_all.py` with the sslp test that uses `--integer-relax-then-enforce` and confirm no deprecation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)