### PR TITLE
CI: fix schur-complement and gradient-rho flakes (conda env activation)

### DIFF
--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -809,7 +809,7 @@ jobs:
       - name: Install dependencies
         run: |
           conda install -y conda-forge::libstdcxx-ng
-          conda install -y -c conda-forge openmpi mpi4py "numpy" setuptools cmake
+          conda install -y -c conda-forge openmpi mpi4py "numpy" setuptools cmake pip
           conda run -n test_env --no-capture-output pip install pyomo pandas xpress cplex scipy sympy dill packaging coverage
 
       - name: setup the program

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -810,18 +810,18 @@ jobs:
         run: |
           conda install -y conda-forge::libstdcxx-ng
           conda install -y -c conda-forge openmpi mpi4py "numpy" setuptools cmake
-          pip install pyomo pandas xpress cplex scipy sympy dill packaging coverage
+          conda run -n test_env --no-capture-output pip install pyomo pandas xpress cplex scipy sympy dill packaging coverage
 
       - name: setup the program
         run: |
-          pip install -e .
+          conda run -n test_env --no-capture-output pip install -e .
 
       - name: run gradient/rho tests
         timeout-minutes: 10
         run: |
           cd mpisppy/tests
-          coverage run $COV_ARGS test_gradient_rho.py
-          coverage run $COV_ARGS test_xbar_w_reader_writer.py
+          conda run -n test_env --no-capture-output coverage run $COV_ARGS test_gradient_rho.py
+          conda run -n test_env --no-capture-output coverage run $COV_ARGS test_xbar_w_reader_writer.py
 
       - name: Upload coverage data
         if: always()

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -350,6 +350,7 @@ jobs:
       - name: Install dependencies
         shell: bash -l {0}
         run: |
+          conda install -y pip
           python -m pip install --upgrade pip
           pip install pytest pytest-cov pybind11 coverage
           conda install -y conda-forge::libstdcxx-ng

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -344,7 +344,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: ${{ matrix.python-version }}
-          channels: anaconda, conda-forge
+          channels: conda-forge, anaconda
           activate-environment: test_env
 
       - name: Install dependencies

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -794,6 +794,9 @@ jobs:
     name: gradient and rho tests
     runs-on: ubuntu-latest
     needs: [ruff]
+    defaults:
+      run:
+        shell: bash -l {0}
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
## Summary

Two related CI flakes, both caused by conda env activation in
setup-miniconda jobs not behaving the way one might expect. Both
manifested as recurring red checks on recent PRs (#681, #692).

### schur-complement: `No module named pip`

The schur-complement job's install step started with `python -m pip
install --upgrade pip` — but setup-miniconda v3 only installs `python`
into `test_env`, and modern conda-forge Python no longer bundles
`pip` (it's a separate `pip` conda package). The other conda-based
jobs in this workflow happen to work because their install step
starts with `conda install <stuff>`, which resolves `pip` as a
transitive dep before the first `pip` invocation.

Also reordered the channel list from \`anaconda, conda-forge\` to
\`conda-forge, anaconda\` so Python comes from conda-forge (where the
recipe is well-maintained and reliable), with anaconda as fallback.

Fix: add \`conda install -y pip\` as the first line of the install
step, plus the channel reorder.

### gradient-and-rho: `module 'mpisppy.MPI' has no attribute 'Comm'`

The gradient-rho job's failing pattern:

  - conda installs \`mpi4py-4.1.1-py311…\` correctly into test_env
  - \`pip install pyomo pandas …\` reports \`Defaulting to user
    installation because normal site-packages is not writeable\` and
    installs cp312 wheels into \`/home/runner/.local/lib/python3.12/…\`
  - the test then runs under system Python 3.12 (which has pyomo but
    no mpi4py) → \`mpisppy.MPI\` falls back to the in-repo shim →
    \`spwindow.py\`'s \`MPI.Comm\` type annotation fails at import

Root cause: GitHub Actions' default shell (\`bash --noprofile
--norc\`) doesn't source the conda activation hooks setup-miniconda
writes to \`~/.profile\`. The action attempts to set
\`defaults.run.shell\` on the job, but the override is not
consistently picked up.

Fix: set \`defaults.run.shell: bash -l {0}\` on the job. Login shell
sources \`~/.profile\`, conda activates test_env, conda env's pip and
python win on PATH. Deterministic.

## Test plan

- [ ] On this PR, \`schur-complement (3.11)\` passes (no \`No module
      named pip\`)
- [ ] On this PR, \`gradient and rho tests\` passes (no \`MPI has no
      attribute 'Comm'\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)