### PR TITLE
docs: data-only averaging principle for Jensen's bound

### DIFF
--- a/doc/src/jensens.rst
+++ b/doc/src/jensens.rst
@@ -116,6 +116,42 @@ A scenario module that wants to participate must define:
    if a flag is set but the module does not define the function,
    ``cfg_vanilla`` raises a clear error at spoke-setup time.
 
+The recommended authoring pattern — which ``examples/farmer/farmer.py``
+now demonstrates — is to split the work into two underscore helpers
+that are shared between ``scenario_creator`` and
+``average_scenario_creator``:
+
+.. code-block:: python
+
+   def _scenario_data(scenario_name, **kwargs):
+       """Pure-Python random data as a plain dict. No Pyomo."""
+       ...
+
+   def _build_model(scenario_name, data, *, probability, **kwargs):
+       """Build Pyomo model from the data dict. Shared build path."""
+       ...
+
+   def scenario_creator(scenario_name, **kwargs):
+       data = _scenario_data(scenario_name, **kwargs)
+       prob = 1.0 / kwargs["num_scens"] if kwargs.get("num_scens") else "uniform"
+       return _build_model(scenario_name, data, probability=prob, **kwargs)
+
+   def average_scenario_creator(scenario_name, **kwargs):
+       # NOTE: could be multi-threaded for large num_scens.
+       snames = scenario_names_creator(kwargs["num_scens"])
+       datas  = [_scenario_data(s, **kwargs) for s in snames]
+       avg    = _average_scenario_data(datas)
+       return _build_model(scenario_name, avg, probability=1.0, **kwargs)
+
+Benefits of this split:
+
+* One source of truth for "what does the Pyomo model look like." If
+  ``scenario_creator`` and ``average_scenario_creator`` each build the
+  model inline, they will eventually drift.
+* Separating data from model makes averaging trivial: average the
+  dict, not the Pyomo components.
+* Every rank independently calls ``average_scenario_creator`` and gets
+  an identical model. No collective communication needed.
 
 Data-only averaging: the model is the model
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -159,45 +195,9 @@ infeasible: ``Allocation`` is Binary in the model and cannot be
 fractional. Relaxing ``Allocation`` to continuous in the average
 scenario would make the LP feasible but would violate the
 data-only-averaging principle above, so sslp opts out. A user who
-flips ``--*-try-jensens-first`` against sslp will get a clear
-error from ``cfg_vanilla`` saying the function is missing.
-
-The recommended authoring pattern — which ``examples/farmer/farmer.py``
-now demonstrates — is to split the work into two underscore helpers
-that are shared between ``scenario_creator`` and
-``average_scenario_creator``:
-
-.. code-block:: python
-
-   def _scenario_data(scenario_name, **kwargs):
-       """Pure-Python random data as a plain dict. No Pyomo."""
-       ...
-
-   def _build_model(scenario_name, data, *, probability, **kwargs):
-       """Build Pyomo model from the data dict. Shared build path."""
-       ...
-
-   def scenario_creator(scenario_name, **kwargs):
-       data = _scenario_data(scenario_name, **kwargs)
-       prob = 1.0 / kwargs["num_scens"] if kwargs.get("num_scens") else "uniform"
-       return _build_model(scenario_name, data, probability=prob, **kwargs)
-
-   def average_scenario_creator(scenario_name, **kwargs):
-       # NOTE: could be multi-threaded for large num_scens.
-       snames = scenario_names_creator(kwargs["num_scens"])
-       datas  = [_scenario_data(s, **kwargs) for s in snames]
-       avg    = _average_scenario_data(datas)
-       return _build_model(scenario_name, avg, probability=1.0, **kwargs)
-
-Benefits of this split:
-
-* One source of truth for "what does the Pyomo model look like." If
-  ``scenario_creator`` and ``average_scenario_creator`` each build the
-  model inline, they will eventually drift.
-* Separating data from model makes averaging trivial: average the
-  dict, not the Pyomo components.
-* Every rank independently calls ``average_scenario_creator`` and gets
-  an identical model. No collective communication needed.
+flips ``--*-try-jensens-first`` against a model module with no
+``average_scenario_creator`` function will get a clear error from
+``cfg_vanilla`` saying the function is missing.
 
 Seed management
 ---------------

--- a/doc/src/jensens.rst
+++ b/doc/src/jensens.rst
@@ -112,10 +112,55 @@ A scenario module that wants to participate must define:
 .. admonition:: Under the Hood
    :class: note
 
-   Discovery is via ``getattr(module, "average_scenario_creator", None)``; 
-   if a flag is set but the module does not define the function, 
+   Discovery is via ``getattr(module, "average_scenario_creator", None)``;
+   if a flag is set but the module does not define the function,
    ``cfg_vanilla`` raises a clear error at spoke-setup time.
-   
+
+
+Data-only averaging: the model is the model
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The model returned by ``average_scenario_creator`` must be the
+same model that ``scenario_creator`` returns; only the *data* that
+varies across scenarios may change. Variable domains — including
+integrality and bounds — are part of the model and must not be
+relaxed in the average scenario. Constraint forms must not be
+edited either. The only thing that legitimately moves between the
+two creators is the values of whatever data the original
+``scenario_creator`` would have read from disk or generated
+randomly.
+
+If averaging the per-scenario data produces a model that is
+infeasible — for example because averaging a binary stochastic
+parameter yields a fractional value that conflicts with an integer
+recourse constraint — then the problem is not amenable to
+Jensen-style averaging, and the right answer is **not** to ship
+an ``average_scenario_creator`` at all. Working around the
+infeasibility by relaxing a Var domain in the average scenario
+would produce a *different* model whose solution would be solving
+a different problem — at best an LP-relaxation heuristic that
+happens to share the same shape, not a Jensen's bound.
+
+When the model isn't amenable: sslp
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``examples/sslp/sslp.py`` deliberately does **not** ship an
+``average_scenario_creator``. Its only stochastic data is the
+binary indicator ``ClientPresent[i]`` (one per client, in
+:math:`\{0, 1\}` per scenario). The empirical mean across
+scenarios is a fraction in :math:`[0, 1]`, which makes the model
+constraint
+
+.. code-block:: python
+
+   sum(Allocation[i, j] for j in Servers) == ClientPresent[i]
+
+infeasible: ``Allocation`` is Binary in the model and cannot be
+fractional. Relaxing ``Allocation`` to continuous in the average
+scenario would make the LP feasible but would violate the
+data-only-averaging principle above, so sslp opts out. A user who
+flips ``--*-try-jensens-first`` against sslp will get a clear
+error from ``cfg_vanilla`` saying the function is missing.
 
 The recommended authoring pattern — which ``examples/farmer/farmer.py``
 now demonstrates — is to split the work into two underscore helpers


### PR DESCRIPTION
## Summary

Spell out a principle that came up while looking at sslp: ``average_scenario_creator`` must return the same model that ``scenario_creator`` returns. Only the *data* may vary across the two — variable domains (including integrality) and constraint forms are part of the model and must not be edited in the average scenario.

If averaging the data makes the model infeasible, the problem isn't amenable to Jensen-style averaging and the right answer is **not** to ship an ``average_scenario_creator`` for it. Working around it by relaxing a Var domain would produce a different model whose solution is solving a different problem — at best an LP-relaxation heuristic that happens to share the same shape, not Jensen's bound.

Adds two subsections to ``doc/src/jensens.rst`` under "Authoring":

- **"Data-only averaging: the model is the model"** — states the principle.
- **"When the model isn't amenable: sslp"** — walks through sslp as the canonical example: only stochastic data is the binary ``ClientPresent`` indicator, whose mean is fractional, which makes the equality ``sum_j Allocation[i,j] == ClientPresent[i]`` infeasible because ``Allocation`` is binary. Relaxing ``Allocation`` would violate the principle, so sslp opts out — flipping ``--*-try-jensens-first`` against sslp gets a clean missing-creator error from ``cfg_vanilla``.

No code changes; no ``average_scenario_creator`` shipped for sslp.

## Test plan

- [x] ``cd doc && make html`` builds with no new warnings