### PR TITLE
Solver options: switch consumption to layers + deprecate Gapper static-dict

### DIFF
--- a/mpisppy/cylinders/lagranger_bounder.py
+++ b/mpisppy/cylinders/lagranger_bounder.py
@@ -95,10 +95,10 @@ class LagrangerOuterBound(_JensensMixin, _LagrangianMixin, mpisppy.cylinders.spo
         if extensions:
             self.opt.extobject.pre_iter0()
         self.A_iter = 1
-        # _PHIter drives the per-iteration fold inside
-        # PHBase._effective_solver_options (see
-        # doc/designs/solver_options_redesign.md §5.4); lagranger
-        # doesn't otherwise track it.
+        # _PHIter drives the per-iteration solver-options fold inside
+        # PHBase._effective_solver_options; lagranger doesn't
+        # otherwise track it, so we flip it manually across the
+        # iter0→iterk boundary.
         self.opt._PHIter = 0
         self.trivial_bound = self._lagrangian(0)
         if extensions:

--- a/mpisppy/cylinders/lagranger_bounder.py
+++ b/mpisppy/cylinders/lagranger_bounder.py
@@ -95,15 +95,23 @@ class LagrangerOuterBound(_JensensMixin, _LagrangianMixin, mpisppy.cylinders.spo
         if extensions:
             self.opt.extobject.pre_iter0()
         self.A_iter = 1
+        # _PHIter drives the per-iteration fold inside
+        # PHBase._effective_solver_options (see
+        # doc/designs/solver_options_redesign.md §5.4); lagranger
+        # doesn't otherwise track it.
+        self.opt._PHIter = 0
         self.trivial_bound = self._lagrangian(0)
         if extensions:
             self.opt.extobject.post_iter0()
+        self.opt._PHIter = 1
 
         self.send_bound(self.trivial_bound)
         if extensions:
             self.opt.extobject.post_iter0_after_sync()
 
-        self.opt.current_solver_options = self.opt.iterk_solver_options
+        # Clear the dynamic-overrides overlay at the iter0→iterk
+        # transition; static iterk options come from the layer fold.
+        self.opt.current_solver_options = {}
 
         while not self.got_kill_signal():
             # because of aph, do not check for new data, just go for it

--- a/mpisppy/cylinders/lagrangian_bounder.py
+++ b/mpisppy/cylinders/lagrangian_bounder.py
@@ -32,7 +32,7 @@ class _LagrangianMixin:
             teeme = self.opt.options['tee-rank0-solves']
 
         self.opt.solve_loop(
-            solver_options=self.opt.current_solver_options,
+            solver_options=self.opt._effective_solver_options(self.opt._PHIter),
             dtiming=False,
             gripe=True,
             tee=teeme,
@@ -95,7 +95,9 @@ class LagrangianOuterBound(_JensensMixin, _LagrangianMixin, mpisppy.cylinders.sp
             self.opt.extobject.post_iter0()
         self.opt._PHIter += 1
 
-        self.opt.current_solver_options = self.opt.iterk_solver_options
+        # Clear the dynamic-overrides overlay at the iter0→iterk
+        # transition; static iterk options come from the layer fold.
+        self.opt.current_solver_options = {}
 
         self.send_bound(self.trivial_bound)
         if extensions:

--- a/mpisppy/extensions/mipgapper.py
+++ b/mpisppy/extensions/mipgapper.py
@@ -29,17 +29,14 @@ class Gapper(mpisppy.extensions.extension.Extension):
             # The static-schedule mode is subsumed by the
             # solver_options_layers system: --mipgaps-json is now
             # routed straight to after_iter layers in
-            # cfg_vanilla.add_gapper, and arbitrary per-iteration
-            # mipgap settings will be expressible via
-            # --solver-options-file (see
-            # doc/designs/solver_options_redesign.md §5.3, §5.7).
-            # Auto mode (starting_mipgap / mipgap_ratio) is not
-            # deprecated.
+            # cfg_vanilla.add_gapper, with no need for this extension.
+            # The dynamic (auto-tightening) mode driven by
+            # starting_mipgap / mipgap_ratio is not deprecated.
             warnings.warn(
                 "Gapper's static mipgap-dictionary mode is deprecated; "
-                "use --mipgaps-json (now routed through "
-                "solver_options_layers) or --solver-options-file. "
-                "Automatic mipgap mode (starting_mipgap / "
+                "use --mipgaps-json, which is now plumbed directly "
+                "through solver_options_layers without the Gapper "
+                "extension. Automatic mipgap mode (starting_mipgap / "
                 "mipgap_ratio) is not affected.",
                 DeprecationWarning,
                 stacklevel=2,

--- a/mpisppy/extensions/mipgapper.py
+++ b/mpisppy/extensions/mipgapper.py
@@ -11,6 +11,8 @@
     extension.
 """
 
+import warnings
+
 from mpisppy import global_toc
 import mpisppy.extensions.extension
 
@@ -23,6 +25,25 @@ class Gapper(mpisppy.extensions.extension.Extension):
         self.mipgapdict = self.gapperoptions.get("mipgapdict", None)
         self.starting_mipgap = self.gapperoptions.get("starting_mipgap", None)
         self.mipgap_ratio = self.gapperoptions.get("mipgap_ratio", None)
+        if self.mipgapdict is not None:
+            # The static-schedule mode is subsumed by the
+            # solver_options_layers system: --mipgaps-json is now
+            # routed straight to after_iter layers in
+            # cfg_vanilla.add_gapper, and arbitrary per-iteration
+            # mipgap settings will be expressible via
+            # --solver-options-file (see
+            # doc/designs/solver_options_redesign.md §5.3, §5.7).
+            # Auto mode (starting_mipgap / mipgap_ratio) is not
+            # deprecated.
+            warnings.warn(
+                "Gapper's static mipgap-dictionary mode is deprecated; "
+                "use --mipgaps-json (now routed through "
+                "solver_options_layers) or --solver-options-file. "
+                "Automatic mipgap mode (starting_mipgap / "
+                "mipgap_ratio) is not affected.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self._check_options()
 
     def _check_options(self):

--- a/mpisppy/phbase.py
+++ b/mpisppy/phbase.py
@@ -281,17 +281,80 @@ class PHBase(mpisppy.spopt.SPOpt):
         self.ph_converger = ph_converger
         self.rho_setter = rho_setter
 
-        self.iter0_solver_options = options["iter0_solver_options"]
-        self.iterk_solver_options = options["iterk_solver_options"]
-        self.current_solver_options = self.iter0_solver_options
-        # Phase-1 groundwork (doc/designs/solver_options_redesign.md
-        # §6.4 phase 1). Layer list is stored but not yet read by the
-        # solve path; iter0/iterk dicts above continue to drive solves.
-        self.solver_options_layers = options.get("solver_options_layers", [])
+        # solver_options_layers is the source of truth for
+        # per-iteration solver options; _effective_solver_options(k)
+        # folds them and overlays current_solver_options as a final
+        # "dynamic overrides" layer (used by Gapper auto-mode and the
+        # spoke iter0→iterk handoff). iter0_solver_options /
+        # iterk_solver_options below are read-only properties derived
+        # from the layer fold. See
+        # doc/designs/solver_options_redesign.md §5.2, §5.4.
+        self.solver_options_layers = list(options.get("solver_options_layers") or [])
+        if not self.solver_options_layers:
+            # Caller bypassed cfg_vanilla and supplied only the legacy
+            # iter0/iterk dicts (tests, ciutils, examples/hydro
+            # fixtures). Synthesize the equivalent layers so the fold
+            # matches what the legacy dicts described.
+            _iter0_dict = options.get("iter0_solver_options") or {}
+            _iterk_dict = options.get("iterk_solver_options") or {}
+            if _iter0_dict:
+                self.solver_options_layers.append(
+                    sputils.solver_options_layer("iter0", _iter0_dict))
+            if _iterk_dict:
+                self.solver_options_layers.append(
+                    sputils.solver_options_layer("iterk", _iterk_dict))
+        # Dynamic-overrides overlay: Gapper auto-mode mutates
+        # ["mipgap"] here; spokes clear it at iter0→iterk transition.
+        # _effective_solver_options reads it as the last fold step.
+        self.current_solver_options = {}
 
         # flags to complete the invariant
         self.convobject = None  # PH converger
         self.attach_xbars()
+
+
+    def _effective_solver_options(self, k):
+        """Effective solver options for iteration *k*.
+
+        Folds solver_options_layers per
+        doc/designs/solver_options_redesign.md §5.4, then overlays
+        self.current_solver_options as a final "dynamic overrides"
+        layer so Gapper auto-mode mutations and the spoke iter0→iterk
+        handoff continue to surface in the solve.
+
+        Args:
+            k (int): iteration number (0 for iter0).
+
+        Returns:
+            dict: merged options for the solver.
+        """
+        folded = sputils.fold_solver_options_layers(
+            self.solver_options_layers, k)
+        if self.current_solver_options:
+            folded.update(self.current_solver_options)
+        return folded
+
+    @property
+    def iter0_solver_options(self):
+        """Read-only fold of solver_options_layers for iteration 0.
+
+        Derived from solver_options_layers (the source of truth);
+        retained for back-compat with callers that read this attr
+        directly. Solve sites should use _effective_solver_options(k).
+        """
+        return sputils.fold_solver_options_layers(
+            self.solver_options_layers, 0)
+
+    @property
+    def iterk_solver_options(self):
+        """Read-only fold of solver_options_layers for iteration k>=1.
+
+        Returns the fold at k=1; later iterations may differ when
+        after_iter layers are present (callers wanting an exact
+        per-iteration view should call _effective_solver_options(k)).
+        """
+        return sputils.fold_solver_options_layers(
+            self.solver_options_layers, 1)
 
 
     def Compute_Xbar(self, verbose=False):
@@ -980,7 +1043,7 @@ class PHBase(mpisppy.spopt.SPOpt):
                 print ("About to call PH Iter0 solve loop on rank={}".format(self.cylinder_rank))
             global_toc("Entering solve loop in PHBase.Iter0")
 
-            self.solve_loop(solver_options=self.current_solver_options,
+            self.solve_loop(solver_options=self._effective_solver_options(self._PHIter),
                             dtiming=dtiming,
                             gripe=True,
                             tee=teeme,
@@ -1053,7 +1116,11 @@ class PHBase(mpisppy.spopt.SPOpt):
 
         self.reenable_W_and_prox()
 
-        self.current_solver_options = self.options["iterk_solver_options"]
+        # Clear the dynamic-overrides overlay at the iter0→iterk
+        # transition: static iterk options come from the layer fold,
+        # and dropping any Gapper auto-mode mipgap accumulated during
+        # iter0 lets iterk start from the static fold + fresh updates.
+        self.current_solver_options = {}
 
         return self.trivial_bound
 
@@ -1141,7 +1208,7 @@ class PHBase(mpisppy.spopt.SPOpt):
             )
 
             self.solve_loop(
-                solver_options=self.current_solver_options,
+                solver_options=self._effective_solver_options(self._PHIter),
                 dtiming=dtiming,
                 gripe=True,
                 disable_pyomo_signal_handling=False,

--- a/mpisppy/phbase.py
+++ b/mpisppy/phbase.py
@@ -287,8 +287,7 @@ class PHBase(mpisppy.spopt.SPOpt):
         # "dynamic overrides" layer (used by Gapper auto-mode and the
         # spoke iter0→iterk handoff). iter0_solver_options /
         # iterk_solver_options below are read-only properties derived
-        # from the layer fold. See
-        # doc/designs/solver_options_redesign.md §5.2, §5.4.
+        # from the layer fold.
         self.solver_options_layers = list(options.get("solver_options_layers") or [])
         if not self.solver_options_layers:
             # Caller bypassed cfg_vanilla and supplied only the legacy
@@ -316,11 +315,12 @@ class PHBase(mpisppy.spopt.SPOpt):
     def _effective_solver_options(self, k):
         """Effective solver options for iteration *k*.
 
-        Folds solver_options_layers per
-        doc/designs/solver_options_redesign.md §5.4, then overlays
-        self.current_solver_options as a final "dynamic overrides"
-        layer so Gapper auto-mode mutations and the spoke iter0→iterk
-        handoff continue to surface in the solve.
+        Folds solver_options_layers (each layer's "when" predicate
+        decides whether it applies at iteration k; last write wins
+        per key), then overlays self.current_solver_options as a
+        final "dynamic overrides" layer so Gapper auto-mode
+        mutations and the spoke iter0→iterk handoff continue to
+        surface in the solve.
 
         Args:
             k (int): iteration number (0 for iter0).

--- a/mpisppy/tests/test_ph_extensions.py
+++ b/mpisppy/tests/test_ph_extensions.py
@@ -14,6 +14,7 @@
 import glob
 import os
 import unittest
+import warnings
 
 import mpisppy.opt.ph
 import mpisppy.tests.examples.farmer as farmer
@@ -56,49 +57,69 @@ class TestGapper(unittest.TestCase):
     @unittest.skipIf(not solver_available,
                      "%s solver is not available" % (solver_name,))
     def test_gapper_dict_mode(self):
-        """Gapper with mipgapdict should set mipgap per iteration."""
+        """Gapper's static mipgapdict path runs end-to-end and warns.
+
+        Constructing gapperoptions['mipgapdict'] is the deprecated
+        static-schedule path (the supported path is --mipgaps-json,
+        which cfg_vanilla.add_gapper routes through
+        solver_options_layers). This test exercises the legacy code
+        path and asserts the DeprecationWarning fires. The sizes
+        3-scenario fixture trivially converges at iter0, so this
+        fixture cannot verify later-iteration mipgap values — that
+        regression lives in test_solver_options_layers.py instead.
+        """
         from mpisppy.extensions.mipgapper import Gapper
         options = self._copy_options()
         options["gapperoptions"] = {
             "mipgapdict": {0: 0.10, 2: 0.05, 4: 0.01},
         }
-        ph = mpisppy.opt.ph.PH(
-            options,
-            self.scenario_names,
-            sizes_creator,
-            sizes_denouement,
-            scenario_creator_kwargs=self.creator_kwargs,
-            extensions=Gapper,
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            ph = mpisppy.opt.ph.PH(
+                options,
+                self.scenario_names,
+                sizes_creator,
+                sizes_denouement,
+                scenario_creator_kwargs=self.creator_kwargs,
+                extensions=Gapper,
+            )
+        self.assertTrue(
+            any(issubclass(w.category, DeprecationWarning)
+                and "Gapper" in str(w.message) for w in caught),
+            f"Expected DeprecationWarning from Gapper static-dict mode; "
+            f"got {[(w.category.__name__, str(w.message)) for w in caught]}",
         )
         conv, obj, tbound = ph.ph_main()
         self.assertIsNotNone(obj)
-        # After iteration 4, mipgap should have been set to 0.01
-        self.assertAlmostEqual(
-            ph.current_solver_options["mipgap"], 0.01, places=5)
 
     @unittest.skipIf(not solver_available,
                      "%s solver is not available" % (solver_name,))
     def test_gapper_changes_gap(self):
-        """Verify Gapper actually changes the gap across iterations."""
+        """Verify Gapper's mipgapdict path runs end-to-end and warns."""
         from mpisppy.extensions.mipgapper import Gapper
         options = self._copy_options()
         options["PHIterLimit"] = 3
         options["gapperoptions"] = {
             "mipgapdict": {0: 0.50, 2: 0.001},
         }
-        ph = mpisppy.opt.ph.PH(
-            options,
-            self.scenario_names,
-            sizes_creator,
-            sizes_denouement,
-            scenario_creator_kwargs=self.creator_kwargs,
-            extensions=Gapper,
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            ph = mpisppy.opt.ph.PH(
+                options,
+                self.scenario_names,
+                sizes_creator,
+                sizes_denouement,
+                scenario_creator_kwargs=self.creator_kwargs,
+                extensions=Gapper,
+            )
+        self.assertTrue(
+            any(issubclass(w.category, DeprecationWarning)
+                and "Gapper" in str(w.message) for w in caught),
+            f"Expected DeprecationWarning from Gapper static-dict mode; "
+            f"got {[(w.category.__name__, str(w.message)) for w in caught]}",
         )
         conv, obj, tbound = ph.ph_main()
         self.assertIsNotNone(obj)
-        # Verify the final gap was applied
-        self.assertAlmostEqual(
-            ph.current_solver_options["mipgap"], 0.001, places=5)
 
 
 class TestMultRhoUpdater(unittest.TestCase):

--- a/mpisppy/tests/test_solver_options_layers.py
+++ b/mpisppy/tests/test_solver_options_layers.py
@@ -6,13 +6,13 @@
 # All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
 # full copyright and license information.
 ###############################################################################
-# Phase-1 tests for solver_options_layers — see
-# doc/designs/solver_options_redesign.md §6.4. The contract this file
-# pins is: the new layered representation folds (per-iteration) to
-# dicts identical to the legacy iter0_solver_options /
+# Tests for solver_options_layers — see
+# doc/designs/solver_options_redesign.md §5.2, §5.4. The contract
+# this file pins is: the layered representation folds (per-iteration)
+# to dicts identical to the legacy iter0_solver_options /
 # iterk_solver_options dicts produced by shared_options and
-# apply_solver_specs. Phase 1 is a pure-refactor groundwork step;
-# every later phase will lean on this equivalence.
+# apply_solver_specs. Later changes to merge precedence (§5.5) lean
+# on this equivalence.
 
 import copy
 import unittest
@@ -86,9 +86,9 @@ class TestSharedOptionsLayers(unittest.TestCase):
         self.assertEqual(folded["threads"], 4)
 
     def test_combined_fold_equals_legacy_iter0_iterk_dicts(self):
-        # The regression contract for phase 1: under any cfg
-        # combination, fold(layers, 0) must match iter0_solver_options
-        # and fold(layers, k>=1) must match iterk_solver_options.
+        # Regression contract: under any cfg combination,
+        # fold(layers, 0) must match iter0_solver_options and
+        # fold(layers, k>=1) must match iterk_solver_options.
         cfg = _bare_cfg()
         cfg.solver_options = "logfile=run.log threads=2"
         cfg.max_solver_threads = 4
@@ -118,9 +118,9 @@ class TestApplySolverSpecsLayers(unittest.TestCase):
         return {"opt_kwargs": {"options": copy.deepcopy(sh)}}
 
     def test_per_spoke_solver_options_replace_layers(self):
-        # Phase 1 mirrors today's replace-not-overlay semantics in
-        # apply_solver_specs (cfg_vanilla.py:119-120). Phase 5 will
-        # change this to overlay; phase-1 tests pin the legacy contract.
+        # Today's per-spoke semantics are replace-not-overlay in
+        # apply_solver_specs (cfg_vanilla.py:119-120); these tests pin
+        # the legacy contract. §5.5 will change this to overlay later.
         cfg = _spoke_cfg("lagrangian")
         cfg.solver_options = "logfile=run.log"
         cfg.lagrangian_solver_options = "mipgap=0.001"
@@ -212,6 +212,123 @@ class TestPredicateValidation(unittest.TestCase):
         bad_layers = [{"when": "huh", "options": {}}]
         with self.assertRaises(ValueError):
             fold_solver_options_layers(bad_layers, 0)
+
+
+class TestEffectiveSolverOptions(unittest.TestCase):
+    """The PHBase consumption contract.
+
+    Pins three properties of PHBase._effective_solver_options(k):
+      1. It folds solver_options_layers per the predicates in §5.4.
+      2. current_solver_options is overlaid last (so Gapper auto-mode
+         writes to current_solver_options surface in the solve).
+      3. after_iter layers fire on iterations >= N, matching the
+         per-iter mipgap semantics --mipgaps-json now produces via
+         add_gapper.
+    """
+
+    @staticmethod
+    def _effective(layers, current, k):
+        """Call PHBase._effective_solver_options against a fake.
+
+        Avoids constructing a full PHBase (which needs scenarios) by
+        invoking the unbound method on a duck-typed object.
+        """
+        from mpisppy.phbase import PHBase
+        fake = type("FakePH", (), {})()
+        fake.solver_options_layers = layers
+        fake.current_solver_options = current
+        return PHBase._effective_solver_options(fake, k)
+
+    def test_iter0_iterk_layers_fold_per_k(self):
+        layers = [
+            solver_options_layer("iter0", {"mipgap": 0.01}),
+            solver_options_layer("iterk", {"mipgap": 0.001}),
+        ]
+        self.assertEqual(
+            self._effective(layers, {}, 0), {"mipgap": 0.01})
+        self.assertEqual(
+            self._effective(layers, {}, 1), {"mipgap": 0.001})
+        self.assertEqual(
+            self._effective(layers, {}, 5), {"mipgap": 0.001})
+
+    def test_current_solver_options_overlays_last(self):
+        # Gapper auto-mode writes to current_solver_options and that
+        # write must surface in the next solve, on top of layer fold.
+        layers = [solver_options_layer("default", {"mipgap": 0.1})]
+        current = {"mipgap": 0.001}  # Gapper-style override
+        self.assertEqual(
+            self._effective(layers, current, 0), {"mipgap": 0.001})
+        self.assertEqual(
+            self._effective(layers, current, 5), {"mipgap": 0.001})
+
+    def test_after_iter_layers_match_mipgaps_json_semantics(self):
+        # cfg_vanilla.add_gapper turns --mipgaps-json {0: G0, 5: G5,
+        # 10: G10} into a list of after_iter layers; assert the fold
+        # gives the expected per-iter mipgap.
+        layers = [
+            solver_options_layer(("after_iter", 0), {"mipgap": 0.10}),
+            solver_options_layer(("after_iter", 5), {"mipgap": 0.01}),
+            solver_options_layer(("after_iter", 10), {"mipgap": 0.005}),
+        ]
+        self.assertEqual(self._effective(layers, {}, 0)["mipgap"], 0.10)
+        self.assertEqual(self._effective(layers, {}, 4)["mipgap"], 0.10)
+        self.assertEqual(self._effective(layers, {}, 5)["mipgap"], 0.01)
+        self.assertEqual(self._effective(layers, {}, 9)["mipgap"], 0.01)
+        self.assertEqual(self._effective(layers, {}, 10)["mipgap"], 0.005)
+
+
+class TestAddGapperMipgapsJsonLayers(unittest.TestCase):
+    """add_gapper's static-schedule path now appends layers and skips
+    the Gapper extension. See doc/designs/solver_options_redesign.md
+    §5.7 and the test_effective_solver_options assertions above.
+    """
+
+    def _hub_dict(self):
+        return {
+            "opt_kwargs": {
+                "options": {"solver_options_layers": []},
+            },
+        }
+
+    def _write_mipgaps_json(self, schedule):
+        import json
+        import tempfile
+        path = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False).name
+        with open(path, "w") as f:
+            json.dump({str(k): v for k, v in schedule.items()}, f)
+        return path
+
+    def test_mipgaps_json_appends_after_iter_layers(self):
+        import os
+        from mpisppy.utils.cfg_vanilla import add_gapper
+        cfg = _bare_cfg()
+        cfg.add_to_config(
+            "mipgaps_json", description="x", domain=str, default=None)
+        cfg.add_to_config(
+            "starting_mipgap", description="x", domain=float, default=None)
+        cfg.add_to_config(
+            "mipgap_ratio", description="x", domain=float, default=None)
+        path = self._write_mipgaps_json({0: 0.10, 5: 0.01, 10: 0.005})
+        try:
+            cfg.mipgaps_json = path
+            hub_dict = self._hub_dict()
+            add_gapper(hub_dict, cfg)
+            layers = hub_dict["opt_kwargs"]["options"]["solver_options_layers"]
+            # 3 after_iter layers in ascending-N order
+            self.assertEqual(len(layers), 3)
+            self.assertEqual(layers[0]["when"], ("after_iter", 0))
+            self.assertEqual(layers[1]["when"], ("after_iter", 5))
+            self.assertEqual(layers[2]["when"], ("after_iter", 10))
+            self.assertEqual(
+                [layer["options"] for layer in layers],
+                [{"mipgap": 0.10}, {"mipgap": 0.01}, {"mipgap": 0.005}],
+            )
+            # No Gapper extension was wired (gapperoptions not added)
+            self.assertNotIn(
+                "gapperoptions", hub_dict["opt_kwargs"]["options"])
+        finally:
+            os.unlink(path)
 
 
 if __name__ == "__main__":

--- a/mpisppy/tests/test_solver_options_layers.py
+++ b/mpisppy/tests/test_solver_options_layers.py
@@ -6,13 +6,11 @@
 # All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
 # full copyright and license information.
 ###############################################################################
-# Tests for solver_options_layers — see
-# doc/designs/solver_options_redesign.md §5.2, §5.4. The contract
-# this file pins is: the layered representation folds (per-iteration)
-# to dicts identical to the legacy iter0_solver_options /
-# iterk_solver_options dicts produced by shared_options and
-# apply_solver_specs. Later changes to merge precedence (§5.5) lean
-# on this equivalence.
+# Tests for solver_options_layers. The contract this file pins is:
+# the layered representation folds (per-iteration) to dicts
+# identical to the legacy iter0_solver_options / iterk_solver_options
+# dicts produced by shared_options and apply_solver_specs. Later
+# changes to per-spoke merge semantics will lean on this equivalence.
 
 import copy
 import unittest
@@ -119,8 +117,10 @@ class TestApplySolverSpecsLayers(unittest.TestCase):
 
     def test_per_spoke_solver_options_replace_layers(self):
         # Today's per-spoke semantics are replace-not-overlay in
-        # apply_solver_specs (cfg_vanilla.py:119-120); these tests pin
-        # the legacy contract. §5.5 will change this to overlay later.
+        # apply_solver_specs: each --{name}-solver-options call
+        # discards the global --solver-options dict. A later phase
+        # will change this to overlay; this test pins the legacy
+        # contract until then.
         cfg = _spoke_cfg("lagrangian")
         cfg.solver_options = "logfile=run.log"
         cfg.lagrangian_solver_options = "mipgap=0.001"
@@ -218,7 +218,8 @@ class TestEffectiveSolverOptions(unittest.TestCase):
     """The PHBase consumption contract.
 
     Pins three properties of PHBase._effective_solver_options(k):
-      1. It folds solver_options_layers per the predicates in §5.4.
+      1. It folds solver_options_layers in list order, picking layers
+         whose "when" predicate matches k and last-write-wins per key.
       2. current_solver_options is overlaid last (so Gapper auto-mode
          writes to current_solver_options surface in the solve).
       3. after_iter layers fire on iterations >= N, matching the
@@ -278,9 +279,12 @@ class TestEffectiveSolverOptions(unittest.TestCase):
 
 
 class TestAddGapperMipgapsJsonLayers(unittest.TestCase):
-    """add_gapper's static-schedule path now appends layers and skips
-    the Gapper extension. See doc/designs/solver_options_redesign.md
-    §5.7 and the test_effective_solver_options assertions above.
+    """add_gapper's static-schedule path now appends after_iter
+    layers and skips the Gapper extension. The resulting per-iter
+    mipgap behavior is pinned by
+    TestEffectiveSolverOptions.test_after_iter_layers_match_mipgaps_json_semantics
+    above; this class pins the cfg_vanilla wiring that produces
+    those layers from the JSON file.
     """
 
     def _hub_dict(self):

--- a/mpisppy/utils/cfg_vanilla.py
+++ b/mpisppy/utils/cfg_vanilla.py
@@ -62,10 +62,11 @@ def shared_options(cfg, is_hub=False):
         "display_convergence_detail": cfg.display_convergence_detail,
         "iter0_solver_options": dict(),
         "iterk_solver_options": dict(),
-        # Phase-1 groundwork (see doc/designs/solver_options_redesign.md
-        # §5.2 / §6.4). The layer list is built in parallel with the
-        # legacy iter0/iterk dicts and folds to the same values; no
-        # consumer reads from it yet.
+        # Layered representation of solver options (see
+        # doc/designs/solver_options_redesign.md §5.2). Built in
+        # parallel with the legacy iter0/iterk dicts above and folds
+        # to the same values; PHBase consumes via
+        # _effective_solver_options(k).
         "solver_options_layers": [],
         "tee-rank0-solves": cfg.tee_rank0_solves,
         "trace_prefix" : cfg.trace_prefix,
@@ -129,10 +130,11 @@ def shared_options(cfg, is_hub=False):
 
 def apply_solver_specs(name, spoke, cfg):
     options = spoke["opt_kwargs"]["options"]
-    # Phase-1 groundwork: keep the legacy iter0/iterk dict mutations and
-    # mirror them onto solver_options_layers (§5.2 / §6.4 phase 1).
-    # Layer list is dormant; no consumer reads it yet. Phase 5 will
-    # change replace-style to overlay; phase 1 keeps the legacy contract.
+    # Mirror the legacy iter0/iterk dict mutations onto
+    # solver_options_layers (see
+    # doc/designs/solver_options_redesign.md §5.2). The current
+    # behavior of per-spoke options is replace-style; §5.5 will change
+    # this to overlay later.
     options.setdefault("solver_options_layers", [])
     if _hasit(cfg, name+"_solver_name"):
         options["solver_name"] = cfg.get(name+"_solver_name")
@@ -426,23 +428,57 @@ def extension_adder(hub_dict,ext_class):
     return hub_dict
 
 def add_gapper(hub_dict, cfg, name=None):
-    from mpisppy.extensions.mipgapper import Gapper
-    hub_dict = extension_adder(hub_dict, Gapper)
-    if name is None and cfg.mipgaps_json is not None:
+    """Wire mipgap schedule / auto mipgap into a hub or spoke dict.
+
+    Two modes:
+      * static schedule (``--mipgaps-json``, global only): the JSON is
+        parsed into ``after_iter`` solver-options layers appended to
+        ``solver_options_layers`` on the cylinder dict. No Gapper
+        extension is registered; the layer fold drives the per-iter
+        mipgap directly. See
+        doc/designs/solver_options_redesign.md §5.7.
+      * auto mipgap (``--starting-mipgap`` + ``--mipgap-ratio``, also
+        per-spoke as e.g. ``--lagrangian-starting-mipgap``): the
+        Gapper extension is registered and observes inner/outer bound
+        cylinders at runtime to tighten mipgap.
+
+    The two modes are mutually exclusive at the global level (Gapper
+    historically raised this; the check now lives here since the
+    static path no longer goes through Gapper).
+    """
+    prefix = "" if name is None else name + "_"
+    starting_mipgap = getattr(cfg, f"{prefix}starting_mipgap", None)
+    mipgap_ratio = getattr(cfg, f"{prefix}mipgap_ratio", None)
+    static_schedule = (name is None and cfg.mipgaps_json is not None)
+
+    if static_schedule and starting_mipgap is not None:
+        raise RuntimeError(
+            "--mipgaps-json (static schedule) and --starting-mipgap "
+            "(auto mipgap) are mutually exclusive; pick one."
+        )
+
+    if static_schedule:
         with open(cfg.mipgaps_json) as fin:
             din = json.load(fin)
         mipgapdict = {int(i): din[i] for i in din}
-    else:
-        mipgapdict = None
-    if name is None:
-        name = ""
-    else:
-        name = name + "_"
+        layers = hub_dict["opt_kwargs"]["options"].setdefault(
+            "solver_options_layers", [])
+        for N in sorted(mipgapdict.keys()):
+            layers.append(
+                sputils.solver_options_layer(
+                    ("after_iter", N), {"mipgap": mipgapdict[N]}))
+        return
+
+    # Auto-mipgap mode: Gapper observes bound cylinders and tightens
+    # mipgap at runtime. starting_mipgap (and the per-spoke variants)
+    # must be set; the caller gates on this.
+    from mpisppy.extensions.mipgapper import Gapper
+    hub_dict = extension_adder(hub_dict, Gapper)
     hub_dict["opt_kwargs"]["options"]["gapperoptions"] = {
         "verbose": cfg.verbose,
-        "mipgapdict": mipgapdict,
-        "starting_mipgap": getattr(cfg, f"{name}starting_mipgap"),
-        "mipgap_ratio" : getattr(cfg, f"{name}mipgap_ratio"),
+        "mipgapdict": None,
+        "starting_mipgap": starting_mipgap,
+        "mipgap_ratio": mipgap_ratio,
     }
 
 def add_fixer(hub_dict,

--- a/mpisppy/utils/cfg_vanilla.py
+++ b/mpisppy/utils/cfg_vanilla.py
@@ -62,11 +62,10 @@ def shared_options(cfg, is_hub=False):
         "display_convergence_detail": cfg.display_convergence_detail,
         "iter0_solver_options": dict(),
         "iterk_solver_options": dict(),
-        # Layered representation of solver options (see
-        # doc/designs/solver_options_redesign.md §5.2). Built in
-        # parallel with the legacy iter0/iterk dicts above and folds
-        # to the same values; PHBase consumes via
-        # _effective_solver_options(k).
+        # Layered representation of solver options. Built in parallel
+        # with the legacy iter0/iterk dicts above and folds to the
+        # same values; PHBase consumes via _effective_solver_options.
+        # Each layer is {"when": <predicate>, "options": <dict>}.
         "solver_options_layers": [],
         "tee-rank0-solves": cfg.tee_rank0_solves,
         "trace_prefix" : cfg.trace_prefix,
@@ -131,10 +130,10 @@ def shared_options(cfg, is_hub=False):
 def apply_solver_specs(name, spoke, cfg):
     options = spoke["opt_kwargs"]["options"]
     # Mirror the legacy iter0/iterk dict mutations onto
-    # solver_options_layers (see
-    # doc/designs/solver_options_redesign.md §5.2). The current
-    # behavior of per-spoke options is replace-style; §5.5 will change
-    # this to overlay later.
+    # solver_options_layers. Per-spoke option specs are currently
+    # replace-style (each --{name}-solver-options call overwrites
+    # rather than overlays the global --solver-options); a later
+    # phase will change this to overlay semantics.
     options.setdefault("solver_options_layers", [])
     if _hasit(cfg, name+"_solver_name"):
         options["solver_name"] = cfg.get(name+"_solver_name")
@@ -435,8 +434,7 @@ def add_gapper(hub_dict, cfg, name=None):
         parsed into ``after_iter`` solver-options layers appended to
         ``solver_options_layers`` on the cylinder dict. No Gapper
         extension is registered; the layer fold drives the per-iter
-        mipgap directly. See
-        doc/designs/solver_options_redesign.md §5.7.
+        mipgap directly.
       * auto mipgap (``--starting-mipgap`` + ``--mipgap-ratio``, also
         per-spoke as e.g. ``--lagrangian-starting-mipgap``): the
         Gapper extension is registered and observes inner/outer bound


### PR DESCRIPTION
## Summary

Step B of the solver-options redesign (see
[doc/designs/solver_options_redesign.md §6.4](https://github.com/Pyomo/mpi-sppy/blob/main/doc/designs/solver_options_redesign.md#64-phased-rollout)).

Two coupled changes:

1. **Switch PH's solve path from the legacy iter0/iterk dicts to the
   layered representation that landed dormant in step A.** Adds
   \`PHBase._effective_solver_options(k)\` which folds
   \`solver_options_layers\` per §5.4 and overlays
   \`current_solver_options\` as a final dynamic-overrides layer (so
   Gapper auto-mode and the spoke iter0→iterk handoff continue to
   work). \`iter0_solver_options\` and \`iterk_solver_options\` become
   read-only properties derived from the layer fold.

2. **Deprecate Gapper's static \`mipgapdict\` mode.** The static
   schedule is now expressible directly as \`after_iter\`
   solver_options_layers entries; \`cfg_vanilla.add_gapper\` parses
   \`--mipgaps-json\` straight into layers and skips the Gapper
   extension. The dynamic / automatic mode (\`--starting-mipgap\` +
   \`--mipgap-ratio\`) is **not** deprecated — it still requires
   Gapper because it observes cross-cylinder bounds at runtime.
   Programmatic uses of \`gapperoptions['mipgapdict']\` (e.g. the
   sslp and uc examples) continue to function but emit a
   \`DeprecationWarning\`.

CLI compatibility: every flag that worked before still works,
including \`--mipgaps-json\` (now plumbed via layers instead of
Gapper) and \`--starting-mipgap\` / \`--mipgap-ratio\` (unchanged).

## What changed

### Consumption switch
- \`PHBase._effective_solver_options(k)\` (new)
- \`iter0_solver_options\` / \`iterk_solver_options\` → read-only
  \`@property\` derived from the layer fold
- Init shim: synthesize layers from legacy iter0/iterk dicts when
  callers (tests, confidence_intervals, examples/hydro) bypass
  cfg_vanilla
- \`solve_loop\` callsites at \`phbase.py:983\` and \`:1144\` pass
  \`self._effective_solver_options(self._PHIter)\`
- \`lagrangian_bounder\` and \`lagranger_bounder\` solve callsites
  switched similarly; \`lagranger\` now sets \`_PHIter\` explicitly
  across the iter0→iterk boundary
- At the iter0→iterk transition, the legacy \`current_solver_options
  = iterk_solver_options\` lines now just clear the dynamic-overrides
  overlay to \`{}\`. Static iterk options come from the fold.
- \`lshaped_bounder\` uses \`Xhat_Eval\` (SPOpt, no layer machinery
  yet) and is unchanged — pushing layers into SPOpt is deferred.

### Gapper deprecation
- \`cfg_vanilla.add_gapper\`: static-schedule path now appends
  \`after_iter\` layers and skips wiring Gapper. Auto-mode path is
  unchanged. The mutual-exclusivity check (\`mipgaps-json\` vs
  \`starting-mipgap\`) was moved from \`Gapper._check_options\` to
  \`add_gapper\` (Gapper isn't created in the static-schedule path
  any more).
- \`Gapper.__init__\` emits \`DeprecationWarning\` when
  \`gapperoptions['mipgapdict']\` is non-None.

### Tests
- \`test_solver_options_layers.py\` gains:
  - \`TestEffectiveSolverOptions\` (3 tests pinning fold + current
    overlay + after_iter-as-mipgaps-json semantics)
  - \`TestAddGapperMipgapsJsonLayers\` (asserts the layer list and
    absence of \`gapperoptions\` for static mode)
- \`test_ph_extensions.py\`'s two Gapper tests now \`assertWarns\`
  the \`DeprecationWarning\` and drop the brittle final-mipgap
  assertion that **was already failing on main** (the sizes
  3-scenario fixture trivially converges at iter0, so Gapper never
  reaches the iter-4 entry of \`mipgapdict\`; this is now a known
  fixture limitation noted in the docstring).

## Test plan

- [x] Local: \`ruff check .\` clean
- [x] Local: 187/187 pass across \`test_ef_ph\`, \`test_ph_main\`,
      \`test_ph_extensions\`, \`test_aph\`, \`test_jensens\`,
      \`test_solver_options_layers\`, \`test_proper_bundler\`,
      \`test_config\`, \`test_generic_cylinders\`
- [ ] CI: regression, ph-extensions, ph-main, aph, jensens, generic
      tests all green
- [ ] CI: codecov/patch covers the new \`_effective_solver_options\`
      and \`add_gapper\` static-schedule branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)