### PR TITLE
Split run_all.py CI into first/second parts to reduce PR bottleneck

### DIFF
--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -124,8 +124,8 @@ jobs:
           if-no-files-found: ignore
           include-hidden-files: true
 
-  runall_persistent:
-    name: run_all.py persistent solver
+  runall_persistent_part1:
+    name: run_all.py persistent solver (part 1)
     runs-on: ubuntu-latest
     needs: [ruff]
     timeout-minutes: 15
@@ -151,23 +151,65 @@ jobs:
         run: |
           pip install -e .
 
-      - name: Test run_all nouc
+      - name: Test run_all nouc (first part)
         run: |
           PYARGS="-m coverage run $COV_ARGS"
           cd examples
-          coverage run $EX_COV_ARGS run_all.py xpress_persistent "" nouc --python-args="$PYARGS"
+          coverage run $EX_COV_ARGS run_all.py xpress_persistent "" nouc --first-part-only --python-args="$PYARGS"
 
       - name: Upload coverage data
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-runall-persistent
+          name: coverage-runall-persistent-part1
           path: ${{ github.workspace }}/.coverage.*
           if-no-files-found: ignore
           include-hidden-files: true
 
-  runall:
-    name: run_all.py direct solver
+  runall_persistent_part2:
+    name: run_all.py persistent solver (part 2)
+    runs-on: ubuntu-latest
+    needs: [ruff]
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v3
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: test_env
+          python-version: 3.11
+          auto-activate-base: false
+      - name: Install dependencies
+        run: |
+          conda install mpi4py pandas setuptools
+          pip install pyomo sphinx sphinx_rtd_theme dill gridx-egret cplex pybind11
+          pip install xpress coverage
+
+      - name: Build pyomo extensions
+        run: |
+          # we don't need it all; just APPSI's extensions
+          pyomo build-extensions || python -c "from pyomo.contrib.appsi.cmodel import cmodel_available; exit(0) if bool(cmodel_available) else exit(1)"
+
+      - name: setup the program
+        run: |
+          pip install -e .
+
+      - name: Test run_all nouc (second part)
+        run: |
+          PYARGS="-m coverage run $COV_ARGS"
+          cd examples
+          coverage run $EX_COV_ARGS run_all.py xpress_persistent "" nouc --second-part-only --python-args="$PYARGS"
+
+      - name: Upload coverage data
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-runall-persistent-part2
+          path: ${{ github.workspace }}/.coverage.*
+          if-no-files-found: ignore
+          include-hidden-files: true
+
+  runall_part1:
+    name: run_all.py direct solver (part 1)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -192,17 +234,58 @@ jobs:
         run: |
           pip install -e .
 
-      - name: Test run_all nouc
+      - name: Test run_all nouc (first part)
         run: |
           PYARGS="-m coverage run $COV_ARGS"
           cd examples
-          coverage run $EX_COV_ARGS run_all.py xpress_direct "" nouc --python-args="$PYARGS"
+          coverage run $EX_COV_ARGS run_all.py xpress_direct "" nouc --first-part-only --python-args="$PYARGS"
 
       - name: Upload coverage data
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-runall-direct
+          name: coverage-runall-direct-part1
+          path: ${{ github.workspace }}/.coverage.*
+          if-no-files-found: ignore
+          include-hidden-files: true
+
+  runall_part2:
+    name: run_all.py direct solver (part 2)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v3
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: test_env
+          python-version: 3.11
+          auto-activate-base: false
+      - name: Install dependencies
+        run: |
+          conda install mpi4py pandas setuptools
+          pip install pyomo sphinx sphinx_rtd_theme dill gridx-egret cplex pybind11
+          pip install xpress coverage
+
+      - name: Build pyomo extensions
+        run: |
+          # we don't need it all; just APPSI's extensions
+          pyomo build-extensions || python -c "from pyomo.contrib.appsi.cmodel import cmodel_available; exit(0) if bool(cmodel_available) else exit(1)"
+
+      - name: setup the program
+        run: |
+          pip install -e .
+
+      - name: Test run_all nouc (second part)
+        run: |
+          PYARGS="-m coverage run $COV_ARGS"
+          cd examples
+          coverage run $EX_COV_ARGS run_all.py xpress_direct "" nouc --second-part-only --python-args="$PYARGS"
+
+      - name: Upload coverage data
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-runall-direct-part2
           path: ${{ github.workspace }}/.coverage.*
           if-no-files-found: ignore
           include-hidden-files: true
@@ -881,8 +964,10 @@ jobs:
     needs:
       - nompi4py
       - regression
-      - runall_persistent
-      - runall
+      - runall_persistent_part1
+      - runall_persistent_part2
+      - runall_part1
+      - runall_part2
       - schur-complement
       - straight-tests
       - admm-wrapper

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -124,6 +124,32 @@ jobs:
           if-no-files-found: ignore
           include-hidden-files: true
 
+  runall_persistent:
+    name: run_all.py persistent solver
+    runs-on: ubuntu-latest
+    needs: [runall_persistent_part1, runall_persistent_part2]
+    if: always()
+    steps:
+      - name: Aggregate persistent run_all parts
+        run: |
+          if [[ "${{ needs.runall_persistent_part1.result }}" != "success" || "${{ needs.runall_persistent_part2.result }}" != "success" ]]; then
+            echo "part1=${{ needs.runall_persistent_part1.result }} part2=${{ needs.runall_persistent_part2.result }}"
+            exit 1
+          fi
+
+  runall:
+    name: run_all.py direct solver
+    runs-on: ubuntu-latest
+    needs: [runall_part1, runall_part2]
+    if: always()
+    steps:
+      - name: Aggregate direct run_all parts
+        run: |
+          if [[ "${{ needs.runall_part1.result }}" != "success" || "${{ needs.runall_part2.result }}" != "success" ]]; then
+            echo "part1=${{ needs.runall_part1.result }} part2=${{ needs.runall_part2.result }}"
+            exit 1
+          fi
+
   runall_persistent_part1:
     name: run_all.py persistent solver (part 1)
     runs-on: ubuntu-latest

--- a/examples/run_all.py
+++ b/examples/run_all.py
@@ -21,7 +21,10 @@ import os
 import sys
 
 # Parse --python-args (extra args inserted after "python" in subcommands, e.g. for coverage)
+# and --first-part-only / --second-part-only (split pre-nouc work in half so CI can parallelize).
 python_args = ""
+first_part_only = False
+second_part_only = False
 _remaining = []
 _i = 1
 while _i < len(sys.argv):
@@ -30,10 +33,18 @@ while _i < len(sys.argv):
     elif sys.argv[_i] == "--python-args" and _i + 1 < len(sys.argv):
         _i += 1
         python_args = sys.argv[_i]
+    elif sys.argv[_i] == "--first-part-only":
+        first_part_only = True
+    elif sys.argv[_i] == "--second-part-only":
+        second_part_only = True
     else:
         _remaining.append(sys.argv[_i])
     _i += 1
 sys.argv = [sys.argv[0]] + _remaining
+if first_part_only and second_part_only:
+    raise RuntimeError("--first-part-only and --second-part-only are mutually exclusive")
+run_first_part = not second_part_only
+run_second_part = not first_part_only
 
 solver_name = "gurobi_persistent"
 if len(sys.argv) > 1:
@@ -123,135 +134,139 @@ def do_one_mmw(dirname, modname, runefstring, npyfile, mmwargstring):
     os.chdir("..")
     os.chdir("..")  # moved to CI directory
 
-do_one("farmer/CI", "farmer_ef.py", 1,
-       "1 3 {}".format(solver_name))
-# for farmer_cylinders, the first arg is num_scens and is required
-do_one("farmer/archive", "farmer_cylinders.py",  3,
-       "--num-scens 3 --max-iterations=50 --default-rho=1 --solver-name={} "
-       "--primal-dual-converger --primal-dual-converger-tol=0.5 --lagrangian --xhatshuffle "
-       "--intra-hub-conv-thresh -0.1 --rel-gap=1e-6".format(solver_name))
-do_one("farmer/archive", "farmer_cylinders.py",  5,
-       "--num-scens 3 --max-iterations=20 --default-rho=1 --solver-name={} "
-       "--use-norm-rho-converger --use-norm-rho-updater --rel-gap=1e-6 --lagrangian --lagranger "
-       "--xhatshuffle --fwph --W-fname=out_ws.txt --Xbar-fname=out_xbars.txt "
-       "--ph-track-progress --track-convergence=4 --track-xbar=4 --track-nonants=4 "
-       "--track-duals=4".format(solver_name))
-do_one("farmer/archive", "farmer_cylinders.py",  5,
-       "--num-scens 3 --max-iterations=20 --default-rho=1 --solver-name={} "
-       "--use-norm-rho-converger --use-norm-rho-updater --lagrangian --lagranger --xhatshuffle --fwph "
-       "--init-W-fname=out_ws.txt --init-Xbar-fname=out_xbars.txt --ph-track-progress --track-convergence=4 "  "--track-xbar=4 --track-nonants=4 --track-duals=4 ".format(solver_name))
-do_one("farmer", "farmer_lshapedhub.py", 2,
-       "--num-scens 3 --max-iterations=50 "
-       "--solver-name={} --rel-gap=0.0 "
-       "--xhatlshaped --max-solver-threads=1".format(solver_name))
-do_one("farmer/archive", "farmer_cylinders.py", 3,
-       "--num-scens 3 --max-iterations=50 "
-       "--default-rho=1 "
-       "--solver-name={} --lagranger --xhatlooper".format(solver_name))
-do_one("farmer", "../../mpisppy/generic_cylinders.py", 3,
-       "--module-name farmer --num-scens 6 "
-       "--rel-gap 0.001 --max-iterations=50 "
-       "--grad-rho --grad-order-stat 0.5 "
-       "--default-rho=2 --solver-name={} --lagrangian --xhatshuffle".format(solver_name))
-do_one("farmer", "../../mpisppy/generic_cylinders.py", 3,
-       "--module-name farmer --num-scens 6 "
-       "--rel-gap 0.001 --max-iterations=50 "
-       "--grad-rho --indep-denom "
-       "--default-rho=2 --solver-name={} --lagrangian --xhatshuffle".format(solver_name))
-do_one("farmer", "../../mpisppy/generic_cylinders.py", 4,
-       "--module-name farmer --num-scens 6 "
-       "--rel-gap 0.001 --max-iterations=50 "
-       "--ph-primal-hub --ph-dual --ph-dual-rescale-rho-factor=0.1 "
-       "--default-rho=2 --solver-name={} --lagrangian --xhatshuffle".format(solver_name))
-do_one("farmer", "../../mpisppy/generic_cylinders.py", 4,
-       "--module-name farmer "
-       "--num-scens 6 --max-iterations=50 --grad-rho --grad-order-stat 0.5 "
-       "--ph-dual-grad-order-stat 0.3 "
-       "--ph-primal-hub --ph-dual --ph-dual-rescale-rho-factor=0.1 --ph-dual-rho-multiplier 0.2 "
-       "--default-rho=1 --solver-name={} --lagrangian --xhatshuffle".format(solver_name))
+# -------- First part: farmer family --------
+if run_first_part:
+    do_one("farmer/CI", "farmer_ef.py", 1,
+           "1 3 {}".format(solver_name))
+    # for farmer_cylinders, the first arg is num_scens and is required
+    do_one("farmer/archive", "farmer_cylinders.py",  3,
+           "--num-scens 3 --max-iterations=50 --default-rho=1 --solver-name={} "
+           "--primal-dual-converger --primal-dual-converger-tol=0.5 --lagrangian --xhatshuffle "
+           "--intra-hub-conv-thresh -0.1 --rel-gap=1e-6".format(solver_name))
+    do_one("farmer/archive", "farmer_cylinders.py",  5,
+           "--num-scens 3 --max-iterations=20 --default-rho=1 --solver-name={} "
+           "--use-norm-rho-converger --use-norm-rho-updater --rel-gap=1e-6 --lagrangian --lagranger "
+           "--xhatshuffle --fwph --W-fname=out_ws.txt --Xbar-fname=out_xbars.txt "
+           "--ph-track-progress --track-convergence=4 --track-xbar=4 --track-nonants=4 "
+           "--track-duals=4".format(solver_name))
+    do_one("farmer/archive", "farmer_cylinders.py",  5,
+           "--num-scens 3 --max-iterations=20 --default-rho=1 --solver-name={} "
+           "--use-norm-rho-converger --use-norm-rho-updater --lagrangian --lagranger --xhatshuffle --fwph "
+           "--init-W-fname=out_ws.txt --init-Xbar-fname=out_xbars.txt --ph-track-progress --track-convergence=4 "  "--track-xbar=4 --track-nonants=4 --track-duals=4 ".format(solver_name))
+    do_one("farmer", "farmer_lshapedhub.py", 2,
+           "--num-scens 3 --max-iterations=50 "
+           "--solver-name={} --rel-gap=0.0 "
+           "--xhatlshaped --max-solver-threads=1".format(solver_name))
+    do_one("farmer/archive", "farmer_cylinders.py", 3,
+           "--num-scens 3 --max-iterations=50 "
+           "--default-rho=1 "
+           "--solver-name={} --lagranger --xhatlooper".format(solver_name))
+    do_one("farmer", "../../mpisppy/generic_cylinders.py", 3,
+           "--module-name farmer --num-scens 6 "
+           "--rel-gap 0.001 --max-iterations=50 "
+           "--grad-rho --grad-order-stat 0.5 "
+           "--default-rho=2 --solver-name={} --lagrangian --xhatshuffle".format(solver_name))
+    do_one("farmer", "../../mpisppy/generic_cylinders.py", 3,
+           "--module-name farmer --num-scens 6 "
+           "--rel-gap 0.001 --max-iterations=50 "
+           "--grad-rho --indep-denom "
+           "--default-rho=2 --solver-name={} --lagrangian --xhatshuffle".format(solver_name))
+    do_one("farmer", "../../mpisppy/generic_cylinders.py", 4,
+           "--module-name farmer --num-scens 6 "
+           "--rel-gap 0.001 --max-iterations=50 "
+           "--ph-primal-hub --ph-dual --ph-dual-rescale-rho-factor=0.1 "
+           "--default-rho=2 --solver-name={} --lagrangian --xhatshuffle".format(solver_name))
+    do_one("farmer", "../../mpisppy/generic_cylinders.py", 4,
+           "--module-name farmer "
+           "--num-scens 6 --max-iterations=50 --grad-rho --grad-order-stat 0.5 "
+           "--ph-dual-grad-order-stat 0.3 "
+           "--ph-primal-hub --ph-dual --ph-dual-rescale-rho-factor=0.1 --ph-dual-rho-multiplier 0.2 "
+           "--default-rho=1 --solver-name={} --lagrangian --xhatshuffle".format(solver_name))
 
-do_one("farmer/from_pysp", "concrete_ampl.py", 1, solver_name)
-do_one("farmer/from_pysp", "abstract.py", 1, solver_name)
+    do_one("farmer/from_pysp", "concrete_ampl.py", 1, solver_name)
+    do_one("farmer/from_pysp", "abstract.py", 1, solver_name)
 
-do_one("farmer/archive",
-       "farmer_cylinders.py", 4,
-       f"--num-scens 3 --max-iterations=20 --default-rho=1 --solver-name={solver_name}  --lagrangian --xhatshuffle --fwph --max-stalled-iters 1")
+    do_one("farmer/archive",
+           "farmer_cylinders.py", 4,
+           f"--num-scens 3 --max-iterations=20 --default-rho=1 --solver-name={solver_name}  --lagrangian --xhatshuffle --fwph --max-stalled-iters 1")
 
-do_one("farmer/archive",
-       "../../../mpisppy/generic_cylinders.py",
-       4,
-       "--module-name farmer --farmer-with-integer "
-       "--num-scens=3 "
-       "--lagrangian --ph-primal-hub "
-       "--max-iterations=10 --default-rho=0.1 "
-       "--relaxed-ph-rescale-rho-factor=10 "
-       "--relaxed-ph --relaxed-ph-fixer --xhatshuffle "
-       "--linearize-proximal-terms "
-       "--rel-gap=0.0 "
-       "--solver-name={}".format(solver_name))
+    do_one("farmer/archive",
+           "../../../mpisppy/generic_cylinders.py",
+           4,
+           "--module-name farmer --farmer-with-integer "
+           "--num-scens=3 "
+           "--lagrangian --ph-primal-hub "
+           "--max-iterations=10 --default-rho=0.1 "
+           "--relaxed-ph-rescale-rho-factor=10 "
+           "--relaxed-ph --relaxed-ph-fixer --xhatshuffle "
+           "--linearize-proximal-terms "
+           "--rel-gap=0.0 "
+           "--solver-name={}".format(solver_name))
 
-# NOTE: Pyomo OBBT does not support persistent solvers as of Aug 2025
-direct_solver_name = solver_name.replace("_persistent", "_direct") if "_persistent" in solver_name else solver_name
-do_one("netdes", "netdes_cylinders.py", 4,
-       "--max-iterations=3 --instance-name=network-10-20-L-01 "
-       "--solver-name={} --rel-gap=0.0 --default-rho=10000 --presolve --obbt --obbt-solver={} "
-       "--slammax --subgradient-hub --xhatshuffle --cross-scenario-cuts --max-solver-threads=2".format(solver_name, direct_solver_name))
+# -------- Second part: netdes, sizes, sslp, hydro, aircond, MMW --------
+if run_second_part:
+    # NOTE: Pyomo OBBT does not support persistent solvers as of Aug 2025
+    direct_solver_name = solver_name.replace("_persistent", "_direct") if "_persistent" in solver_name else solver_name
+    do_one("netdes", "netdes_cylinders.py", 4,
+           "--max-iterations=3 --instance-name=network-10-20-L-01 "
+           "--solver-name={} --rel-gap=0.0 --default-rho=10000 --presolve --obbt --obbt-solver={} "
+           "--slammax --subgradient-hub --xhatshuffle --cross-scenario-cuts --max-solver-threads=2".format(solver_name, direct_solver_name))
 
-# sizes is slow for xpress so try linearizing the proximal term.
-do_one("sizes",
-       "sizes_cylinders.py",
-       3,
-       "--config-file=sizes_config.txt "
-       "--num-scens=10 "
-       "--solver-name={}".format(solver_name))
+    # sizes is slow for xpress so try linearizing the proximal term.
+    do_one("sizes",
+           "sizes_cylinders.py",
+           3,
+           "--config-file=sizes_config.txt "
+           "--num-scens=10 "
+           "--solver-name={}".format(solver_name))
 
-do_one("sizes",
-       "sizes_cylinders.py",
-       3,
-       "--linearize-proximal-terms "
-       "--num-scens=10 --max-iterations=5 "
-       "--default-rho=1 --lagrangian --xhatxbar "
-       "--iter0-mipgap=0.01 --iterk-mipgap=0.001 "
-       "--solver-name={}".format(solver_name))
+    do_one("sizes",
+           "sizes_cylinders.py",
+           3,
+           "--linearize-proximal-terms "
+           "--num-scens=10 --max-iterations=5 "
+           "--default-rho=1 --lagrangian --xhatxbar "
+           "--iter0-mipgap=0.01 --iterk-mipgap=0.001 "
+           "--solver-name={}".format(solver_name))
 
-do_one("sizes", "sizes_pysp.py", 1, "3 {}".format(solver_name))
-do_one("sslp",
-       "sslp_cylinders.py",
-       4,
-       "--instance-name=sslp_15_45_10 "
-       "--integer-relax-then-enforce "
-       "--integer-relax-then-enforce-ratio=0.8 "
-       "--lagrangian "
-       "--reduced-costs-rho "
-       "--max-iterations=20 --default-rho=1e-6 "
-       "--reduced-costs --rc-fixer --xhatshuffle "
-       "--linearize-proximal-terms "
-       "--rel-gap=0.0 --surrogate-nonant "
-       "--use-primal-dual-rho-updater --primal-dual-rho-update-threshold=10 "
-       "--solver-name={}".format(solver_name))
-do_one("hydro", "hydro_cylinders.py", 3,
-       "--branching-factors \'3 3\' --max-iterations=100 "
-       "--default-rho=1 --xhatshuffle --lagrangian "
-       "--solver-name={} --stage2EFsolvern={}".format(solver_name, solver_name))
+    do_one("sizes", "sizes_pysp.py", 1, "3 {}".format(solver_name))
+    do_one("sslp",
+           "sslp_cylinders.py",
+           4,
+           "--instance-name=sslp_15_45_10 "
+           "--integer-relax-then-enforce "
+           "--integer-relax-then-enforce-ratio=0.8 "
+           "--lagrangian "
+           "--reduced-costs-rho "
+           "--max-iterations=20 --default-rho=1e-6 "
+           "--reduced-costs --rc-fixer --xhatshuffle "
+           "--linearize-proximal-terms "
+           "--rel-gap=0.0 --surrogate-nonant "
+           "--use-primal-dual-rho-updater --primal-dual-rho-update-threshold=10 "
+           "--solver-name={}".format(solver_name))
+    do_one("hydro", "hydro_cylinders.py", 3,
+           "--branching-factors \'3 3\' --max-iterations=100 "
+           "--default-rho=1 --xhatshuffle --lagrangian "
+           "--solver-name={} --stage2EFsolvern={}".format(solver_name, solver_name))
 
-do_one("hydro", "hydro_cylinders_pysp.py", 3,
-       "--max-iterations=100 "
-       "--default-rho=1 --xhatshuffle --lagrangian "
-       "--solver-name={}".format(solver_name))
+    do_one("hydro", "hydro_cylinders_pysp.py", 3,
+           "--max-iterations=100 "
+           "--default-rho=1 --xhatshuffle --lagrangian "
+           "--solver-name={}".format(solver_name))
 
-# the next might hang with 6 ranks
-do_one("aircond", "aircond_cylinders.py", 3,
-       "--branching-factors \'4 3 2\' --max-iterations=100 "
-       "--default-rho=1 --lagrangian --xhatshuffle "
-       "--solver-name={}".format(solver_name))
-do_one("aircond", "aircond_ama.py", 3,
-       "--branching-factors \'3 3\' --max-iterations=100 "
-       "--default-rho=1 --lagrangian --xhatshuffle "
-       "--solver-name={}".format(solver_name))
+    # the next might hang with 6 ranks
+    do_one("aircond", "aircond_cylinders.py", 3,
+           "--branching-factors \'4 3 2\' --max-iterations=100 "
+           "--default-rho=1 --lagrangian --xhatshuffle "
+           "--solver-name={}".format(solver_name))
+    do_one("aircond", "aircond_ama.py", 3,
+           "--branching-factors \'3 3\' --max-iterations=100 "
+           "--default-rho=1 --lagrangian --xhatshuffle "
+           "--solver-name={}".format(solver_name))
 
-#=========MMW TESTS==========
-# do_one_mmw is special
-do_one_mmw("farmer/CI", "farmer", f"python farmer_ef.py 1 3 0 {solver_name}", "farmer_root_nonants.npy", f"--MMW-num-batches=5 --confidence-level 0.95 --MMW-batch-size=10 --start-scen 4 --EF-solver-name={solver_name}")
+    #=========MMW TESTS==========
+    # do_one_mmw is special
+    do_one_mmw("farmer/CI", "farmer", f"python farmer_ef.py 1 3 0 {solver_name}", "farmer_root_nonants.npy", f"--MMW-num-batches=5 --confidence-level 0.95 --MMW-batch-size=10 --start-scen 4 --EF-solver-name={solver_name}")
 
 
 #============================


### PR DESCRIPTION
## Summary

- Adds `--first-part-only` and `--second-part-only` flags to `examples/run_all.py` that split the pre-`nouc` work roughly in half (first part: farmer family; second part: netdes/sizes/sslp/hydro/aircond/MMW). Neither flag passed = both parts run, preserving existing behavior.
- Splits the `runall_persistent` and `runall` jobs in `.github/workflows/test_pr_and_main.yml` into four jobs (persistent/direct x part1/part2). `run_all.py` was the bottleneck for PR CI; the four parallel jobs should cut end-to-end wall time roughly in half.
- `coverage-report` `needs:` list updated for the new job names; coverage artifact names differentiated (`-part1` / `-part2`).
- `run_coverage.bash` is unchanged: a bare `run_all.py SOLVER "" nouc` (no part flag) still runs both parts, so local coverage stays aligned with the two CI halves.

## Test plan

- [ ] CI: the four `runall` jobs (persistent/direct x part1/part2) run in parallel and both pass per solver
- [ ] `coverage-report` combines artifacts from all four and succeeds
- [ ] Local: `python examples/run_all.py <solver> "" nouc` still runs all pre-`nouc` examples
- [ ] Local: `python examples/run_all.py <solver> "" nouc --first-part-only` runs only the farmer-family block
- [ ] Local: `python examples/run_all.py <solver> "" nouc --second-part-only` runs only the netdes/sizes/sslp/hydro/aircond/MMW block

🤖 Generated with [Claude Code](https://claude.com/claude-code)