### PR TITLE
distr example cleanup: typo, dead code, kwarg defaults, go.bash modernization

### DIFF
--- a/examples/distr/distr.py
+++ b/examples/distr/distr.py
@@ -118,22 +118,24 @@ def min_cost_distr_problem(local_dict, cfg, sense=pyo.minimize, max_revenue=None
 
 
 ###Creates the scenario
-def scenario_creator(scenario_name, inter_region_dict=None, cfg=None, data_params=None, all_nodes_dict=None):
+def scenario_creator(scenario_name, inter_region_dict, cfg, data_params=None, all_nodes_dict=None):
     """Creates the model, which should include the consensus variables. \n
     However, this function shouldn't attach the consensus variables to root nodes, as it is done in admmWrapper.
 
     Args:
-        scenario_name (str): the name of the scenario that will be created. Here is of the shape f"Region{i}" with 1<=i<=num_scens \n
-        num_scens (int): number of scenarios (regions). Useful to create the corresponding inter-region dictionary
+        scenario_name (str): the name of the scenario that will be created.
+            Of the shape f"Region{i}" with 1<=i<=num_scens. \n
+        inter_region_dict (dict): inter-region arcs/costs/capacities; from kw_creator(cfg). \n
+        cfg (Config): mpi-sppy config object. \n
+        data_params (dict, optional): pseudo-random data params; required when cfg.scalable. \n
+        all_nodes_dict (dict, optional): per-region node lists; required when cfg.scalable.
 
     Returns:
         Pyomo ConcreteModel: the instantiated model
-    """        
-    assert (inter_region_dict is not None)
-    assert (cfg is not None)
+    """
     if cfg.scalable:
-        assert (data_params is not None)
-        assert (all_nodes_dict is not None)
+        assert data_params is not None, "data_params is required when cfg.scalable"
+        assert all_nodes_dict is not None, "all_nodes_dict is required when cfg.scalable"
         region_creation_starting_time = time.time()
         region_dict = distr_data.scalable_region_dict_creator(scenario_name, all_nodes_dict=all_nodes_dict, cfg=cfg, data_params=data_params)
         region_creation_end_time = time.time()
@@ -166,12 +168,6 @@ def scenario_denouement(rank, scenario_name, scenario, eps=10**(-6)):
         if 'DC' in var:
             if (abs(scenario.y[var].value) > eps):
                 print(f"The penalty slack {scenario.y[var].name} is too big, its absolute value is {abs(scenario.y[var].value)}")
-    return
-    print(f"flow values for {scenario_name}")
-    scenario.flow.pprint()
-    print(f"slack values for {scenario_name}")
-    scenario.y.pprint()
-    pass
 
 
 def consensus_vars_creator(num_scens, all_scenario_names, inter_region_dict=None, **kwargs):
@@ -282,7 +278,7 @@ def inparser_adder(cfg):
     cfg.num_scens_required()
 
     cfg.add_to_config("scalable",
-                      description="decides whether a sclale model is used",
+                      description="generate pseudo-random data parameterized by --mnpr instead of using the hardwired 2/3/4-region datasets",
                       domain=bool,
                       default=False)
 

--- a/examples/distr/go.bash
+++ b/examples/distr/go.bash
@@ -1,9 +1,19 @@
 #!/bin/bash
+# Recommended ADMM runs via generic_cylinders --admm.
+# The legacy custom driver distr_admm_cylinders.py is still in this
+# directory for reference; see doc/src/generic_admm.rst for the
+# rationale and a tutorial.
 
 SOLVERNAME=xpress
 
-# Runs a hard-wired example
-#mpiexec -np 3 python -u -m mpi4py distr_admm_cylinders.py --num-scens 3 --default-rho 10 --solver-name $SOLVERNAME --max-iterations 50 --xhatxbar --lagrangian --rel-gap 0.05 --ensure-xhat-feas
+# Hard-wired example (2/3/4 regions: change --num-scens accordingly)
+#mpiexec -np 3 python -u -m mpi4py ../../mpisppy/generic_cylinders.py \
+#    --module-name distr --admm --num-scens 3 \
+#    --default-rho 10 --solver-name $SOLVERNAME --max-iterations 50 \
+#    --xhatxbar --lagrangian --rel-gap 0.05 --ensure-xhat-feas
 
-# Runs a scalable example with xhatxbar as inner bounder and lagrangian as outer bounder
-mpiexec -np 6 python -u -m mpi4py distr_admm_cylinders.py --num-scens 5 --default-rho 10 --solver-name $SOLVERNAME --max-iterations 50 --xhatxbar --lagrangian --mnpr 6 --rel-gap 0.05 --scalable --ensure-xhat-feas
+# Scalable example with xhatxbar (inner bound) and lagrangian (outer bound)
+mpiexec -np 6 python -u -m mpi4py ../../mpisppy/generic_cylinders.py \
+    --module-name distr --admm --num-scens 5 \
+    --default-rho 10 --solver-name $SOLVERNAME --max-iterations 50 \
+    --xhatxbar --lagrangian --mnpr 6 --rel-gap 0.05 --scalable --ensure-xhat-feas

--- a/examples/stoch_distr/stoch_distr.py
+++ b/examples/stoch_distr/stoch_distr.py
@@ -404,7 +404,7 @@ def inparser_adder(cfg):
     
     ### For the scalable example
     cfg.add_to_config("scalable",
-                      description="decides whether a scalable model is used",
+                      description="generate pseudo-random data parameterized by --mnpr instead of using the hardwired 2/3/4-region datasets",
                       domain=bool,
                       default=False)
 


### PR DESCRIPTION
## Summary

Four review items from a walkthrough of `examples/distr/distr.py`, bundled into one PR. Independent of the phase-A work in PR #686.

- **Typo + vague description.** The `--scalable` CLI option's help string said `"decides whether a sclale model is used"`. Fix the typo and broaden the wording to explain what the flag actually does: `"generate pseudo-random data parameterized by --mnpr instead of using the hardwired 2/3/4-region datasets"`. Apply the same description to `examples/stoch_distr/stoch_distr.py` for consistency.

- **Dead code in `scenario_denouement`.** Five lines after an unconditional `return` (`pprint`/`print` calls) — removed.

- **Misleading kwarg defaults.** `scenario_creator` declared `inter_region_dict=None, cfg=None, data_params=None, all_nodes_dict=None` and then `assert ... is not None` on entry. For `inter_region_dict` and `cfg` this is misleading — `kw_creator` always passes them and the `=None` defaults imply optionality. Make them required kwargs and let Python's missing-arg error report the problem naturally. Keep `=None` defaults on `data_params` / `all_nodes_dict` (genuinely scalable-only). Rewrite the (stale) docstring to match.

- **`go.bash` modernization (#3 from the review list).** Switch to `generic_cylinders --admm`, matching the recommendation we put at the top of `admmWrapper.rst` in PR #685. The legacy custom driver `distr_admm_cylinders.py` stays in the directory for reference; `go.bash` has a comment pointing at the doc rationale.

## Test plan

- [x] `bash go.bash` (SOLVERNAME=gurobi_persistent locally) — converges to 2.1% gap (below the 5% target)
- [x] `python -m pytest mpisppy/tests/test_admm_bundler.py` — 26/26 pass
- [x] `python -m pytest mpisppy/tests/test_admmWrapper.py` — 6/7 pass; the 7th (`test_values`) is a pre-existing flaky subprocess-capture failure that also fails on clean main (same pattern as `test_stoch_admmWrapper::test_values`)
- [x] `ruff check examples/distr/distr.py examples/stoch_distr/stoch_distr.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)