### PR TITLE
docs(rho_setting): document grad-rho options + flag sep-rho/reduced-costs-rho deprecations

### DIFF
--- a/doc/src/grad_rho.rst
+++ b/doc/src/grad_rho.rst
@@ -1,6 +1,8 @@
+.. _grad_rho:
+
 Gradient-based Rho
 ==================
 
-Gradient-based rho documentation has been consolidated into
-:ref:`rho_setting`. See the "Gradient-based Rho" and "Dynamic Rho Updates"
-sections there.
+For the user-facing options that drive gradient-based rho, see the
+"Gradient-based Rho" and "Dynamic Rho Updates" sections of
+:ref:`rho_setting`.

--- a/doc/src/rho_setting.rst
+++ b/doc/src/rho_setting.rst
@@ -41,6 +41,12 @@ Uses the separation between scenario solutions to set rho. Enabled with:
 
    --sep-rho
 
+.. note::
+   ``--sep-rho`` is scheduled for deprecation; its functionality is
+   expected to be subsumed into ``--grad-rho``. Instantiating ``SepRho``
+   now emits a ``DeprecationWarning``. See
+   `issue #673 <https://github.com/Pyomo/mpi-sppy/issues/673>`_.
+
 Coefficient-based Rho (``--coeff-rho``)
 ----------------------------------------
 
@@ -76,19 +82,45 @@ Sets rho based on reduced costs from LP relaxations. Enabled with:
 
 Like ``--sensi-rho``, this will use existing rho values if available.
 
+.. note::
+   ``--reduced-costs-rho`` is scheduled for deprecation; reduced-cost
+   rho has not been demonstrated to be effective in practice.
+   Instantiating ``ReducedCostsRho`` now emits a ``DeprecationWarning``.
+   See `issue #673 <https://github.com/Pyomo/mpi-sppy/issues/673>`_.
+
 Gradient-based Rho (``--grad-rho``)
 ------------------------------------
 
-Uses gradient information to set rho values. Enabled with:
+Uses per-variable gradient information from the scenario subproblems
+to set rho. Enabled with:
 
 .. code-block:: bash
 
    --grad-rho
 
 A detailed example is in ``examples.farmer.CI.farmer_rho_demo.py``.
+See :ref:`grad_rho` for the algorithmic description (forthcoming).
 
-The ``--grad-rho-multiplier`` option provides a cumulative multiplier
-applied when rho is set or updated.
+Options:
+
+- ``--grad-rho-multiplier`` (default ``1.0``): scalar multiplier
+  applied to every computed rho.
+- ``--grad-order-stat`` (default ``0.5``): order statistic across
+  scenarios used to combine per-scenario rho values into one. ``0``
+  selects the min, ``1`` the max, ``0.5`` the mean; values in
+  ``(0, 0.5)`` interpolate min-to-mean and values in ``(0.5, 1)``
+  interpolate mean-to-max.
+- ``--grad-rho-relative-bound`` (default ``100``): floor on the
+  primal-residual denominator relative to the consensus value (xbar).
+  Prevents tiny ``|x − xbar|`` from inflating rho when a variable is
+  near consensus.
+- ``--eval-at-xhat`` (default off): when an xhat-producing spoke is
+  present (e.g. ``--xhatshuffle``), evaluate the gradient at the best
+  xhat seen so far instead of at the latest subproblem iterate values.
+  Falls back to the iterate values until the first xhat arrives.
+- ``--indep-denom`` (default off): use a single
+  probability-weighted, MPI-Allreduced denominator across all
+  scenarios instead of a per-scenario denominator.
 
 Dynamic Rho Updates
 -------------------


### PR DESCRIPTION
## Summary

Doc-only follow-up to #679. Two changes:

1. **Document the gradient-rho options.** ``rho_setting.rst`` previously
   described only ``--grad-rho-multiplier`` out of the six options
   ``cfg.gradient_args()`` registers. Add a bullet list covering all
   five undocumented options:

   - ``--grad-order-stat`` (default ``0.5``) — order statistic across
     scenarios; 0 = min, 1 = max, 0.5 = mean, with linear interpolation
     in the open intervals.
   - ``--grad-rho-relative-bound`` (default ``100``) — floor on the
     primal-residual denominator relative to xbar.
   - ``--eval-at-xhat`` (default off) — evaluate the gradient at the
     best xhat from an xhat-producing spoke instead of at the latest
     subproblem iterate.
   - ``--indep-denom`` (default off) — use a single
     probability-weighted, MPI-Allreduced denominator across scenarios.
   - ``--grad-rho-multiplier`` (default ``1.0``) — scalar multiplier
     applied to every computed rho (already documented; left in for
     completeness in the same list).

2. **Flag ``--sep-rho`` and ``--reduced-costs-rho`` as scheduled for
   deprecation.** Per
   `issue #673 <https://github.com/Pyomo/mpi-sppy/issues/673>`_, both
   methods are slated for removal: ``SepRho`` is expected to be
   subsumed into ``GradRho``, and reduced-cost rho has not been
   demonstrated to be effective in practice. PR #679 has already
   added a ``DeprecationWarning`` at instantiation; this PR adds an
   ``.. note::`` on each section so the rendered docs match.

``grad_rho.rst`` stays a brief pointer (the academic paper covering the
algorithm is in preparation); a ``.. _grad_rho:`` cross-reference label
is added so ``rho_setting.rst`` can link to it.

## Test plan

- [ ] ``cd doc && make html`` builds without new warnings (verified
      locally — the only warning is the pre-existing
      ``viewcode_import`` config typo, unrelated).
- [ ] Read the Docs preview renders the new option list and deprecation
      notes correctly.
- [ ] No code changes; non-docs CI is N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)