### PR TITLE
netdes: add average_scenario_creator for Jensen's bound

### DIFF
--- a/examples/netdes/netdes.py
+++ b/examples/netdes/netdes.py
@@ -21,23 +21,32 @@ import numpy as np
 from parse import parse
 
 
-def scenario_creator(scenario_name, path=None):
-    if path is None:
-        raise RuntimeError('Must provide the name of the .dat file '
-                           'containing the instance data via the '
-                           'path argument to scenario_creator')
-    
-    scenario_ix = _get_scenario_ix(scenario_name)
-    model = build_scenario_model(path, scenario_ix)
+# ===========================================================================
+# Underscore helpers (best-practice pattern -- see doc/src/jensens.rst):
+#
+#   _scenario_data : pure-Python data dict for one scenario, no Pyomo
+#   _build_model   : build the Pyomo model from a data dict
+#
+# scenario_creator and average_scenario_creator both go through these
+# helpers so the model-build code lives in exactly one place.
+# ===========================================================================
 
-    # now attach the one and only scenario tree node
-    sputils.attach_root_node(model, model.FirstStageCost, [model.x[:,:], ])
-    
-    return model
+def _scenario_data(scenario_ix, path):
+    """Return the full data dict for one scenario as plain Python.
+
+    Thin wrapper over parse(...) so scenario_creator and
+    average_scenario_creator share the same data-loading entry point.
+    """
+    return parse(path, scenario_ix=scenario_ix)
 
 
-def build_scenario_model(fname, scenario_ix):
-    data = parse(fname, scenario_ix=scenario_ix)
+def _build_model(data, probability):
+    """Build the network-design Pyomo model from a data dict.
+
+    Shared by scenario_creator and average_scenario_creator. The dict
+    must have keys N, A, el, c, d, u, b (the first four are
+    deterministic; d, u, b are the second-stage stochastic data).
+    """
     num_nodes = data['N']
     adj = data['A']    # Adjacency matrix
     edges = data['el'] # Edge list
@@ -45,14 +54,13 @@ def build_scenario_model(fname, scenario_ix):
     d = data['d']      # Second-stage cost matrix (per edge)
     u = data['u']      # Capacity of each arc
     b = data['b']      # Demand of each node
-    p = data['p']      # Probability of scenario
 
     model = pyo.ConcreteModel()
     model.x = pyo.Var(edges, domain=pyo.Binary)           # First stage vars
     model.y = pyo.Var(edges, domain=pyo.NonNegativeReals) # Second stage vars
 
     model.edges = edges
-    model._mpisppy_probability = p
+    model._mpisppy_probability = probability
 
     ''' Objective '''
     model.FirstStageCost  = pyo.quicksum(c[e] * model.x[e] for e in edges)
@@ -63,7 +71,7 @@ def build_scenario_model(fname, scenario_ix):
     ''' Variable upper bound constraints on each edge '''
     model.vubs = pyo.ConstraintList()
     for e in edges:
-        expr = model.y[e] - u[e] * model.x[e] 
+        expr = model.y[e] - u[e] * model.x[e]
         model.vubs.add(expr <= 0)
 
     ''' Flow balance constraints for each node '''
@@ -75,6 +83,84 @@ def build_scenario_model(fname, scenario_ix):
               pyo.quicksum(model.y[j,i] for j in in_nbs)
         model.bals.add(lhs == b[i])
 
+    return model
+
+
+def scenario_creator(scenario_name, path=None):
+    if path is None:
+        raise RuntimeError('Must provide the name of the .dat file '
+                           'containing the instance data via the '
+                           'path argument to scenario_creator')
+
+    scenario_ix = _get_scenario_ix(scenario_name)
+    data = _scenario_data(scenario_ix, path)
+    model = _build_model(data, probability=data['p'])
+
+    # now attach the one and only scenario tree node
+    sputils.attach_root_node(model, model.FirstStageCost, [model.x[:,:], ])
+
+    return model
+
+
+def average_scenario_creator(scenario_name, path=None):
+    """Build the average scenario for ``--*-try-jensens-first``.
+
+    Constructs a single deterministic model whose second-stage data
+    (d, u, b) is the probability-weighted mean of the per-scenario
+    data shipped in the instance file. The first-stage data (c) and
+    network topology (N, A, el) are deterministic and copied through.
+    ``_mpisppy_probability`` is 1.0.
+
+    Every rank constructs an identical model independently. The
+    instance file is parsed once.
+
+    Jensen's-bound validity (see doc/src/jensens.rst):
+
+      * netdes has continuous recourse (``model.y`` is
+        ``NonNegativeReals``), so the integer-recourse guard on the
+        outer-bound path will pass.
+      * Randomness lives in the second-stage objective coefficients
+        ``d``, the per-arc capacity ``u`` (which appears in
+        ``y[e] - u[e]*x[e] <= 0``, i.e. as an effective RHS once x
+        is fixed), and the node demand RHS ``b``. RHS-only randomness
+        gives a recourse value that is convex in those parameters,
+        so the Jensen's outer bound is valid for randomness in
+        ``u`` and ``b``. Cost-coefficient randomness (``d``) makes
+        the recourse value concave in ``d``; users who require a
+        provably valid Jensen's *outer* bound should be aware of
+        this and decide whether the bound is meaningful for their
+        instance.
+      * The xhat (inner-bound) path is unaffected by the convexity
+        question -- it uses the average scenario only as a source of
+        a candidate first-stage x, which is then honestly evaluated
+        across all real scenarios.
+    """
+    if path is None:
+        raise RuntimeError('Must provide the name of the .dat file '
+                           'containing the instance data via the '
+                           'path argument to average_scenario_creator')
+
+    full = parse(path, scenario_ix=None)
+    K = full['K']
+    p = full['p']
+    # Probability-weighted mean across all scenarios. Netdes ships
+    # non-uniform probabilities in general, so this is NOT a simple
+    # arithmetic mean.
+    avg_d = sum(p[k] * full['d'][k] for k in range(K))
+    avg_u = sum(p[k] * full['u'][k] for k in range(K))
+    avg_b = sum(p[k] * full['b'][k] for k in range(K))
+
+    avg_data = {
+        'N': full['N'],
+        'A': full['A'],
+        'el': full['el'],
+        'c': full['c'],
+        'd': avg_d,
+        'u': avg_u,
+        'b': avg_b,
+    }
+    model = _build_model(avg_data, probability=1.0)
+    sputils.attach_root_node(model, model.FirstStageCost, [model.x[:,:], ])
     return model
 
 

--- a/examples/run_all.py
+++ b/examples/run_all.py
@@ -134,7 +134,7 @@ def do_one_mmw(dirname, modname, runefstring, npyfile, mmwargstring):
     os.chdir("..")
     os.chdir("..")  # moved to CI directory
 
-# -------- First part: farmer family --------
+# -------- First part: farmer family, usar, netdes --------
 if run_first_part:
     do_one("farmer/CI", "farmer_ef.py", 1,
            "1 3 {}".format(solver_name))
@@ -218,8 +218,7 @@ if run_first_part:
            f"--max-iterations=3 --default-rho=1 --lagrangian --xhatshuffle "
            f"--output-dir=solutions_ws {usar_problem_args}")
 
-# -------- Second part: netdes, sizes, sslp, hydro, aircond, MMW --------
-if run_second_part:
+    # netdes
     # NOTE: Pyomo OBBT does not support persistent solvers as of Aug 2025
     direct_solver_name = solver_name.replace("_persistent", "_direct") if "_persistent" in solver_name else solver_name
     do_one("netdes", "netdes_cylinders.py", 4,
@@ -239,6 +238,22 @@ if run_second_part:
            "--subgradient-hub --xhatshuffle --max-solver-threads=2 "
            "--solver-name={}".format(solver_name))
 
+    # Smoke-test netdes's average_scenario_creator via --*-try-jensens-first.
+    # PH hub + lagrangian + xhatshuffle = 3 cylinders. The lagrangian spoke
+    # solves the average scenario before iter-0 and sends the result as its
+    # first outer bound; the xhatshuffle spoke uses the average scenario's
+    # first-stage solution as its first xhat candidate.
+    do_one("netdes", "../../mpisppy/generic_cylinders.py", 3,
+           "--module-name netdes --max-iterations=3 "
+           "--instance-name=network-10-20-L-01 --netdes-data-path ./data "
+           "--rel-gap=0.0 --default-rho=10000 --presolve "
+           "--lagrangian --xhatshuffle "
+           "--lagrangian-try-jensens-first --xhatshuffle-try-jensens-first "
+           "--max-solver-threads=2 "
+           "--solver-name={}".format(solver_name))
+
+# -------- Second part: sizes, sslp, hydro, aircond, MMW --------
+if run_second_part:
     # sizes is slow for xpress so try linearizing the proximal term.
     do_one("sizes",
            "sizes_cylinders.py",

--- a/examples/run_all.py
+++ b/examples/run_all.py
@@ -238,11 +238,16 @@ if run_first_part:
            "--subgradient-hub --xhatshuffle --max-solver-threads=2 "
            "--solver-name={}".format(solver_name))
 
-    # Smoke-test netdes's average_scenario_creator via --*-try-jensens-first.
-    # PH hub + lagrangian + xhatshuffle = 3 cylinders. The lagrangian spoke
-    # solves the average scenario before iter-0 and sends the result as its
-    # first outer bound; the xhatshuffle spoke uses the average scenario's
-    # first-stage solution as its first xhat candidate.
+    # Smoke-test netdes's average_scenario_creator end-to-end on both
+    # jensens paths. PH hub + lagrangian + xhatshuffle = 3 cylinders.
+    # Lagrangian sends the average-scenario dual bound as its first
+    # outer bound. Xhatshuffle takes the average-scenario primal x as
+    # its first xhat candidate and evaluates it across the real
+    # scenarios; that evaluation often fails (the average x can be
+    # infeasible for a real demand, and netdes has no penalty/dummy
+    # variable), so the xhat-jensens path is required to silently skip
+    # such candidates rather than crash. This run exercises that
+    # tolerance.
     do_one("netdes", "../../mpisppy/generic_cylinders.py", 3,
            "--module-name netdes --max-iterations=3 "
            "--instance-name=network-10-20-L-01 --netdes-data-path ./data "

--- a/mpisppy/cylinders/_jensens_mixin.py
+++ b/mpisppy/cylinders/_jensens_mixin.py
@@ -189,3 +189,28 @@ class _JensensMixin:
         if self.opt.no_incumbent_prob() != 0.0:
             return None
         return self.opt.Eobjective(verbose=False)
+
+    def _try_average_scenario_xhat(self):
+        """One-shot helper for xhat spokes that opt in via
+        ``--*-try-jensens-first``. No-op when the flag is off.
+
+        When enabled, builds the average scenario, solves it, evaluates
+        its first-stage solution as a candidate xhat across all real
+        scenarios, and -- if every scenario is feasible at that xhat --
+        calls ``self.update_if_improving`` with the resulting expected
+        objective. If any scenario is infeasible, silently skips: the
+        spoke's normal main loop will keep trying other candidates.
+
+        Each xhat spoke's ``main()`` calls this helper exactly once, in
+        place of the inline four-line block, so the integer-recourse
+        tolerance, infeasibility skipping, and bound-update logic live
+        in one place.
+        """
+        if not self._jensens_enabled():
+            return
+        avg_scenario = self._jensens_build_avg()
+        _, nonant_values = self._jensens_solve(avg_scenario)
+        cache = self._jensens_pack_nonant_cache(nonant_values)
+        Eobj = self._jensens_evaluate_xhat(cache)
+        if Eobj is not None:
+            self.update_if_improving(Eobj)

--- a/mpisppy/cylinders/_jensens_mixin.py
+++ b/mpisppy/cylinders/_jensens_mixin.py
@@ -156,3 +156,36 @@ class _JensensMixin:
         cache format consumed by Xhat_Eval._fix_nonants / .evaluate.
         Two-stage: ROOT only."""
         return {"ROOT": np.array(nonant_values, dtype='d')}
+
+    def _jensens_evaluate_xhat(self, nonant_cache):
+        """Evaluate the average-scenario nonants as a candidate xhat
+        across all real scenarios and return the expected objective, or
+        ``None`` if at least one scenario is infeasible at this xhat.
+
+        Mirrors the two-stage branch of
+        ``mpisppy.extensions.xhatbase.XhatBase._try_one``: fix nonants,
+        solve every local scenario with ``need_solution=False`` (so
+        infeasible solves don't raise), then check
+        ``self.opt.no_incumbent_prob()``. If any scenario was infeasible,
+        return ``None`` so the caller can silently skip the candidate;
+        every xhat spoke already tolerates a None-valued xhat in its
+        normal main loop, since infeasibility is a routine outcome of
+        candidate evaluation.
+
+        We deliberately do NOT use ``Xhat_Eval.evaluate`` here.
+        ``evaluate`` calls ``solve_loop(compute_val_at_nonant=True)``,
+        which then unconditionally evaluates ``pyo.value(objfct)`` on
+        each local scenario, crashing when a solve produced no solution
+        (e.g. infeasibility with no slack/penalty variables).
+        """
+        self.opt._fix_nonants(nonant_cache)
+        solver_options = self.opt.options.get("solver_options")
+        self.opt.solve_loop(
+            solver_options=solver_options,
+            verbose=False,
+            tee=False,
+            need_solution=False,
+        )
+        if self.opt.no_incumbent_prob() != 0.0:
+            return None
+        return self.opt.Eobjective(verbose=False)

--- a/mpisppy/cylinders/xhatlooper_bounder.py
+++ b/mpisppy/cylinders/xhatlooper_bounder.py
@@ -36,8 +36,9 @@ class XhatLooperInnerBound(_JensensMixin, XhatInnerBoundBase):
             avg_scenario = self._jensens_build_avg()
             _, nonant_values = self._jensens_solve(avg_scenario)
             cache = self._jensens_pack_nonant_cache(nonant_values)
-            Eobj = self.opt.evaluate(cache)
-            self.update_if_improving(Eobj)
+            Eobj = self._jensens_evaluate_xhat(cache)
+            if Eobj is not None:
+                self.update_if_improving(Eobj)
 
         scen_limit = self.opt.options['xhat_looper_options']['scen_limit']
 

--- a/mpisppy/cylinders/xhatlooper_bounder.py
+++ b/mpisppy/cylinders/xhatlooper_bounder.py
@@ -32,13 +32,8 @@ class XhatLooperInnerBound(_JensensMixin, XhatInnerBoundBase):
 
         xhatter = self.xhat_prep()
 
-        if self._jensens_enabled():
-            avg_scenario = self._jensens_build_avg()
-            _, nonant_values = self._jensens_solve(avg_scenario)
-            cache = self._jensens_pack_nonant_cache(nonant_values)
-            Eobj = self._jensens_evaluate_xhat(cache)
-            if Eobj is not None:
-                self.update_if_improving(Eobj)
+        # No-op unless --xhatlooper-try-jensens-first is set.
+        self._try_average_scenario_xhat()
 
         scen_limit = self.opt.options['xhat_looper_options']['scen_limit']
 

--- a/mpisppy/cylinders/xhatshufflelooper_bounder.py
+++ b/mpisppy/cylinders/xhatshufflelooper_bounder.py
@@ -75,8 +75,9 @@ class XhatShuffleInnerBound(_JensensMixin, XhatInnerBoundBase):
             # candidate xhat).
             _, nonant_values = self._jensens_solve(avg_scenario)
             cache = self._jensens_pack_nonant_cache(nonant_values)
-            Eobj = self.opt.evaluate(cache)
-            self.update_if_improving(Eobj)
+            Eobj = self._jensens_evaluate_xhat(cache)
+            if Eobj is not None:
+                self.update_if_improving(Eobj)
 
         if "reverse" in self.opt.options["xhat_looper_options"]:
             self.reverse = self.opt.options["xhat_looper_options"]["reverse"]

--- a/mpisppy/cylinders/xhatshufflelooper_bounder.py
+++ b/mpisppy/cylinders/xhatshufflelooper_bounder.py
@@ -68,16 +68,9 @@ class XhatShuffleInnerBound(_JensensMixin, XhatInnerBoundBase):
 
         self.xhat_prep()
 
-        if self._jensens_enabled():
-            avg_scenario = self._jensens_build_avg()
-            # deliberately NO integer-safety check — xhat path tolerates
-            # integer recourse (the average-scenario solution is only a
-            # candidate xhat).
-            _, nonant_values = self._jensens_solve(avg_scenario)
-            cache = self._jensens_pack_nonant_cache(nonant_values)
-            Eobj = self._jensens_evaluate_xhat(cache)
-            if Eobj is not None:
-                self.update_if_improving(Eobj)
+        # No-op unless --xhatshuffle-try-jensens-first is set. Tolerates
+        # integer recourse and per-scenario infeasibility (silent skip).
+        self._try_average_scenario_xhat()
 
         if "reverse" in self.opt.options["xhat_looper_options"]:
             self.reverse = self.opt.options["xhat_looper_options"]["reverse"]

--- a/mpisppy/cylinders/xhatspecific_bounder.py
+++ b/mpisppy/cylinders/xhatspecific_bounder.py
@@ -47,8 +47,9 @@ class XhatSpecificInnerBound(_JensensMixin, XhatInnerBoundBase):
             avg_scenario = self._jensens_build_avg()
             _, nonant_values = self._jensens_solve(avg_scenario)
             cache = self._jensens_pack_nonant_cache(nonant_values)
-            Eobj = self.opt.evaluate(cache)
-            self.update_if_improving(Eobj)
+            Eobj = self._jensens_evaluate_xhat(cache)
+            if Eobj is not None:
+                self.update_if_improving(Eobj)
 
         ib_iter = 1  # ib is for inner bound
         while (not self.got_kill_signal()):

--- a/mpisppy/cylinders/xhatspecific_bounder.py
+++ b/mpisppy/cylinders/xhatspecific_bounder.py
@@ -43,13 +43,8 @@ class XhatSpecificInnerBound(_JensensMixin, XhatInnerBoundBase):
 
         xhatter = self.xhat_prep()
 
-        if self._jensens_enabled():
-            avg_scenario = self._jensens_build_avg()
-            _, nonant_values = self._jensens_solve(avg_scenario)
-            cache = self._jensens_pack_nonant_cache(nonant_values)
-            Eobj = self._jensens_evaluate_xhat(cache)
-            if Eobj is not None:
-                self.update_if_improving(Eobj)
+        # No-op unless --xhatspecific-try-jensens-first is set.
+        self._try_average_scenario_xhat()
 
         ib_iter = 1  # ib is for inner bound
         while (not self.got_kill_signal()):

--- a/mpisppy/cylinders/xhatxbar_bounder.py
+++ b/mpisppy/cylinders/xhatxbar_bounder.py
@@ -62,13 +62,8 @@ class XhatXbarInnerBound(_JensensMixin, XhatInnerBoundBase):
 
         xhatter = self.xhat_prep()
 
-        if self._jensens_enabled():
-            avg_scenario = self._jensens_build_avg()
-            _, nonant_values = self._jensens_solve(avg_scenario)
-            cache = self._jensens_pack_nonant_cache(nonant_values)
-            Eobj = self._jensens_evaluate_xhat(cache)
-            if Eobj is not None:
-                self.update_if_improving(Eobj)
+        # No-op unless --xhatxbar-try-jensens-first is set.
+        self._try_average_scenario_xhat()
 
         ib_iter = 1  # ib is for inner bound
         while (not self.got_kill_signal()):

--- a/mpisppy/cylinders/xhatxbar_bounder.py
+++ b/mpisppy/cylinders/xhatxbar_bounder.py
@@ -66,8 +66,9 @@ class XhatXbarInnerBound(_JensensMixin, XhatInnerBoundBase):
             avg_scenario = self._jensens_build_avg()
             _, nonant_values = self._jensens_solve(avg_scenario)
             cache = self._jensens_pack_nonant_cache(nonant_values)
-            Eobj = self.opt.evaluate(cache)
-            self.update_if_improving(Eobj)
+            Eobj = self._jensens_evaluate_xhat(cache)
+            if Eobj is not None:
+                self.update_if_improving(Eobj)
 
         ib_iter = 1  # ib is for inner bound
         while (not self.got_kill_signal()):

--- a/mpisppy/tests/test_jensens.py
+++ b/mpisppy/tests/test_jensens.py
@@ -302,5 +302,145 @@ class TestSizesInvalidScenarioCount(unittest.TestCase):
             sizes.average_scenario_creator("Average", scenario_count=5)
 
 
+class _StubXhatOpt:
+    """Stub stand-in for the Xhat_Eval that lives at spoke.opt.
+
+    Captures the calls _jensens_evaluate_xhat makes and returns
+    parameterized values for the feasibility check. Lets us exercise
+    both the feasible path (returns Eobj, caller updates the bound)
+    and the infeasible path (returns None, caller silently skips)
+    without standing up real MPI machinery.
+    """
+
+    def __init__(self, *, infeas_prob, eobj, options=None):
+        self._infeas_prob = infeas_prob
+        self._eobj = eobj
+        self.options = options if options is not None else {}
+        self.fix_calls = []
+        self.solve_loop_calls = []
+
+    def _fix_nonants(self, cache):
+        self.fix_calls.append(cache)
+
+    def solve_loop(self, **kwargs):
+        self.solve_loop_calls.append(kwargs)
+
+    def no_incumbent_prob(self):
+        return self._infeas_prob
+
+    def Eobjective(self, verbose=False):
+        return self._eobj
+
+
+class _StubXhatSpoke(_JensensMixin):
+    """Mixin host that records update_if_improving calls so we can
+    assert the helper's branching behavior."""
+
+    def __init__(self, opt):
+        self.opt = opt
+        self.bound_updates = []
+
+    def update_if_improving(self, Eobj):
+        self.bound_updates.append(Eobj)
+
+
+class TestJensensEvaluateXhat(unittest.TestCase):
+    """Unit tests for _JensensMixin._jensens_evaluate_xhat. The real
+    code path goes through Xhat_Eval; we stub it to isolate the
+    feasibility branching that fixes the crash on infeasible recourse.
+    """
+
+    def test_returns_eobj_when_all_scenarios_feasible(self):
+        opt = _StubXhatOpt(infeas_prob=0.0, eobj=42.5)
+        sp = _StubXhatSpoke(opt)
+        result = sp._jensens_evaluate_xhat({"ROOT": [1.0, 2.0]})
+        self.assertEqual(result, 42.5)
+
+    def test_returns_none_when_any_scenario_infeasible(self):
+        opt = _StubXhatOpt(infeas_prob=0.25, eobj=999.0)  # eobj should be ignored
+        sp = _StubXhatSpoke(opt)
+        result = sp._jensens_evaluate_xhat({"ROOT": [1.0, 2.0]})
+        self.assertIsNone(result)
+
+    def test_passes_cache_to_fix_nonants(self):
+        opt = _StubXhatOpt(infeas_prob=0.0, eobj=1.0)
+        sp = _StubXhatSpoke(opt)
+        cache = {"ROOT": [3.0, 4.0]}
+        sp._jensens_evaluate_xhat(cache)
+        self.assertEqual(opt.fix_calls, [cache])
+
+    def test_solve_loop_called_with_need_solution_false(self):
+        # critical: with need_solution=True (the buggy old path), an
+        # infeasible solve crashes downstream on pyo.value(objfct).
+        opt = _StubXhatOpt(infeas_prob=0.0, eobj=1.0)
+        sp = _StubXhatSpoke(opt)
+        sp._jensens_evaluate_xhat({"ROOT": [1.0]})
+        self.assertEqual(len(opt.solve_loop_calls), 1)
+        self.assertFalse(opt.solve_loop_calls[0]["need_solution"])
+
+    def test_solver_options_threaded_from_opt_options(self):
+        opt = _StubXhatOpt(infeas_prob=0.0, eobj=1.0,
+                           options={"solver_options": {"mipgap": 0.01}})
+        sp = _StubXhatSpoke(opt)
+        sp._jensens_evaluate_xhat({"ROOT": [1.0]})
+        self.assertEqual(opt.solve_loop_calls[0]["solver_options"],
+                         {"mipgap": 0.01})
+
+
+class TestTryAverageScenarioXhat(unittest.TestCase):
+    """Unit tests for _JensensMixin._try_average_scenario_xhat -- the
+    one-shot helper each xhat spoke calls instead of inlining a
+    four-line block. Covers the fast-return when the flag is off, the
+    feasible path that updates the bound, and the infeasible path that
+    silently skips.
+    """
+
+    def _opt_with_jensens(self, *, jensens_dict=None, **stub_kwargs):
+        opt = _StubXhatOpt(**stub_kwargs)
+        if jensens_dict is not None:
+            opt.options["jensens"] = jensens_dict
+            opt.options["solver_name"] = solver_name
+            opt.options["iterk_solver_options"] = {}
+        # all_scenario_names is read by _jensens_build_avg
+        opt.all_scenario_names = farmer.scenario_names_creator(3)
+        return opt
+
+    def test_noop_when_flag_off(self):
+        opt = self._opt_with_jensens(infeas_prob=0.0, eobj=1.0)  # no jensens key
+        sp = _StubXhatSpoke(opt)
+        sp._try_average_scenario_xhat()
+        self.assertEqual(sp.bound_updates, [])
+        self.assertEqual(opt.fix_calls, [])
+
+    @unittest.skipUnless(solver_available, "no Pyomo-compatible MIP solver")
+    def test_updates_bound_when_feasible(self):
+        # Stub no_incumbent_prob to 0 so the helper takes the feasible
+        # branch; Eobjective stub returns the value the bound update
+        # should receive.
+        opt = self._opt_with_jensens(
+            jensens_dict={
+                "average_scenario_creator": farmer.average_scenario_creator,
+                "scenario_creator_kwargs": {"num_scens": 3},
+            },
+            infeas_prob=0.0, eobj=123.4,
+        )
+        sp = _StubXhatSpoke(opt)
+        sp._try_average_scenario_xhat()
+        self.assertEqual(sp.bound_updates, [123.4])
+
+    @unittest.skipUnless(solver_available, "no Pyomo-compatible MIP solver")
+    def test_skips_silently_when_infeasible(self):
+        opt = self._opt_with_jensens(
+            jensens_dict={
+                "average_scenario_creator": farmer.average_scenario_creator,
+                "scenario_creator_kwargs": {"num_scens": 3},
+            },
+            infeas_prob=0.5, eobj=999.0,  # eobj ignored on infeasible path
+        )
+        sp = _StubXhatSpoke(opt)
+        sp._try_average_scenario_xhat()
+        self.assertEqual(sp.bound_updates, [])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Refactor `examples/netdes/netdes.py` along the §7 farmer pattern from `doc/jensens_bound_design.md`: split the old `build_scenario_model` into `_scenario_data` (thin wrapper over `parse`, returns dict) and `_build_model` (Pyomo). `scenario_creator` now goes through both; external behavior unchanged.
- Add `average_scenario_creator(scenario_name, path=None)` that probability-weighted-averages the second-stage data (`d`, `u`, `b`) across all scenarios in the instance file. Netdes ships **non-uniform** probabilities so this is *not* a simple arithmetic mean. Returns a model with `_mpisppy_probability=1.0`.
- Big docstring caveat on Jensen's-bound validity: `u` and `b` are RHS-only (clean Jensen's case) but `d` is an objective coefficient (Q is concave in `d`), so users need to think before flipping `--lagrangian-try-jensens-first`. The xhat path is unconditionally fine.
- `examples/run_all.py`: move all three netdes entries from second part → first part since the second part is the long pole. Add a third netdes entry that smoke-tests the new code via `--lagrangian-try-jensens-first --xhatshuffle-try-jensens-first` through the generic driver. Header comments updated for both parts; `direct_solver_name` calculation moved with the OBBT-using entry.

sslp is **not** included here — it has integer recourse plus a Binary-typed stochastic param (`ClientPresent`), which needs a separate design discussion. Will be a follow-up PR.

## Test plan

- [x] `ruff check examples/netdes/netdes.py` passes
- [x] `examples/netdes/netdes.py` smoke: `scenario_creator('Scen3', path=...)` and `average_scenario_creator('avg', path=...)` both build; constraint counts match; average scenario has `_mpisppy_probability=1.0`
- [x] Average scenario LP solves with cplex on `network-10-10-L-01.dat` (objective 80788.39)
- [x] Full EF on the same instance solves to 88557.30 — average is below the EF optimum, consistent with Jensen's lower-bound theory for the convex (RHS-randomness) part of the recourse on this instance
- [x] `examples/run_all.py` parses
- [x] Full `python examples/run_all.py <solver> --first-part-only` run (delegating to CI)