### PR TITLE
ADMM doc cross-refs, BFs flow-through, stage2ef hard error

### DIFF
--- a/doc/src/admmWrapper.rst
+++ b/doc/src/admmWrapper.rst
@@ -3,6 +3,20 @@
 AdmmWrapper
 ===========
 
+.. important::
+
+   **Most users should use** :ref:`generic_cylinders <generic_cylinders>`
+   **with the** ``--admm`` **flag rather than writing a custom driver.**
+   See :ref:`generic_admm` for the recommended workflow, including the
+   model-module interface and a tutorial using the same ``distr`` example
+   described on this page.  The stochastic counterpart is
+   :ref:`stoch_admmWrapper` (run via ``--stoch-admm``).
+
+   This page documents the underlying ``AdmmWrapper`` class and the
+   custom-driver pattern.  It is primarily useful if you are writing your
+   own driver, extending the wrapper, or trying to understand how
+   ``generic_cylinders --admm`` works under the hood.
+
 .. automodule:: distr
    :noindex:
    :show-inheritance:
@@ -11,7 +25,7 @@ AdmmWrapper
    :noindex:
    :show-inheritance:
 
-**AdmmWrapper** uses progressive hedging implemented in mpi-sppy 
+**AdmmWrapper** uses progressive hedging implemented in mpi-sppy
 to solve a non-stochastic problem by breaking them into subproblems.
 
 An example of usage is given below.

--- a/doc/src/generic_admm.rst
+++ b/doc/src/generic_admm.rst
@@ -295,15 +295,15 @@ constraints.
    def scenario_creator(scenario_name, **kwargs):
        cfg = kwargs["cfg"]
        model = build_my_model(scenario_name, cfg)
-       # Attach a trivial root node (ADMM wrapper will handle consensus)
-       varlist = list()
-       sputils.attach_root_node(model, model.Obj, varlist)
        return model
 
 .. Note::
-   Pass an empty ``varlist`` to ``attach_root_node``. The ADMM wrapper
-   automatically manages which variables are non-anticipative (the consensus
-   variables).
+   For ``--admm``, **do not** call ``sputils.attach_root_node`` in your
+   ``scenario_creator``.  ``AdmmWrapper`` builds the scenario tree itself
+   (calling ``attach_root_node`` internally with the consensus variables as
+   the non-anticipative list); any user-supplied node list would be
+   overwritten.  For ``--stoch-admm`` the contract is different — see the
+   note in "Extending to Stochastic ADMM" below.
 
 Step 4: Implement ``consensus_vars_creator``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -366,7 +366,7 @@ Step 7: Run
 
 
 Extending to Stochastic ADMM
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To support ``--stoch-admm``, additionally implement:
 
@@ -378,10 +378,27 @@ To support ``--stoch-admm``, additionally implement:
 These functions define the naming convention for composite scenarios. See
 ``examples/stoch_distr/stoch_distr.py`` for a complete working example.
 
-Your ``scenario_creator`` will receive composite names and must split them
-to determine both which ADMM subproblem and which stochastic scenario to build.
 Your ``consensus_vars_creator`` returns ``(variable_name, stage)`` tuples
 instead of plain strings.
+
+.. Note::
+
+   ``scenario_creator`` differs from the deterministic case in two ways:
+
+   1. **Receives a composite name.**  The argument is e.g.
+      ``"ADMM_STOCH_Region1_StochasticScenario3"``; the function must split
+      it (using ``split_admm_stoch_subproblem_scenario_name``) to determine
+      both which ADMM subproblem and which stochastic scenario to build.
+
+   2. **Must call** ``sputils.attach_root_node`` with the *original*
+      problem's first-stage variables (i.e., not the ADMM consensus vars).
+      Unlike ``AdmmWrapper`` (which overwrites the node list),
+      ``Stoch_AdmmWrapper`` *reads* the user-supplied node list and
+      *appends* an ADMM-consensus stage to it.  Skipping the call will
+      assertion-fail inside the wrapper.
+
+   See ``stoch_distr.scenario_creator`` for the canonical pattern:
+   ``sputils.attach_root_node(model, model.FirstStageCost, [...factory vars...])``.
 
 
 .. _admm_bundling:

--- a/doc/src/generic_admm.rst
+++ b/doc/src/generic_admm.rst
@@ -83,6 +83,43 @@ Here:
   ``num_admm_subproblems * num_stoch_scens = 9``.
 
 
+.. _stoch_admm_branching_factors:
+
+Branching factors with ``--stoch-admm``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. important::
+
+   When using ``--stoch-admm``, the value passed to ``--branching-factors``
+   describes the **original** problem's tree (i.e., the branching factors
+   **before** the ADMM-stage augmentation).  The stochastic ADMM wrapper
+   appends ``num_admm_subproblems`` as the final stage, then republishes
+   the augmented branching factors back to the config so that downstream
+   consumers (notably xhatshuffle's stage2ef path) see the correct tree
+   shape automatically.
+
+   - For a 2-stage-origin problem (e.g., ``stoch_distr``): ``--branching-factors``
+     may be omitted entirely.  The wrapper infers ``[num_stoch_scens]`` from
+     ``--num-stoch-scens`` and produces the augmented tree
+     ``[num_stoch_scens, num_admm_subproblems]``.
+   - For an N-stage-origin problem: pass the N-1 original branching factors.
+     The wrapper appends ``num_admm_subproblems`` to produce an
+     N-level augmented tree.
+
+   **Semantics change (post mpi-sppy 0.13.2):** earlier versions of
+   ``setup_stoch_admm`` ignored ``--branching-factors`` entirely and hard-coded
+   ``BFs=None`` into ``Stoch_AdmmWrapper``.  As a result, anyone using
+   ``--stoch-admm`` together with ``--xhatshuffle --stage2-ef-solver-name``
+   had to hand-encode the augmented tree as
+   ``--branching-factors "<num_stoch_scens> <num_admm_subproblems>"``.
+   **That workaround now produces an incorrect (too deep) tree** and must be
+   removed: pass only the original problem's branching factors (or omit the
+   flag for 2-stage-origin problems).
+
+A worked example using stage2ef is provided in
+``examples/stoch_distr/stoch_admm_stage2ef.bash``.
+
+
 Model Module Interface
 -----------------------
 

--- a/doc/src/generic_admm.rst
+++ b/doc/src/generic_admm.rst
@@ -25,6 +25,16 @@ There are two modes:
    ADMM (``--admm``), but are supported with stochastic ADMM
    (``--stoch-admm``); see :ref:`admm_bundling` below.
 
+.. Note::
+   With ``--stoch-admm``, the ``--xhatshuffle`` spoke requires
+   ``--stage2-ef-solver-name`` and an error is raised otherwise.  Without
+   it, xhatshuffle would fix nonants only along the picked scenario's tree
+   path, leaving the ADMM consensus variables in other stochastic outcomes
+   unconstrained and producing an invalid (over-optimistic) inner bound.
+   Use ``--xhatxbar`` if you want an inner bound without solving a stage-2
+   EF; xhatxbar fixes nonants to the PH ``xbar``, which is itself the
+   consensus value.
+
 
 Tutorial: Running the ``distr`` Example
 -----------------------------------------

--- a/doc/src/stoch_admmWrapper.rst
+++ b/doc/src/stoch_admmWrapper.rst
@@ -3,6 +3,21 @@
 StochAdmmWrapper
 ================
 
+.. important::
+
+   **Most users should use** :ref:`generic_cylinders <generic_cylinders>`
+   **with the** ``--stoch-admm`` **flag rather than writing a custom driver.**
+   See :ref:`generic_admm` for the recommended workflow, including a
+   tutorial that uses the same ``stoch_distr`` example described on this
+   page and a section on :ref:`bundling <admm_bundling>` stochastic
+   scenarios within each ADMM subproblem.  The deterministic counterpart
+   is :ref:`admmWrapper` (run via ``--admm``).
+
+   This page documents the underlying ``Stoch_AdmmWrapper`` class and the
+   custom-driver pattern.  It is primarily useful if you are writing your
+   own driver, extending the wrapper, or trying to understand how
+   ``generic_cylinders --stoch-admm`` works under the hood.
+
 .. automodule:: stoch_distr
    :noindex:
    :show-inheritance:

--- a/examples/distr/distr.py
+++ b/examples/distr/distr.py
@@ -145,9 +145,9 @@ def scenario_creator(scenario_name, inter_region_dict=None, cfg=None, data_param
     # Generating the model
     model = min_cost_distr_problem(local_dict, cfg, max_revenue=data_params["max revenue"])
 
-    #varlist = list()
-    #sputils.attach_root_node(model, model.MinCost, varlist)    
-    
+    # No attach_root_node call here: AdmmWrapper builds the scenario tree
+    # itself (with the consensus variables as the non-anticipative list)
+    # and would overwrite any node list set here.  See doc/src/generic_admm.rst.
     return model
 
 

--- a/examples/stoch_distr/stoch_admm_stage2ef.bash
+++ b/examples/stoch_distr/stoch_admm_stage2ef.bash
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Example: stochastic ADMM via generic_cylinders with the stage2_ef_solver_name
+# option enabled.
+#
+# Why stage2ef matters here:
+#   stoch-admm wraps the 2-stage stoch_distr problem into a 3-level scenario
+#   tree (ROOT -> per-stoch-scenario nodes -> per-admm-subproblem nodes).
+#   That makes the problem "multistage" in mpi-sppy's view, so xhatshuffle's
+#   stage2_ef path applies: for each stage-2 node it builds and solves an EF
+#   that re-couples all ADMM subproblems for that stochastic outcome with
+#   the root nonants fixed.  Without stage2ef, xhatshuffle would evaluate
+#   the (stoch_scen, admm_sub) "scenarios" independently and lose the ADMM
+#   consensus coupling, producing an invalid inner bound.
+#
+# Note: `num_admm_subproblems == num_stoch_scens` keeps things simple here.
+# The stage2ef rank-assignment assertion in mpisppy/extensions/xhatbase.py
+# uses `branching_factors[1]` (num_admm_subproblems after wrapper
+# augmentation) and compares it to the locally-observed count of stage-2
+# nodes (== num_stoch_scens with one rank per cylinder).  Generalizing to
+# unequal counts requires care with --np.
+#
+# We deliberately do *not* pass --branching-factors: setup_stoch_admm
+# publishes the augmented BFs back to cfg, so xhatshuffle's stage2ef path
+# sees the correct tree shape automatically.
+
+set -e
+
+SOLVER=${SOLVERNAME:-gurobi_persistent}
+N=3   # num_admm_subproblems == num_stoch_scens
+
+mpiexec -np 3 python -u -m mpi4py ../../mpisppy/generic_cylinders.py \
+    --module-name stoch_distr --stoch-admm \
+    --num-admm-subproblems ${N} --num-stoch-scens ${N} \
+    --default-rho 10 --max-iterations 50 \
+    --solver-name ${SOLVER} \
+    --lagrangian --xhatshuffle --stage2-ef-solver-name ${SOLVER} \
+    --rel-gap 0.01 --ensure-xhat-feas

--- a/mpisppy/generic/admm.py
+++ b/mpisppy/generic/admm.py
@@ -93,6 +93,24 @@ def _check_admm_compatibility(cfg):
             raise RuntimeError(
                 f"--{opt.replace('_', '-')} is not supported with ADMM"
             )
+    # xhatshuffle without stage2_ef_solver_name is invalid for stoch-admm:
+    # the picked scenario's xhats only fix nonants along its own tree path,
+    # leaving ADMM consensus variables in other stochastic outcomes
+    # unconstrained.  The resulting "inner bound" violates the problem's
+    # ADMM consensus constraints and has no valid interpretation as a
+    # relaxation, so it must not be silently produced.
+    if (cfg.get("stoch_admm", ifmissing=False)
+            and cfg.get("xhatshuffle", ifmissing=False)
+            and cfg.get("stage2_ef_solver_name") is None):
+        raise RuntimeError(
+            "--xhatshuffle with --stoch-admm requires --stage2-ef-solver-name. "
+            "Without it, xhatshuffle fixes nonants only along one scenario's "
+            "tree path, leaving the ADMM consensus variables in other "
+            "stochastic outcomes unconstrained and producing an invalid "
+            "(over-optimistic) inner bound.  Pass --stage2-ef-solver-name "
+            "(typically the same solver as --solver-name), or use "
+            "--xhatxbar instead."
+        )
 
 
 def setup_admm(module, cfg, n_cylinders):

--- a/mpisppy/generic/admm.py
+++ b/mpisppy/generic/admm.py
@@ -158,13 +158,19 @@ def setup_stoch_admm(module, cfg, n_cylinders):
         n_cylinders=n_cylinders,
         mpicomm=MPI.COMM_WORLD,
         scenario_creator_kwargs=scenario_creator_kwargs,
-        BFs=None,
+        BFs=cfg.get("branching_factors"),
     )
 
     # Store on cfg as plain attributes (Pyomo Config can't handle these types)
     object.__setattr__(cfg, "_admm_variable_probability", admm.var_prob_list)
     object.__setattr__(cfg, "_admm_scenario_names", all_names)
     object.__setattr__(cfg, "_admm_nodenames", admm.all_nodenames)
+
+    # Publish the augmented branching factors so downstream consumers
+    # (notably xhatshuffle's stage2ef path in extensions/xhatbase.py) see
+    # the wrapper's true tree shape without the user having to hand-encode
+    # the wrapper's append convention.
+    cfg.quick_assign("branching_factors", list, list(admm.BFs))
 
     return (admm.admmWrapper_scenario_creator, {},
             all_names, admm.all_nodenames)

--- a/mpisppy/tests/test_admm_bundler.py
+++ b/mpisppy/tests/test_admm_bundler.py
@@ -241,6 +241,62 @@ class TestAdmmArgs(unittest.TestCase):
         # Should not raise
         _check_admm_compatibility(cfg)
 
+    def test_check_stoch_admm_xhatshuffle_without_stage2ef_errors(self):
+        """stoch_admm + xhatshuffle without stage2_ef_solver_name is an
+        invalid configuration: xhatshuffle fixes nonants only along one
+        scenario's tree path, leaving ADMM consensus variables in other
+        stochastic outcomes unconstrained.  This must error, not silently
+        produce an invalid inner bound."""
+        from mpisppy.generic.admm import _check_admm_compatibility
+        cfg = config.Config()
+        cfg.add_to_config("stoch_admm", description="", domain=bool, default=True)
+        cfg.add_to_config("xhatshuffle", description="", domain=bool, default=True)
+        cfg.add_to_config("stage2_ef_solver_name", description="",
+                          domain=str, default=None)
+        with self.assertRaises(RuntimeError) as cm:
+            _check_admm_compatibility(cfg)
+        self.assertIn("stage2-ef-solver-name", str(cm.exception))
+
+    def test_check_stoch_admm_xhatshuffle_with_stage2ef_ok(self):
+        """stoch_admm + xhatshuffle + stage2_ef_solver_name is valid."""
+        from mpisppy.generic.admm import _check_admm_compatibility
+        cfg = config.Config()
+        cfg.add_to_config("stoch_admm", description="", domain=bool, default=True)
+        cfg.add_to_config("xhatshuffle", description="", domain=bool, default=True)
+        cfg.add_to_config("stage2_ef_solver_name", description="",
+                          domain=str, default="gurobi")
+        # Should not raise
+        _check_admm_compatibility(cfg)
+
+    def test_check_stoch_admm_xhatxbar_without_stage2ef_ok(self):
+        """stoch_admm + xhatxbar (without xhatshuffle) does not need
+        stage2_ef_solver_name: xhatxbar fixes nonants to the PH xbar, which
+        IS the consensus value, so ADMM consensus is preserved without an
+        EF resolve."""
+        from mpisppy.generic.admm import _check_admm_compatibility
+        cfg = config.Config()
+        cfg.add_to_config("stoch_admm", description="", domain=bool, default=True)
+        cfg.add_to_config("xhatxbar", description="", domain=bool, default=True)
+        cfg.add_to_config("stage2_ef_solver_name", description="",
+                          domain=str, default=None)
+        # Should not raise
+        _check_admm_compatibility(cfg)
+
+    def test_check_admm_xhatshuffle_without_stage2ef_ok(self):
+        """Deterministic --admm + xhatshuffle without stage2_ef_solver_name
+        is allowed: deterministic ADMM treats subproblems as a flat 2-stage
+        tree (all consensus at ROOT), so xhatshuffle's single-path fix
+        reaches every consensus variable.  The stage2ef error is specific
+        to --stoch-admm where the tree is genuinely multistage."""
+        from mpisppy.generic.admm import _check_admm_compatibility
+        cfg = config.Config()
+        cfg.add_to_config("admm", description="", domain=bool, default=True)
+        cfg.add_to_config("xhatshuffle", description="", domain=bool, default=True)
+        cfg.add_to_config("stage2_ef_solver_name", description="",
+                          domain=str, default=None)
+        # Should not raise
+        _check_admm_compatibility(cfg)
+
 
 class TestNameListsAdmmPath(unittest.TestCase):
     """Test the ADMM early-return path in parsing.name_lists."""

--- a/mpisppy/utils/stoch_admmWrapper.py
+++ b/mpisppy/utils/stoch_admmWrapper.py
@@ -128,17 +128,19 @@ class Stoch_AdmmWrapper(): #add scenario_tree
     
 
     def create_node_names(self, num_admm_subproblems, num_stoch_scens):
-        if self.BFs is not None: # already multi-stage problem initially
-            self.BFs.append(num_admm_subproblems) # Adds the last stage with admm_subproblems
-            all_nodenames = sputils.create_nodenames_from_branching_factors(self.BFs)
-        else: # 2-stage problem initially
-            all_node_names_0 = ["ROOT"]
-            all_node_names_1 = ["ROOT_" + str(i) for i in range(num_stoch_scens)]
-            all_node_names_2 = [parent + "_" + str(j) \
-                                for parent in all_node_names_1 \
-                                    for j in range(num_admm_subproblems)]
-            all_nodenames = all_node_names_0 + all_node_names_1 + all_node_names_2
-        return all_nodenames
+        # Normalize self.BFs to the original problem's branching factors.
+        # For a 2-stage-origin problem the caller passes BFs=None (or empty);
+        # the original tree's only branching factor is then num_stoch_scens.
+        # Defensive copy: we mutate self.BFs in place below, so we must not
+        # alias a caller-owned list (e.g. cfg.branching_factors).
+        if not self.BFs:
+            self.BFs = [num_stoch_scens]
+        else:
+            self.BFs = list(self.BFs)
+        # The wrapper augments the original tree with an ADMM stage that
+        # branches each leaf into num_admm_subproblems consensus subproblems.
+        self.BFs.append(num_admm_subproblems)
+        return sputils.create_nodenames_from_branching_factors(self.BFs)
 
 
     def var_prob_list(self, s):


### PR DESCRIPTION
## Summary

- **Docs cross-references** (`9ad8963e`): top of `admmWrapper.rst` and `stoch_admmWrapper.rst` now points users at `generic_cylinders --admm` / `--stoch-admm` as the recommended workflow, with the wrapper pages framed as documentation of the underlying class for users writing custom drivers.
- **BFs flow-through for stoch-admm** (`78d68272`): `setup_stoch_admm` now passes `cfg.branching_factors` into `Stoch_AdmmWrapper` and republishes the augmented BFs back to cfg, so xhatshuffle's stage2ef path sees the wrapper's true tree shape automatically. Unifies the previously-dead "multistage origin" branch in `create_node_names`. New example `examples/stoch_distr/stoch_admm_stage2ef.bash`. **Semantics change documented in a new "Branching factors with --stoch-admm" subsection of `generic_admm.rst`**: anyone previously hand-encoding `--branching-factors "<num_stoch_scens> <num_admm_subproblems>"` must now pass only the original problem's BFs.
- **Stage2ef hard error** (`58955c0e`): `--stoch-admm` + `--xhatshuffle` without `--stage2-ef-solver-name` now raises a clear `RuntimeError` (instead of silently producing an invalid inner bound that violates ADMM consensus in non-picked stochastic outcomes). 4 new tests in `test_admm_bundler.py` cover the four configurations.
- **Doc clarification of `attach_root_node` contract** (`24bf5802`): the two ADMM wrappers behave differently — `AdmmWrapper` calls `attach_root_node` itself and overwrites any prior call; `Stoch_AdmmWrapper` reads the user's existing node list and appends to it. `generic_admm.rst` Step 3 now says to skip the call for `--admm`, and a new "Extending to Stochastic ADMM" note spells out the `--stoch-admm` requirement with `stoch_distr.scenario_creator` as the canonical pattern. Dead commented-out lines removed from `examples/distr/distr.py`.

## Test plan

- [x] `python -m pytest mpisppy/tests/test_admm_bundler.py` — 26/26 pass
- [x] `python -m pytest mpisppy/tests/test_stoch_admmWrapper.py` — 10/10 non-deselected pass (pre-existing `test_values` flaky under subprocess capture, unchanged here)
- [x] `examples/stoch_distr/stoch_admm_stage2ef.bash` — converges in ~15 PH iters to 0.8% gap with stage2ef firing
- [x] `examples/distr/` via `generic_cylinders --admm` (gurobi_persistent, 3 regions) — converges
- [x] `ruff check .` — clean for touched files
- [x] `cd doc && make html` — builds cleanly (no new warnings)

## Follow-up

Phased automation work tracked in design doc PR #684 (`admm-api-automation-design`); phase A will supersede commit `24bf5802`'s doc note when the new `first_stage_cost` / `first_stage_varlist` hooks land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)