### PR TITLE
Fix lshaped bug where rank 0 hangs at algorithm convergence

### DIFF
--- a/mpisppy/opt/lshaped.py
+++ b/mpisppy/opt/lshaped.py
@@ -650,16 +650,17 @@ class LShapedMethod(spbase.SPBase):
                 for c in cuts_added:
                     if is_persistent:
                         opt.add_constraint(c)
-                if verbose and len(cuts_added) == 0:
-                    print(
-                        f"Converged in {self.iter+1} iterations.\n"
-                        f"Total Time Elapsed: {time.time()-t:7.2f} "
-                        f"Time Spent on Last Master: {t1:7.2f} "
-                        f"Time spent verifying second stage: {t2:7.2f} "
-                        f"Final Objective: {m.obj.expr():7.2f}"
-                    )
-                    self.first_stage_solution_available = True
-                    self.tree_solution_available = True
+                if len(cuts_added) == 0:
+                    if verbose:
+                        print(
+                            f"Converged in {self.iter+1} iterations.\n"
+                            f"Total Time Elapsed: {time.time()-t:7.2f} "
+                            f"Time Spent on Last Master: {t1:7.2f} "
+                            f"Time spent verifying second stage: {t2:7.2f} "
+                            f"Final Objective: {m.obj.expr():7.2f}"
+                        )
+                        self.first_stage_solution_available = True
+                        self.tree_solution_available = True
                     break
                 if verbose and self.iter == max_iter - 1:
                     print("WARNING MAX ITERATION LIMIT REACHED !!! ")
@@ -683,6 +684,7 @@ class LShapedMethod(spbase.SPBase):
                             f"Final Objective: {m.obj.expr():7.2f}"
                         )
                     break
+        
         return res
 
 def _del_con(c):

--- a/mpisppy/opt/lshaped.py
+++ b/mpisppy/opt/lshaped.py
@@ -659,8 +659,8 @@ class LShapedMethod(spbase.SPBase):
                             f"Time spent verifying second stage: {t2:7.2f} "
                             f"Final Objective: {m.obj.expr():7.2f}"
                         )
-                        self.first_stage_solution_available = True
-                        self.tree_solution_available = True
+                    self.first_stage_solution_available = True
+                    self.tree_solution_available = True
                     break
                 if verbose and self.iter == max_iter - 1:
                     print("WARNING MAX ITERATION LIMIT REACHED !!! ")


### PR DESCRIPTION
In the current code, the `break` is inside the `if verbose:`, so if `verbose` is set to `False` and no more cuts are added, `cylinder_rank` 0 never exits the loop. The others do and send their "terminate" signal, but not 0. This fixes that.