### PR TITLE
wire --wtracker into generic_cylinders.py

### DIFF
--- a/doc/src/extensions.rst
+++ b/doc/src/extensions.rst
@@ -220,12 +220,41 @@ are believed to be "in balance", such that per-variable updates are not needed (
 hinder algorithmic progress when different nonanticipative variables play similar roles in
 the subproblem optimization problems).
 
+.. _wtracker_extension:
+
 wtracker_extension
 ^^^^^^^^^^^^^^^^^^
 
 The wtracker_extension outputs a report about the convergence (or really, lack thereof) of
 W values.
-An example of its use is shown in ``examples.sizes.sizes_demo.py``
+An example of programmatic use is shown in ``examples.sizes.sizes_demo.py``.
+
+From ``generic_cylinders.py``, enable it with ``--wtracker``. Related options:
+
+- ``--wtracker`` -- enable the extension (default off)
+- ``--wtracker-file-prefix <str>`` -- prefix for the rank-by-rank output
+  files (default: empty)
+- ``--wtracker-wlen <int>`` -- moving-window length, in iterations,
+  used by the convergence statistics (default 20)
+- ``--wtracker-reportlen <int>`` -- maximum number of rows in each
+  ranked report (default 100)
+- ``--wtracker-stdevthresh <float>`` -- ignore moving standard deviations
+  below this value when counting "converged" traces (default: use
+  ``E1_tolerance``)
+
+At the end of the run, each rank writes three files using its prefix:
+
+- ``<prefix>_summary_iter<N>_rank<r>.txt`` -- text summary with counts
+  and totals
+- ``<prefix>_stdev_iter<N>_rank<r>.csv`` -- top entries sorted by
+  moving standard deviation
+- ``<prefix>_cv_iter<N>_rank<r>.csv`` -- top entries sorted by moving
+  absolute coefficient of variation
+
+Each CSV row is indexed by ``(varname, scenario_name)`` and gives the
+windowed mean and stdev of W for that nonant/scenario pair. This is a
+diagnostic tool intended for tuning rho and convergence behavior; it
+adds time and memory and is not recommended for production runs.
 
 
 gradient_extension

--- a/doc/src/generic_cylinders.rst
+++ b/doc/src/generic_cylinders.rst
@@ -173,6 +173,9 @@ Some extensions can be activated directly from the command line:
 - ``--fixer`` -- Fix variables that have converged
 - ``--mipgaps-json <file>`` -- MIP gap schedule from a JSON file
 - ``--user-defined-extensions <module>`` -- Load a custom extension module
+- ``--wtracker`` -- Track W (Lagrange-multiplier) values per iteration
+  and write a convergence report at the end of the run
+  (see :ref:`wtracker_extension`)
 
 See :ref:`Extensions` for details on available extensions.
 

--- a/mpisppy/generic/extensions.py
+++ b/mpisppy/generic/extensions.py
@@ -58,6 +58,16 @@ def configure_extensions(hub_dict, module, cfg):
         from mpisppy.utils.w_utils.wxbarwriter import WXBarWriter
         ext_classes.append(WXBarWriter)
 
+    if cfg.get("wtracker", ifmissing=False):
+        from mpisppy.extensions.wtracker_extension import Wtracker_extension
+        ext_classes.append(Wtracker_extension)
+        hub_dict["opt_kwargs"]["options"]["wtracker_options"] = {
+            "wlen": cfg.wtracker_wlen,
+            "reportlen": cfg.wtracker_reportlen,
+            "stdevthresh": cfg.wtracker_stdevthresh,
+            "file_prefix": cfg.wtracker_file_prefix,
+        }
+
     if cfg.user_defined_extensions is not None:
         import json
         for ext_name in cfg.user_defined_extensions:

--- a/mpisppy/generic/parsing.py
+++ b/mpisppy/generic/parsing.py
@@ -140,6 +140,7 @@ def parse_args(m):
     cfg.primal_dual_rho_args()
     cfg.converger_args()
     cfg.wxbar_read_write_args()
+    cfg.wtracker_args()
     cfg.tracking_args()
     cfg.gradient_args()
     cfg.dynamic_rho_args()

--- a/mpisppy/tests/test_generic_cylinders.py
+++ b/mpisppy/tests/test_generic_cylinders.py
@@ -7,11 +7,19 @@
 # full copyright and license information.
 ###############################################################################
 """Tests for generic_cylinders.py entry point."""
+import csv
+import glob
 import io
+import os
 import sys
 import runpy
+import tempfile
 import unittest
 from unittest.mock import patch
+
+from mpisppy.tests.utils import get_solver
+
+solver_available, solver_name, _, _ = get_solver()
 
 
 class TestGenericCylindersUsage(unittest.TestCase):
@@ -27,6 +35,57 @@ class TestGenericCylindersUsage(unittest.TestCase):
         self.assertIn("--module-name", output)
         self.assertIn("--smps-dir", output)
         self.assertIn("--mps-files-directory", output)
+
+
+class TestGenericCylindersWtracker(unittest.TestCase):
+    """End-to-end test that --wtracker actually attaches the extension and records W."""
+
+    @unittest.skipIf(not solver_available,
+                     "no MIP solver available")
+    def test_wtracker_flag_records_W(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            prefix = os.path.join(tmp, "wt")
+            argv = [
+                "generic_cylinders",
+                "--module-name", "mpisppy.tests.examples.farmer",
+                "--num-scens", "3",
+                "--solver-name", solver_name,
+                "--max-iterations", "6",
+                "--default-rho", "1",
+                "--wtracker",
+                "--wtracker-file-prefix", prefix,
+                "--wtracker-wlen", "3",
+                "--wtracker-reportlen", "5",
+            ]
+            with patch.object(sys, "argv", argv):
+                runpy.run_module("mpisppy.generic_cylinders",
+                                 run_name="__main__")
+
+            stdev_files = glob.glob(prefix + "_stdev_*.csv")
+            self.assertTrue(stdev_files,
+                            "wtracker did not write a stdev CSV — "
+                            "extension was probably not wired in")
+
+            with open(stdev_files[0]) as f:
+                rows = list(csv.reader(f))
+            # header + at least one (varname, scenname) row
+            self.assertGreaterEqual(len(rows), 2,
+                                    "wtracker stdev CSV has no data rows")
+            self.assertEqual(rows[0], ["", "mean", "stdev"])
+            # Each data row: index string, mean (float), stdev (non-negative float)
+            for row in rows[1:]:
+                idx, mean_s, stdev_s = row
+                self.assertTrue(idx.startswith("('"),
+                                f"unexpected index format: {idx!r}")
+                mean = float(mean_s)
+                stdev = float(stdev_s)
+                self.assertTrue(mean == mean,  # not NaN
+                                f"mean is NaN for {idx}")
+                self.assertGreaterEqual(stdev, 0.0,
+                                        f"negative stdev for {idx}")
+            # Sanity: farmer has 3 nonants; with 3 scens we have 9 traces,
+            # reportlen=5 caps rows at 5
+            self.assertLessEqual(len(rows) - 1, 5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add the existing `Wtracker_extension` to the `generic_cylinders.py` CLI: `parse_args` calls `cfg.wtracker_args()`, and the hub configurator appends the extension and fills in `wtracker_options` whenever `--wtracker` is set
- New end-to-end test `TestGenericCylindersWtracker.test_wtracker_flag_records_W` in `mpisppy/tests/test_generic_cylinders.py` invokes the CLI on farmer (via `runpy`) and verifies that a real W value lands in the produced stdev CSV
- User docs updated in `doc/src/extensions.rst` (CLI flags + output-file descriptions) and `doc/src/generic_cylinders.rst` (added `--wtracker` to the CLI-extensions bullet list, with cross-reference)

The new flags are `--wtracker`, `--wtracker-file-prefix`, `--wtracker-wlen`, `--wtracker-reportlen`, `--wtracker-stdevthresh` (all already defined by `Config.wtracker_args()`; they just weren't wired in to the generic driver).

## Test plan
- [x] `ruff check .` passes
- [x] `python -m pytest mpisppy/tests/test_generic_cylinders.py -v` passes (2/2)
- [x] Negative control: temporarily reverting the wiring in `mpisppy/generic/extensions.py` makes the new test fail (no stdev CSV produced) — confirms the test actually exercises the wiring
- [x] Manual run: `python mpisppy/generic_cylinders.py --module-name farmer --num-scens 3 --solver-name cplex --max-iterations 8 --default-rho 1 --wtracker --wtracker-file-prefix wt` produces `wt_summary_*.txt`, `wt_stdev_*.csv`, `wt_cv_*.csv` with finite mean/stdev rows like `('DevotedAcreage[CORN0]', 'scen1') = mean 109.23, stdev 29.29`
- [x] `cd doc && make html` builds clean (no new warnings)

Already covered by `run_coverage.bash` and `.github/workflows/test_pr_and_main.yml` since `test_generic_cylinders.py` is already enrolled — no CI workflow changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)