### PR TITLE
Fix coverage report SIGPIPE in CI

### DIFF
--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -809,7 +809,7 @@ jobs:
         run: |
           coverage combine --rcfile=.coveragerc
           coverage xml --rcfile=.coveragerc -o coverage.xml
-          coverage report --rcfile=.coveragerc --show-missing | head -150
+          coverage report --rcfile=.coveragerc --show-missing 2>&1 | head -150 || true
 
       - name: Upload to Codecov
         uses: codecov/codecov-action@v4


### PR DESCRIPTION
## Summary
- Fix `coverage report | head -150` failing with exit code 120 when output exceeds 150 lines
- Add `|| true` so the coverage report step never fails the CI job

One-line change. The actual tests all pass; only the final coverage summary step was failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)