### PR TITLE
Remove runall aggregator jobs now that branch protection uses part names

### DIFF
--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -124,32 +124,6 @@ jobs:
           if-no-files-found: ignore
           include-hidden-files: true
 
-  runall_persistent:
-    name: run_all.py persistent solver
-    runs-on: ubuntu-latest
-    needs: [runall_persistent_part1, runall_persistent_part2]
-    if: always()
-    steps:
-      - name: Aggregate persistent run_all parts
-        run: |
-          if [[ "${{ needs.runall_persistent_part1.result }}" != "success" || "${{ needs.runall_persistent_part2.result }}" != "success" ]]; then
-            echo "part1=${{ needs.runall_persistent_part1.result }} part2=${{ needs.runall_persistent_part2.result }}"
-            exit 1
-          fi
-
-  runall:
-    name: run_all.py direct solver
-    runs-on: ubuntu-latest
-    needs: [runall_part1, runall_part2]
-    if: always()
-    steps:
-      - name: Aggregate direct run_all parts
-        run: |
-          if [[ "${{ needs.runall_part1.result }}" != "success" || "${{ needs.runall_part2.result }}" != "success" ]]; then
-            echo "part1=${{ needs.runall_part1.result }} part2=${{ needs.runall_part2.result }}"
-            exit 1
-          fi
-
   runall_persistent_part1:
     name: run_all.py persistent solver (part 1)
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Follow-up to #654. Removes the two aggregator jobs (`run_all.py persistent solver` and `run_all.py direct solver`) that existed solely to satisfy the old required-check names on branch protection. Branch protection has been updated to require the four part-1/part-2 checks directly, so the aggregators are dead weight.

## Test plan

- [ ] CI: the four `run_all.py ... (part 1|2)` checks run and pass
- [ ] The two old aggregator checks no longer appear on the PR page

🤖 Generated with [Claude Code](https://claude.com/claude-code)