### PR TITLE
Solver options: per-spoke overlay (behavior change) + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,22 @@ Further, without this setting and in situations with a large number of
 ranks (e.g., >> 10), we have observed mpi-sppy stalling once scenario
 instances are created.
 
+2026 NOTICE: per-spoke solver-options now overlay the global dict
+-----------------------------------------------------------------
+
+The per-spoke solver-options flags (``--lagrangian-solver-options``,
+``--reduced-costs-solver-options``, etc.) now **overlay** the
+global ``--solver-options`` dict for that spoke instead of
+**replacing** it. The spoke flag's keys win on the keys it names;
+the global flag's other keys survive. Previously the spoke flag
+wiped the global dict for that spoke.
+
+In the unlikely event you relied on the spoke flag dropping a
+global key, re-spell every key you want in the spoke options or
+omit the global flag.
+See the ``solver-options`` section of the generic_cylinders docs
+for the worked example.
+
 2022 NOTICE
 -----------
 

--- a/doc/designs/solver_options_redesign.md
+++ b/doc/designs/solver_options_redesign.md
@@ -795,7 +795,10 @@ solver behavior.
 
 ### 6.2 The one user-visible behavior change
 
-`apply_solver_specs` switches from replace to overlay (§5.5).
+**Shipped:** `apply_solver_specs` now overlays per-spoke
+solver-options on top of the global dict (replace-style was the
+prior behavior, kept through phases 1–3 to minimize churn).
+
 Concretely:
 
 ```
@@ -816,15 +819,19 @@ mipgap, leaves the rest alone). Users who relied on the spoke flag
 *dropping* a global key recover that by re-spelling the spoke options
 to include the keys they want, or by leaving the global flag unset.
 
-Action items:
+Action items (all complete):
 
-- Release notes call-out under "Behavior changes."
-- Add an integration test asserting the new merge semantics (so a
-  future regression to replace-style would fail CI).
-- Audit `examples/` for any harness whose semantics actually depend
-  on replace-style. (Quick grep so far: no obvious cases — the
-  examples that pass `--{name}-solver-options` use it for tightening
-  mipgap.)
+- ✔ Release notes call-out under "Behavior changes" — README.md
+  has a 2026 NOTICE section pointing at the user docs;
+  `doc/src/generic_cylinders.rst` has a `solver-options` section
+  with a `.. warning::` directive carrying the migration recipe.
+- ✔ Integration test asserting the new merge semantics — see
+  `test_per_spoke_overlay_combines_global_and_spoke_keys` in
+  `mpisppy/tests/test_solver_options_layers.py` (covers the
+  worked example above directly).
+- ✔ Audit `examples/` for any harness whose semantics depend on
+  replace-style — no example uses per-spoke solver-options
+  flags, so nothing needed updating.
 
 ### 6.3 Programmatic-API migration
 

--- a/doc/src/generic_cylinders.rst
+++ b/doc/src/generic_cylinders.rst
@@ -278,6 +278,61 @@ This option gets pulled in with ``cfg.popular_args`` and processed by
 Note that required arguments such as ``num_scens`` *must* be on the
 command line.
 
+``solver-options``
+------------------
+
+mpi-sppy passes solver-specific options to the underlying Pyomo
+solver plugin via a whitespace-separated string of ``key=value``
+pairs. The global flag is ``--solver-options``; every spoke also
+takes a per-spoke variant — ``--lagrangian-solver-options``,
+``--reduced-costs-solver-options``, ``--subgradient-solver-options``,
+and so on — that overlays on top of the global flag for that
+spoke's solves.
+
+Worked example:
+
+.. code-block:: bash
+
+    --solver-options "presolve=2 threads=4"
+    --lagrangian-solver-options "mipgap=0.01"
+
+With this invocation, the lagrangian spoke's effective solver
+options are ``{presolve=2, threads=4, mipgap=0.01}``: the spoke
+flag adds ``mipgap`` and leaves the global ``presolve`` and
+``threads`` in place. The hub and the other spokes see the
+global dict ``{presolve=2, threads=4}`` unchanged.
+
+.. warning::
+
+   Behavior change in 2026: per-spoke solver-options flags
+   **overlay** the global ``--solver-options`` dict; previously
+   they **replaced** it for that spoke. In the unlikely event
+   you relied on the spoke flag dropping a global key, the
+   recipe is to re-spell every key you want in the spoke
+   options, or to omit the global ``--solver-options`` flag
+   entirely. The new behavior
+   is a superset of the old in every case where the spoke flag's
+   keys are a subset of the global's, which is the common
+   pattern (spoke flag tightens ``mipgap``, leaves the rest
+   alone).
+
+Two option names — ``mipgap`` and ``threads`` — are translated
+to each solver's native spelling at solve time, so the same CLI
+invocation works whether the configured solver is CPLEX, Gurobi,
+Xpress, or HiGHS. Other option keys pass through to the solver
+unchanged. If you supply a solver-native key directly (e.g.
+``--solver-options "mip_rel_gap=0.01"`` for HiGHS), it wins over
+any ``mipgap`` set elsewhere.
+
+For iteration-aware mipgap, use ``--iter0-mipgap`` and
+``--iterk-mipgap`` (plus their per-spoke variants), or
+``--mipgaps-json <path>`` for a full schedule. ``--max-solver-threads``
+sets a system-level thread cap that wins over any inline
+``threads`` value; use it on shared HPC nodes.
+
+For solver logging, see ``--solver-log-dir`` below — do not try
+to enable solver logs through ``--solver-options``.
+
 ``solver-log-dir``
 ------------------
 

--- a/doc/src/generic_cylinders.rst
+++ b/doc/src/generic_cylinders.rst
@@ -322,7 +322,7 @@ invocation works whether the configured solver is CPLEX, Gurobi,
 Xpress, or HiGHS. Other option keys pass through to the solver
 unchanged. If you supply a solver-native key directly (e.g.
 ``--solver-options "mip_rel_gap=0.01"`` for HiGHS), it wins over
-any ``mipgap`` set elsewhere (e.g. ``--iter0-mipgap``).
+any ``mipgap`` set elsewhere.
 
 For iteration-aware mipgap, use ``--iter0-mipgap`` and
 ``--iterk-mipgap`` (plus their per-spoke variants), or

--- a/doc/src/generic_cylinders.rst
+++ b/doc/src/generic_cylinders.rst
@@ -289,7 +289,7 @@ takes a per-spoke variant — ``--lagrangian-solver-options``,
 and so on — that overlays on top of the global flag for that
 spoke's solves.
 
-Worked example:
+Example:
 
 .. code-block:: bash
 
@@ -322,7 +322,7 @@ invocation works whether the configured solver is CPLEX, Gurobi,
 Xpress, or HiGHS. Other option keys pass through to the solver
 unchanged. If you supply a solver-native key directly (e.g.
 ``--solver-options "mip_rel_gap=0.01"`` for HiGHS), it wins over
-any ``mipgap`` set elsewhere.
+any ``mipgap`` set elsewhere (e.g. ``--iter0-mipgap``).
 
 For iteration-aware mipgap, use ``--iter0-mipgap`` and
 ``--iterk-mipgap`` (plus their per-spoke variants), or

--- a/mpisppy/tests/test_solver_options_layers.py
+++ b/mpisppy/tests/test_solver_options_layers.py
@@ -115,12 +115,12 @@ class TestApplySolverSpecsLayers(unittest.TestCase):
         # it expects a deepcopy of shared_options output.
         return {"opt_kwargs": {"options": copy.deepcopy(sh)}}
 
-    def test_per_spoke_solver_options_replace_layers(self):
-        # Per-spoke semantics are replace-not-overlay in
-        # apply_solver_specs: each --{name}-solver-options call
-        # discards the global --solver-options dict. This test pins
-        # that contract; if the semantics change to overlay later,
-        # this test should be updated alongside that change.
+    def test_per_spoke_solver_options_overlay_layers(self):
+        # Per-spoke option specs overlay on top of the global
+        # --solver-options dict: keys named by the spoke flag win,
+        # keys it doesn't mention survive from the global flag. A
+        # spoke's logfile, presolve flag, etc. set globally should
+        # still be in the spoke's effective dict.
         cfg = _spoke_cfg("lagrangian")
         cfg.solver_options = "logfile=run.log"
         cfg.lagrangian_solver_options = "mipgap=0.001"
@@ -136,7 +136,47 @@ class TestApplySolverSpecsLayers(unittest.TestCase):
             fold_solver_options_layers(opts["solver_options_layers"], 1),
             opts["iterk_solver_options"],
         )
-        self.assertEqual(opts["iter0_solver_options"], {"mipgap": 0.001})
+        self.assertEqual(
+            opts["iter0_solver_options"],
+            {"logfile": "run.log", "mipgap": 0.001},
+        )
+
+    def test_per_spoke_overlay_combines_global_and_spoke_keys(self):
+        # The worked example from the design doc: global supplies
+        # presolve+threads, the spoke flag supplies mipgap, and the
+        # lagrangian-spoke effective dict is the union of all three.
+        cfg = _spoke_cfg("lagrangian")
+        cfg.solver_options = "presolve=2 threads=4"
+        cfg.lagrangian_solver_options = "mipgap=0.01"
+        sh = shared_options(cfg)
+        spoke = self._spoke_dict_from(sh)
+        apply_solver_specs("lagrangian", spoke, cfg)
+        opts = spoke["opt_kwargs"]["options"]
+        expected = {"presolve": 2, "threads": 4, "mipgap": 0.01}
+        self.assertEqual(
+            fold_solver_options_layers(opts["solver_options_layers"], 0),
+            expected,
+        )
+        self.assertEqual(
+            fold_solver_options_layers(opts["solver_options_layers"], 1),
+            expected,
+        )
+
+    def test_per_spoke_overlay_overrides_shared_key(self):
+        # When the spoke flag overrides a key the global flag already
+        # set, the spoke's value wins (last write in the fold) but the
+        # other global keys survive.
+        cfg = _spoke_cfg("lagrangian")
+        cfg.solver_options = "mipgap=0.01 logfile=run.log"
+        cfg.lagrangian_solver_options = "mipgap=0.001"
+        sh = shared_options(cfg)
+        spoke = self._spoke_dict_from(sh)
+        apply_solver_specs("lagrangian", spoke, cfg)
+        opts = spoke["opt_kwargs"]["options"]
+        self.assertEqual(
+            fold_solver_options_layers(opts["solver_options_layers"], 0),
+            {"logfile": "run.log", "mipgap": 0.001},
+        )
 
     def test_per_spoke_iter0_iterk_mipgap_layer_predicate(self):
         cfg = _spoke_cfg("lagrangian")

--- a/mpisppy/utils/cfg_vanilla.py
+++ b/mpisppy/utils/cfg_vanilla.py
@@ -129,21 +129,20 @@ def shared_options(cfg, is_hub=False):
 
 def apply_solver_specs(name, spoke, cfg):
     options = spoke["opt_kwargs"]["options"]
-    # Mirror the legacy iter0/iterk dict mutations onto
-    # solver_options_layers. Per-spoke option specs are replace-
-    # style: each --{name}-solver-options call overwrites rather
-    # than overlays the global --solver-options dict.
+    # Per-spoke option specs (--{name}-solver-options,
+    # --{name}-iter0-mipgap, etc.) overlay on top of the global
+    # --solver-options dict already populated by shared_options:
+    # the global options remain in place; the spoke options take
+    # priority on the keys they name and add any new keys.
     options.setdefault("solver_options_layers", [])
     if _hasit(cfg, name+"_solver_name"):
         options["solver_name"] = cfg.get(name+"_solver_name")
     if _hasit(cfg, name+"_solver_options"):
         odict = sputils.option_string_to_dict(cfg.get(name+"_solver_options"))
-        options["iter0_solver_options"] = odict
-        options["iterk_solver_options"] = copy.deepcopy(odict)
-        # Mirror replace semantics for layers.
-        options["solver_options_layers"] = [
-            sputils.solver_options_layer("default", odict)
-        ]
+        options["iter0_solver_options"].update(odict)
+        options["iterk_solver_options"].update(odict)
+        options["solver_options_layers"].append(
+            sputils.solver_options_layer("default", odict))
     if _hasit(cfg, name+"_iter0_mipgap"):
         options["iter0_solver_options"]["mipgap"] = cfg.get(name+"_iter0_mipgap")
         options["solver_options_layers"].append(
@@ -154,8 +153,9 @@ def apply_solver_specs(name, spoke, cfg):
         options["solver_options_layers"].append(
             sputils.solver_options_layer(
                 "iterk", {"mipgap": cfg.get(name+"_iterk_mipgap")}))
-    # re-apply max_solver_threads since we may have over-written the
-    # iter*_solver_options above.
+    # Re-apply max_solver_threads so the global thread cap wins
+    # even when --{name}-solver-options explicitly sets a different
+    # threads value (system-level cap beats user preference).
     if _hasit(cfg, "max_solver_threads"):
         options["iter0_solver_options"]["threads"] = cfg.max_solver_threads
         options["iterk_solver_options"]["threads"] = cfg.max_solver_threads


### PR DESCRIPTION
## Summary

**User-visible behavior change.** Per-spoke solver-options flags
(\`--lagrangian-solver-options\`, \`--reduced-costs-solver-options\`,
etc.) now **overlay** the global \`--solver-options\` dict for that
spoke's solves instead of **replacing** it.

Worked example (from design doc §6.2):

\`\`\`
--solver-options "presolve=2 threads=4"
--lagrangian-solver-options "mipgap=0.01"
\`\`\`

| Lagrangian-spoke effective dict | Before (replace) | After (overlay) |
|---------------------------------|------------------|-----------------|
| \`mipgap\`                        | 0.01             | 0.01            |
| \`threads\`                       | (only if \`--max-solver-threads\`) | 4 |
| \`presolve\`                      | not set          | 2               |

The new dict is a superset of the old in every case where the
spoke flag's keys are a subset of the global's, which is the
common pattern (spoke flag tightens \`mipgap\`, leaves the rest
alone). In the unlikely event a user relied on the spoke flag
*dropping* a global key, the recipe is to re-spell every key
they want in the spoke options, or omit the global flag.

## Code change

\`apply_solver_specs\` in \`mpisppy/utils/cfg_vanilla.py\`:

- \`iter0_solver_options\` and \`iterk_solver_options\` are now
  updated in place (overlay) rather than re-assigned (replace).
- \`solver_options_layers\` is appended to rather than re-built
  from scratch when \`--{name}-solver-options\` is set.
- The \`max_solver_threads\` re-apply at the end is preserved —
  it now compensates for an inline \`threads=N\` in the spoke
  flag rather than recovering from the replace that no longer
  happens, but the invariant ("global thread cap wins over user
  inline threads value") stays the same.

## Tests

- \`test_per_spoke_solver_options_overlay_layers\` (renamed from
  the old \`_replace_layers\`) now asserts the global key
  survives in the spoke dict.
- \`test_per_spoke_overlay_combines_global_and_spoke_keys\` is
  the design-doc §6.2 worked example, executed.
- \`test_per_spoke_overlay_overrides_shared_key\` pins
  last-write-wins precedence when a key is set in both flags.

Local sweep: 202/202 pass across \`test_ef_ph\`, \`test_ph_main\`,
\`test_ph_extensions\`, \`test_aph\`, \`test_jensens\`,
\`test_solver_options_layers\`, \`test_proper_bundler\`,
\`test_config\`, \`test_generic_cylinders\`. ruff clean.

## Doc updates

- **\`doc/src/generic_cylinders.rst\`** — new \`solver-options\`
  section right before \`solver-log-dir\`. Covers the global
  flag, the per-spoke variants, a worked example, and a
  \`.. warning::\` directive carrying the behavior-change
  call-out and migration recipe. Also brief notes on the
  mipgap/threads cross-solver translation, the iteration-aware
  mipgap flags, and \`--max-solver-threads\`.
- **\`README.md\`** — 2026 NOTICE block in the same style as the
  existing 2022 NOTICE, with the migration recipe and a pointer
  to the new rst section.
- **\`doc/designs/solver_options_redesign.md\`** §6.2 marked
  Shipped and the three action items checked off with pointers
  to the test name, README block, and rst section.

## Examples audit

The design doc's prediction held: no example in \`examples/\` uses
\`--{name}-solver-options\` flags, so no example needed updating
to keep working under the new overlay semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)