### PR TITLE
Solver options: solver-name-aware translation of canonical keys

### DIFF
--- a/mpisppy/spopt.py
+++ b/mpisppy/spopt.py
@@ -181,9 +181,14 @@ class SPOpt(SPBase):
 
         solve_start_time = time.time()
         if (solver_options):
+            # Translate canonical option keys to the solver's native
+            # spelling at the latest moment, so stored options on
+            # PHBase / spokes remain solver-agnostic.
+            translated_options = sputils.translate_solver_options(
+                solver_options, self.options.get("solver_name"))
             _vb("Using sub-problem solver options="
-                + str(solver_options))
-            for option_key,option_value in solver_options.items():
+                + str(translated_options))
+            for option_key,option_value in translated_options.items():
                 s._solver_plugin.options[option_key] = option_value
 
         solve_keyword_args = dict()

--- a/mpisppy/tests/test_solver_options_layers.py
+++ b/mpisppy/tests/test_solver_options_layers.py
@@ -116,11 +116,11 @@ class TestApplySolverSpecsLayers(unittest.TestCase):
         return {"opt_kwargs": {"options": copy.deepcopy(sh)}}
 
     def test_per_spoke_solver_options_replace_layers(self):
-        # Today's per-spoke semantics are replace-not-overlay in
+        # Per-spoke semantics are replace-not-overlay in
         # apply_solver_specs: each --{name}-solver-options call
-        # discards the global --solver-options dict. A later phase
-        # will change this to overlay; this test pins the legacy
-        # contract until then.
+        # discards the global --solver-options dict. This test pins
+        # that contract; if the semantics change to overlay later,
+        # this test should be updated alongside that change.
         cfg = _spoke_cfg("lagrangian")
         cfg.solver_options = "logfile=run.log"
         cfg.lagrangian_solver_options = "mipgap=0.001"
@@ -333,6 +333,97 @@ class TestAddGapperMipgapsJsonLayers(unittest.TestCase):
                 "gapperoptions", hub_dict["opt_kwargs"]["options"])
         finally:
             os.unlink(path)
+
+
+class TestTranslateSolverOptions(unittest.TestCase):
+    """translate_solver_options renames mpi-sppy's canonical option
+    keys (currently mipgap and threads) to the target solver's
+    native key, and passes everything else through unchanged.
+    Stored options remain solver-agnostic; translation is the very
+    last step before the keys hit the Pyomo solver plugin.
+    """
+
+    def _t(self, opts, solver_name):
+        from mpisppy.utils.sputils import translate_solver_options
+        return translate_solver_options(opts, solver_name)
+
+    # --- edge cases ---
+
+    def test_none_opts_returns_none(self):
+        self.assertIsNone(self._t(None, "highs"))
+
+    def test_empty_opts_returns_empty(self):
+        self.assertEqual(self._t({}, "highs"), {})
+
+    def test_none_solver_name_is_passthrough(self):
+        opts = {"mipgap": 0.01, "threads": 4}
+        self.assertEqual(self._t(opts, None), opts)
+
+    def test_empty_solver_name_is_passthrough(self):
+        opts = {"mipgap": 0.01, "threads": 4}
+        self.assertEqual(self._t(opts, ""), opts)
+
+    def test_no_canonical_keys_is_passthrough(self):
+        opts = {"presolve": 2, "logfile": "run.log"}
+        self.assertEqual(self._t(opts, "highs"), opts)
+        self.assertEqual(self._t(opts, "gurobi"), opts)
+
+    def test_input_dict_not_mutated(self):
+        opts = {"mipgap": 0.01}
+        _ = self._t(opts, "highs")
+        self.assertEqual(opts, {"mipgap": 0.01})
+
+    # --- per-solver translation correctness ---
+
+    def test_cplex_needs_no_rename(self):
+        for name in ("cplex", "cplex_persistent"):
+            self.assertEqual(
+                self._t({"mipgap": 0.01, "threads": 4}, name),
+                {"mipgap": 0.01, "threads": 4})
+
+    def test_xpress_needs_no_rename(self):
+        for name in ("xpress", "xpress_persistent"):
+            self.assertEqual(
+                self._t({"mipgap": 0.01, "threads": 4}, name),
+                {"mipgap": 0.01, "threads": 4})
+
+    def test_gurobi_renames_threads(self):
+        for name in ("gurobi", "gurobi_persistent", "appsi_gurobi"):
+            self.assertEqual(
+                self._t({"mipgap": 0.01, "threads": 4}, name),
+                {"mipgap": 0.01, "Threads": 4},
+                f"failed for solver_name={name!r}")
+
+    def test_highs_renames_mipgap(self):
+        for name in ("highs", "appsi_highs"):
+            self.assertEqual(
+                self._t({"mipgap": 0.01, "threads": 4}, name),
+                {"mip_rel_gap": 0.01, "threads": 4},
+                f"failed for solver_name={name!r}")
+
+    # --- collision rule ---
+
+    def test_highs_collision_keeps_native_drops_canonical(self):
+        # User passed mip_rel_gap directly *and* --iter0-mipgap turned
+        # into a layer with mipgap; the native key wins and the
+        # canonical one is dropped (so the solver doesn't see both).
+        result = self._t(
+            {"mipgap": 0.01, "mip_rel_gap": 0.0001}, "highs")
+        self.assertEqual(result, {"mip_rel_gap": 0.0001})
+
+    def test_gurobi_collision_keeps_native_drops_canonical(self):
+        result = self._t(
+            {"threads": 4, "Threads": 1}, "gurobi")
+        self.assertEqual(result, {"Threads": 1})
+
+    # --- pass-through of non-canonical solver-specific keys ---
+
+    def test_solver_specific_unknown_keys_passthrough(self):
+        # e.g. mip_tolerances_mipgap (CPLEX-native) — translation
+        # doesn't touch non-canonical keys regardless of solver.
+        opts = {"mip_tolerances_mipgap": 0.001, "Cuts": 2}
+        self.assertEqual(self._t(opts, "cplex"), opts)
+        self.assertEqual(self._t(opts, "gurobi"), opts)
 
 
 if __name__ == "__main__":

--- a/mpisppy/utils/cfg_vanilla.py
+++ b/mpisppy/utils/cfg_vanilla.py
@@ -130,10 +130,9 @@ def shared_options(cfg, is_hub=False):
 def apply_solver_specs(name, spoke, cfg):
     options = spoke["opt_kwargs"]["options"]
     # Mirror the legacy iter0/iterk dict mutations onto
-    # solver_options_layers. Per-spoke option specs are currently
-    # replace-style (each --{name}-solver-options call overwrites
-    # rather than overlays the global --solver-options); a later
-    # phase will change this to overlay semantics.
+    # solver_options_layers. Per-spoke option specs are replace-
+    # style: each --{name}-solver-options call overwrites rather
+    # than overlays the global --solver-options dict.
     options.setdefault("solver_options_layers", [])
     if _hasit(cfg, name+"_solver_name"):
         options["solver_name"] = cfg.get(name+"_solver_name")

--- a/mpisppy/utils/sputils.py
+++ b/mpisppy/utils/sputils.py
@@ -767,7 +767,7 @@ def fold_solver_options_layers(layers, k):
 
     Walks layers in list order, picks layers whose predicate matches k,
     and flat-dict-unions their options into a running dict (last write
-    wins per key). See doc/designs/solver_options_redesign.md §5.4.
+    wins per key).
 
     Args:
         layers (list): list of layers as built by solver_options_layer.
@@ -781,6 +781,76 @@ def fold_solver_options_layers(layers, k):
         if _layer_matches(layer["when"], k):
             folded.update(layer["options"])
     return folded
+
+
+# Solver-name-aware translation for the two canonical option keys
+# mpi-sppy stores internally. Keys not in this table are passed
+# through unchanged by translate_solver_options.
+#
+# Entries map (canonical_key, solver_name) → solver-native key when
+# the solver names the option differently. Solver names not listed
+# under a canonical key use the canonical name itself (no rename).
+# Persistent variants (e.g. gurobi_persistent) are normalized to the
+# base name before lookup.
+_SOLVER_OPTION_TRANSLATIONS = {
+    "mipgap": {
+        # HiGHS uses its native option name.
+        "highs": "mip_rel_gap",
+        "appsi_highs": "mip_rel_gap",
+    },
+    "threads": {
+        # Gurobi parameter is conventionally capitalized.
+        "gurobi": "Threads",
+        "appsi_gurobi": "Threads",
+    },
+}
+
+
+def translate_solver_options(opts, solver_name):
+    """Return a copy of *opts* with canonical option keys renamed to
+    the solver's native key, where they differ.
+
+    Currently translates only ``mipgap`` and ``threads``; all other
+    keys pass through unchanged. If the user already supplied the
+    solver-native key alongside the canonical key, the
+    solver-native key wins and the canonical key is dropped (so the
+    solver does not receive both forms).
+
+    Args:
+        opts (dict | None): solver options. ``None`` returns ``None``;
+            other inputs return a new dict (the input is not mutated).
+        solver_name (str | None): name of the target Pyomo solver
+            plugin (e.g. ``'gurobi'``, ``'gurobi_persistent'``,
+            ``'appsi_highs'``). ``None`` or empty returns a copy of
+            *opts* unchanged.
+
+    Returns:
+        dict | None: translated copy of *opts*, or ``None`` if *opts*
+        was ``None``.
+    """
+    if opts is None:
+        return None
+    out = dict(opts)
+    if not solver_name:
+        return out
+    # gurobi_persistent → gurobi; appsi_highs stays as appsi_highs;
+    # cplex_persistent → cplex; xpress_persistent → xpress.
+    base_name = solver_name
+    if base_name.endswith("_persistent"):
+        base_name = base_name[:-len("_persistent")]
+    for canonical, mapping in _SOLVER_OPTION_TRANSLATIONS.items():
+        if canonical not in out:
+            continue
+        target = mapping.get(solver_name) or mapping.get(base_name)
+        if target is None or target == canonical:
+            continue
+        if target in out:
+            # User explicitly supplied the solver-native key; respect
+            # it and drop the canonical to avoid sending duplicates.
+            del out[canonical]
+        else:
+            out[target] = out.pop(canonical)
+    return out
 
 
 ################################################################################


### PR DESCRIPTION
## Summary

Next step in the solver-options redesign. Adds
\`sputils.translate_solver_options(opts, solver_name)\`, wired into
\`spopt.solve_one\` just before the option-write loop. Until now,
mpi-sppy passed our stored option keys verbatim to the Pyomo solver
plugin we instantiated, which silently broke when the user wrote
\`mipgap\` and ran against HiGHS (which wants \`mip_rel_gap\`).

Stored options on PHBase / spokes / cfg_vanilla stay
solver-agnostic — translation is the very last step before keys hit
the solver plugin. The layered representation remains universal.

### Translation table

mpi-sppy's canonical key → solver-native key:

| Canonical | cplex | gurobi | xpress | highs / appsi_highs |
|-----------|-------|--------|--------|---------------------|
| \`mipgap\`  | mipgap | mipgap | mipgap | **mip_rel_gap** |
| \`threads\` | threads | **Threads** | threads | threads |

Persistent variants (\`gurobi_persistent\`, \`cplex_persistent\`,
\`xpress_persistent\`) and APPSI variants (\`appsi_gurobi\`,
\`appsi_highs\`) are normalized / handled the same as the base name.
Solver names not in the table pass through unchanged.

### Collision rule

If both the canonical key and its solver-native form are in
\`opts\` (e.g. the user wrote \`mip_rel_gap\` directly in
\`--solver-options\` *and* also passed \`--iter0-mipgap\`), the
solver-native key wins and the canonical key is dropped so the
solver doesn't receive duplicates.

### Edge cases

- \`solver_name\` of \`None\` / empty → no-op (returns copy of
  \`opts\`).
- \`opts\` of \`None\` → returns \`None\`.
- Non-canonical keys (\`mip_tolerances_mipgap\`, \`Cuts\`,
  \`presolve\`, \`logfile\`, …) pass through unchanged regardless of
  solver.
- Input dict is not mutated.

## Side cleanup

Picks up two carry-forward comment cleanups from the phase 2
working tree that referenced "a later phase will" / "until then"
— rephrased to describe current behavior without forward-looking
phase language.

## Test plan

- [x] Local: \`ruff check .\` clean
- [x] Local: 200/200 pass across \`test_ef_ph\`, \`test_ph_main\`,
      \`test_ph_extensions\`, \`test_aph\`, \`test_jensens\`,
      \`test_solver_options_layers\` (12 new tests covering all
      table rows, collision rule, edge cases, persistent
      variants), \`test_proper_bundler\`, \`test_config\`,
      \`test_generic_cylinders\`.
- [ ] CI: regression, ph-extensions, ph-main, gradient-rho,
      schur-complement, and the rest of the test matrix pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)