### PR TITLE
CI: add gurobi-via-pip smoke job

### DIFF
--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -418,6 +418,44 @@ jobs:
           if-no-files-found: ignore
           include-hidden-files: true
 
+  straight-tests-gurobi:
+    name: straight_tests.py (gurobi via pip)
+    runs-on: ubuntu-latest
+    needs: [ruff]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          activate-environment: test_env
+          python-version: 3.11
+      - name: Install dependencies
+        run: |
+          conda install mpi4py pandas setuptools
+          pip install pyomo gurobipy dill matplotlib scipy coverage
+
+      - name: setup the program
+        run: |
+          pip install -e .
+
+      - name: Probe gurobi_persistent availability
+        run: |
+          python -c "import pyomo.environ as pyo; s = pyo.SolverFactory('gurobi_persistent'); print('gurobi_persistent available:', s.available()); import gurobipy; print('gurobipy version:', gurobipy.gurobi.version())"
+
+      - name: mpi tests
+        run: |
+          PYARGS="-m coverage run $COV_ARGS"
+          cd mpisppy/tests
+          coverage run $COV_ARGS straight_tests.py --python-args="$PYARGS"
+
+      - name: Upload coverage data
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-straight-tests-gurobi
+          path: ${{ github.workspace }}/.coverage.*
+          if-no-files-found: ignore
+          include-hidden-files: true
+
   admm-wrapper:
     name: admm wrapper tests
     runs-on: ubuntu-latest
@@ -1037,6 +1075,7 @@ jobs:
       - uc-relaxed
       - schur-complement
       - straight-tests
+      - straight-tests-gurobi
       - admm-wrapper
       - aph
       - ph-main


### PR DESCRIPTION
## Summary

Adds a new CI job, `straight_tests.py (gurobi via pip)`, that runs
`mpisppy/tests/straight_tests.py` against `gurobi_persistent` after
`pip install gurobipy`. The gurobipy wheel ships with a size-limited
trial license (no license file, no account), and the straight-tests
problems (3-scenario farmer, 24-scenario aircond) are well within the
pip license's variable/constraint cap.

Mechanism: the job installs only `gurobipy` as a solver, so the
priority list in `mpisppy/tests/utils.py:get_solver()` (`cplex →
gurobi → xpress`, persistent first) falls through to
`gurobi_persistent`. straight_tests.py picks that up via
`get_solver()` and exercises both EF and the cylinder system.

The job is also wired into `coverage-report`'s `needs:` so its
coverage artifact is merged into the codecov upload alongside the
other solvers.

## Test plan

- [ ] CI shows new `straight_tests.py (gurobi via pip)` job
- [ ] The `Probe gurobi_persistent availability` step prints a
      gurobipy version and `available: True`
- [ ] The `mpi tests` step (straight_tests.py) completes green
- [ ] Coverage Report job includes `coverage-straight-tests-gurobi`
      artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)