### PR TITLE
schur-complement CI: don't fail install on pyomo download-extensions

### DIFF
--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -314,7 +314,7 @@ jobs:
           git clone https://github.com/pyomo/pyomo.git
           cd pyomo/
           pip install -e .
-          pyomo download-extensions
+          pyomo download-extensions || echo "WARNING: pyomo download-extensions had failures (often a netlib.org timeout fetching gjh); not required by test_sc.py"
           pyomo build-extensions
           cd ../
           pip install git+https://github.com/parapint/parapint.git


### PR DESCRIPTION
## Summary

The `schur-complement` job's `Install dependencies` step runs `pyomo download-extensions`, which fetches optional artifacts (`gjh` from `netlib.org`, `mc++`, AMPL GSL). The `netlib.org` GET intermittently hangs (~2.5 min until `URLError [Errno 110]`), causing `pyomo download-extensions` to exit non-zero and the whole install step to fail. The schur-complement job is currently failing on roughly half of all PRs because of this.

`mpisppy/tests/test_sc.py` only imports `parapint`, which depends on `pymumps` (installed via conda earlier in the step) and PyNumero. Neither `gjh` nor `mc++` is referenced anywhere in the Schur-complement path, and `pyomo build-extensions` (which runs on the next line) builds the APPSI/PyNumero C extensions independently of whatever `download-extensions` managed to fetch.

This makes the line non-fatal with an explicit warning. Transient `netlib.org` timeouts no longer red-X the job. If a future test actually needs `gjh`/`mc++`, `build-extensions` will fail loudly and the warning in the log explains why.

## Test plan

- [x] Open this PR; confirm `schur-complement` job passes (or, if it fails, that the failure is in `Test with pytest`, not in the install step).
- [ ] Optional: re-run the job a few times to spot-check that the install step no longer flakes when `netlib.org` is unhappy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)