### PR TITLE
Fix documentation build warnings

### DIFF
--- a/doc/src/confidence_intervals.rst
+++ b/doc/src/confidence_intervals.rst
@@ -1,7 +1,7 @@
 .. _MMW Confidence Intervals:
 
 MMW confidence intervals:
-========================
+=========================
 
 If we want to assess the quality of a given candidate solution ``xhat_one`` 
 (a first stage solution), we could try and evaluate the optimality gap, i.e. 

--- a/doc/src/properbundles.rst
+++ b/doc/src/properbundles.rst
@@ -1,3 +1,5 @@
+.. _Pickled-Bundles:
+
 Proper Bundles
 ==============
 

--- a/mpisppy/cylinders/spcommunicator.py
+++ b/mpisppy/cylinders/spcommunicator.py
@@ -35,6 +35,7 @@ def communicator_array(data_length: int):
     Allocate an MPI memory region with a padded length (multiple of 8 doubles = 64B),
     but expose a logical view of length (data_length + 1) where the last element is
     the read/write id.
+
     Returns:
         full_arr:  padded array (used for SPWindow put/get)
         logical_arr: logical view (data + id), last element is id


### PR DESCRIPTION
## Summary
- Add missing `Pickled-Bundles` label to `properbundles.rst` (resolved two undefined reference warnings in `agnostic.rst`)
- Fix title underline length in `confidence_intervals.rst`
- Add blank line before `Returns:` in `communicator_array` docstring to fix block quote warning

## Test plan
- [x] `cd doc && make html` produces no warnings from our files

🤖 Generated with [Claude Code](https://claude.com/claude-code)