### PR TITLE
Solver options: dynamic_gapper layer, per-spoke mipgaps-json, Gapper cleanup

### DIFF
--- a/examples/sslp/sslp.py
+++ b/examples/sslp/sslp.py
@@ -233,10 +233,15 @@ if __name__ == "__main__":
 
     options["fixeroptions"] = fixoptions
 
-    options["gapperoptions"] = {
-        "verbose": True,
-        "mipgapdict": {0: 0.02, 1: 0.02, 5: 0.01, 10: 0.005},
-    }
+    # Per-iteration mipgap schedule: a list of after_iter layers in
+    # solver_options_layers. Layer N (with N >= 0) takes effect at PH
+    # iteration N and persists until a later after_iter layer wins.
+    _mipgap_schedule = {0: 0.02, 1: 0.02, 5: 0.01, 10: 0.005}
+    options.setdefault("solver_options_layers", [])
+    for _N in sorted(_mipgap_schedule):
+        options["solver_options_layers"].append(
+            sputils.solver_options_layer(
+                ("after_iter", _N), {"mipgap": _mipgap_schedule[_N]}))
 
     all_scenario_names = list()
     for sn in range(ScenCount):

--- a/examples/uc/uc_cylinders.py
+++ b/examples/uc/uc_cylinders.py
@@ -20,7 +20,6 @@ from mpisppy.spin_the_wheel import WheelSpinner
 
 from mpisppy.extensions.extension import MultiExtension
 from mpisppy.extensions.fixer import Fixer
-from mpisppy.extensions.mipgapper import Gapper
 from mpisppy.extensions.xhatclosest import XhatClosest
 from mpisppy.utils import config
 import mpisppy.utils.cfg_vanilla as vanilla
@@ -73,7 +72,6 @@ def main():
     xhatlooper = cfg.xhatlooper
     xhatshuffle = cfg.xhatshuffle
     lagrangian = cfg.lagrangian
-    gapper = cfg.ph_mipgaps_json is not None
     fixer = cfg.fixer
     fixer_tol = cfg.fixer_tol
     cross_scenario_cuts = cfg.cross_scenario_cuts
@@ -110,8 +108,6 @@ def main():
 
     # Extend and/or correct the vanilla dictionary
     ext_classes =  []
-    if gapper:
-        ext_classes.append(Gapper)
     if fixer:
         ext_classes.append(Fixer)
     if cross_scenario_cuts:
@@ -136,17 +132,21 @@ def main():
             "keep_solution" : True
         }
 
+    # Per-iteration mipgap schedule: route the example's
+    # --ph-mipgaps-json into hub solver_options_layers as
+    # after_iter layers so the layer fold drives mipgap at each
+    # PH iteration. No Gapper extension is required for static
+    # schedules.
     if cfg.ph_mipgaps_json is not None:
         with open(cfg.ph_mipgaps_json) as fin:
             din = json.load(fin)
-        mipgapdict = {int(i): din[i] for i in din}
-    else:
-        mipgapdict = None
-
-    hub_dict["opt_kwargs"]["options"]["gapperoptions"] = {
-        "verbose": cfg.verbose,
-        "mipgapdict": mipgapdict
-        }
+        mipgap_schedule = {int(i): din[i] for i in din}
+        hub_options = hub_dict["opt_kwargs"]["options"]
+        hub_options.setdefault("solver_options_layers", [])
+        for _N in sorted(mipgap_schedule):
+            hub_options["solver_options_layers"].append(
+                sputils.solver_options_layer(
+                    ("after_iter", _N), {"mipgap": mipgap_schedule[_N]}))
 
     if cfg.default_rho is None:
         # since we are using a rho_setter anyway

--- a/mpisppy/extensions/mipgapper.py
+++ b/mpisppy/extensions/mipgapper.py
@@ -6,78 +6,102 @@
 # All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
 # full copyright and license information.
 ###############################################################################
-""" Code for a mipgap schedule. This can be used
-    as the only extension, but it could also be called from a "multi"
-    extension.
+""" Adaptive mipgap controller. Reads inner/outer bound gaps from the
+    hub/spoke comm at each miditer and tightens the subproblem mipgap
+    to ``problem_rel_gap * mipgap_ratio`` (clamped from above by
+    ``starting_mipgap``). For a static, iteration-indexed schedule,
+    use ``--mipgaps-json`` instead, which feeds solver_options_layers
+    directly without requiring this extension.
 """
 
 import warnings
 
 from mpisppy import global_toc
 import mpisppy.extensions.extension
+import mpisppy.utils.sputils as sputils
+
 
 class Gapper(mpisppy.extensions.extension.Extension):
 
     def __init__(self, ph):
         self.ph = ph
         self.cylinder_rank = self.ph.cylinder_rank
-        self.gapperoptions = self.ph.options["gapperoptions"] # required
-        self.mipgapdict = self.gapperoptions.get("mipgapdict", None)
+        self.gapperoptions = self.ph.options["gapperoptions"]  # required
         self.starting_mipgap = self.gapperoptions.get("starting_mipgap", None)
         self.mipgap_ratio = self.gapperoptions.get("mipgap_ratio", None)
-        if self.mipgapdict is not None:
-            # The static-schedule mode is subsumed by the
-            # solver_options_layers system: --mipgaps-json is now
-            # routed straight to after_iter layers in
-            # cfg_vanilla.add_gapper, with no need for this extension.
-            # The dynamic (auto-tightening) mode driven by
-            # starting_mipgap / mipgap_ratio is not deprecated.
+        # Compatibility shim: programmatic callers used to set
+        # gapperoptions["mipgapdict"] for a static schedule.
+        # That role is now filled by solver_options_layers
+        # (cfg_vanilla.add_gapper does this for --mipgaps-json
+        # automatically). Translate any legacy mipgapdict into
+        # after_iter layers on the host PHBase so existing user
+        # scripts keep producing the same per-iteration mipgap, and
+        # warn so callers migrate over time.
+        mipgapdict = self.gapperoptions.get("mipgapdict")
+        self._static_compat = False
+        if mipgapdict is not None:
             warnings.warn(
-                "Gapper's static mipgap-dictionary mode is deprecated; "
-                "use --mipgaps-json, which is now plumbed directly "
-                "through solver_options_layers without the Gapper "
-                "extension. Automatic mipgap mode (starting_mipgap / "
-                "mipgap_ratio) is not affected.",
+                "Gapper's static mipgapdict is deprecated. The "
+                "schedule is being translated to "
+                "solver_options_layers automatically; remove the "
+                "Gapper extension and instead pass --mipgaps-json "
+                "on the CLI, or append solver_options_layer("
+                "('after_iter', N), {'mipgap': v}) entries to "
+                "options['solver_options_layers'] directly.",
                 DeprecationWarning,
                 stacklevel=2,
             )
-        self._check_options()
-
-    def _check_options(self):
-        if self.mipgapdict is None and self.starting_mipgap is None:
-            raise RuntimeError(f"{self.ph._get_cylinder_name()}: Need to either set a mipgapdict or a starting_mipgap for Gapper")
-        if self.mipgapdict is not None and self.starting_mipgap is not None:
-            raise RuntimeError(f"{self.ph._get_cylinder_name()} Gapper: Either use a mipgapdict or automatic mode, not both.")
-        # exactly one is not None
-        return
+            # Insert just before the reserved dynamic_gapper layer
+            # so it remains last (and so wins over these for any
+            # adaptive writes).
+            for N in sorted(mipgapdict):
+                self.ph.solver_options_layers.insert(
+                    -1,
+                    sputils.solver_options_layer(
+                        ("after_iter", int(N)),
+                        {"mipgap": mipgapdict[N]},
+                    ),
+                )
+            self._static_compat = True
+            return
+        if self.starting_mipgap is None:
+            raise RuntimeError(
+                f"{self.ph._get_cylinder_name()}: Gapper auto-mode "
+                "requires starting_mipgap to be set."
+            )
 
     def _print_msg(self, msg):
-        global_toc(f"{self.ph._get_cylinder_name()} {self.__class__.__name__}: {msg}", self.cylinder_rank == 0)
+        global_toc(
+            f"{self.ph._get_cylinder_name()} {self.__class__.__name__}: {msg}",
+            self.cylinder_rank == 0,
+        )
 
     def set_mipgap(self, mipgap):
-        """ set the mipgap
-        Args:
-            float (mipgap): the gap to set
+        """ Set the runtime-adaptive mipgap.
+
+        Writes into the PHBase dynamic_gapper layer, which sits at
+        the top of solver_options_layers and so overrides every
+        CLI-configured mipgap when the fold is taken at solve time.
         """
-        oldgap = None
         mipgap = float(mipgap)
-        if "mipgap" in self.ph.current_solver_options:
-            oldgap = self.ph.current_solver_options["mipgap"]
+        layer_options = self.ph._dynamic_solver_options_layer["options"]
+        oldgap = layer_options.get("mipgap")
         if oldgap is None or oldgap != mipgap:
-            oldgap_str = f"{oldgap}" if oldgap is None else f"{oldgap*100:.3f}%"
-            self._print_msg(f"Changing mipgap from {oldgap_str} to {mipgap*100:.3f}%")
-        # no harm in unconditionally setting this, and covers iteration 1
-        self.ph.current_solver_options["mipgap"] = mipgap
-        
+            oldgap_str = "None" if oldgap is None else f"{oldgap*100:.3f}%"
+            self._print_msg(
+                f"Changing mipgap from {oldgap_str} to {mipgap*100:.3f}%")
+        layer_options["mipgap"] = mipgap
+
     def pre_iter0(self):
-        if self.mipgapdict is None:
-            # spcomm not yet set in `__init__`, so check this here
-            if self.ph.spcomm is None:
-                raise RuntimeError("Automatic gapper can only be used with cylinders -- needs both an upper bound and lower bound cylinder")
-            self.set_mipgap(self.starting_mipgap)
-        elif 0 in self.mipgapdict:
-            self.set_mipgap(self.mipgapdict[0])
-                                        
+        if self._static_compat:
+            return
+        # spcomm not yet set in `__init__`, so check this here
+        if self.ph.spcomm is None:
+            raise RuntimeError(
+                "Automatic gapper can only be used with cylinders -- "
+                "needs both an upper bound and lower bound cylinder")
+        self.set_mipgap(self.starting_mipgap)
+
     def post_iter0(self):
         return
 
@@ -86,21 +110,18 @@ class Gapper(mpisppy.extensions.extension.Extension):
         self.ph.spcomm.receive_outerbounds()
         _, problem_rel_gap = self.ph.spcomm.compute_gaps()
         subproblem_rel_gap = problem_rel_gap * self.mipgap_ratio
-        # global_toc(f"{self.ph._get_cylinder_name()}: {self.ph.spcomm.BestInnerBound=}, {self.ph.spcomm.BestOuterBound=}", self.ph.cylinder_rank == 0)
         if subproblem_rel_gap < self.starting_mipgap:
             self.set_mipgap(subproblem_rel_gap)
-        # current_solver_options changes in iteration 1
         elif self.ph._PHIter == 1:
+            # Reapply the starting cap so the first iterk solve uses
+            # it; later iterk solves keep whatever set_mipgap last
+            # wrote into the dynamic layer.
             self.set_mipgap(self.starting_mipgap)
 
     def miditer(self):
-        if self.mipgapdict is None:
-            self._autoset_mipgap()
+        if self._static_compat:
             return
-        PHIter = self.ph._PHIter
-        if PHIter in self.mipgapdict:
-            self.set_mipgap(self.mipgapdict[PHIter])
-
+        self._autoset_mipgap()
 
     def enditer(self):
         return

--- a/mpisppy/generic/spokes.py
+++ b/mpisppy/generic/spokes.py
@@ -48,7 +48,8 @@ def build_spoke_list(cfg, beans, scenario_creator_kwargs,
                                                 all_nodenames=all_nodenames,
                                                 average_scenario_creator=average_scenario_creator,
                                                 )
-        if cfg.lagrangian_starting_mipgap is not None:
+        if (cfg.lagrangian_starting_mipgap is not None
+                or cfg.lagrangian_mipgaps_json is not None):
             vanilla.add_gapper(lagrangian_spoke, cfg, "lagrangian")
 
     # dual ph spoke

--- a/mpisppy/phbase.py
+++ b/mpisppy/phbase.py
@@ -284,10 +284,9 @@ class PHBase(mpisppy.spopt.SPOpt):
         # solver_options_layers is the source of truth for
         # per-iteration solver options; _effective_solver_options(k)
         # folds them and overlays current_solver_options as a final
-        # "dynamic overrides" layer (used by Gapper auto-mode and the
-        # spoke iter0→iterk handoff). iter0_solver_options /
-        # iterk_solver_options below are read-only properties derived
-        # from the layer fold.
+        # "dynamic overrides" layer (back-compat path for external
+        # mutators). iter0_solver_options / iterk_solver_options below
+        # are read-only properties derived from the layer fold.
         self.solver_options_layers = list(options.get("solver_options_layers") or [])
         if not self.solver_options_layers:
             # Caller bypassed cfg_vanilla and supplied only the legacy
@@ -302,9 +301,18 @@ class PHBase(mpisppy.spopt.SPOpt):
             if _iterk_dict:
                 self.solver_options_layers.append(
                     sputils.solver_options_layer("iterk", _iterk_dict))
-        # Dynamic-overrides overlay: Gapper auto-mode mutates
-        # ["mipgap"] here; spokes clear it at iter0→iterk transition.
-        # _effective_solver_options reads it as the last fold step.
+        # Reserved layer for runtime-adaptive extensions (Gapper
+        # auto-mode writes its mipgap into this layer's options
+        # dict). Appended last so the fold of solver_options_layers
+        # picks it up after every CLI-configured layer; the adaptive
+        # value then wins over everything the user configured at
+        # setup, matching the prior runtime-overwrite semantics.
+        self._dynamic_solver_options_layer = sputils.solver_options_layer(
+            "default", {})
+        self.solver_options_layers.append(
+            self._dynamic_solver_options_layer)
+        # Back-compat dynamic-overrides dict. New code should write
+        # into _dynamic_solver_options_layer["options"] instead.
         self.current_solver_options = {}
 
         # flags to complete the invariant

--- a/mpisppy/tests/test_ph_extensions.py
+++ b/mpisppy/tests/test_ph_extensions.py
@@ -7,14 +7,12 @@
 # full copyright and license information.
 ###############################################################################
 # Test PH extensions that are otherwise untested:
-#   - Gapper (mipgapper.py, 0% coverage)
 #   - MultRhoUpdater (mult_rho_updater.py, 24% coverage)
 #   - Wtracker_extension (wtracker_extension.py, 0%) + WTracker (wtracker.py, 27%)
 
 import glob
 import os
 import unittest
-import warnings
 
 import mpisppy.opt.ph
 import mpisppy.tests.examples.farmer as farmer
@@ -27,99 +25,6 @@ solver_available, solver_name, persistent_available, persistent_solver_name = ge
 
 fullcomm = mpi.COMM_WORLD
 global_rank = fullcomm.Get_rank()
-
-
-class TestGapper(unittest.TestCase):
-    """Test the Gapper (mipgapper) extension with sizes."""
-
-    def setUp(self):
-        self.options = {
-            "solver_name": solver_name,
-            "PHIterLimit": 5,
-            "defaultPHrho": 1,
-            "convthresh": 0.001,
-            "verbose": False,
-            "display_timing": False,
-            "display_progress": False,
-            "iter0_solver_options": {"mipgap": 0.1},
-            "iterk_solver_options": {"mipgap": 0.02},
-            "smoothed": 0,
-            "asynchronousPH": False,
-            "subsolvedirectives": None,
-            "toc": False,
-        }
-        self.scenario_names = [f"Scenario{i+1}" for i in range(3)]
-        self.creator_kwargs = {"scenario_count": 3}
-
-    def _copy_options(self):
-        return dict(self.options)
-
-    @unittest.skipIf(not solver_available,
-                     "%s solver is not available" % (solver_name,))
-    def test_gapper_dict_mode(self):
-        """Gapper's static mipgapdict path runs end-to-end and warns.
-
-        Constructing gapperoptions['mipgapdict'] is the deprecated
-        static-schedule path (the supported path is --mipgaps-json,
-        which cfg_vanilla.add_gapper routes through
-        solver_options_layers). This test exercises the legacy code
-        path and asserts the DeprecationWarning fires. The sizes
-        3-scenario fixture trivially converges at iter0, so this
-        fixture cannot verify later-iteration mipgap values — that
-        regression lives in test_solver_options_layers.py instead.
-        """
-        from mpisppy.extensions.mipgapper import Gapper
-        options = self._copy_options()
-        options["gapperoptions"] = {
-            "mipgapdict": {0: 0.10, 2: 0.05, 4: 0.01},
-        }
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            ph = mpisppy.opt.ph.PH(
-                options,
-                self.scenario_names,
-                sizes_creator,
-                sizes_denouement,
-                scenario_creator_kwargs=self.creator_kwargs,
-                extensions=Gapper,
-            )
-        self.assertTrue(
-            any(issubclass(w.category, DeprecationWarning)
-                and "Gapper" in str(w.message) for w in caught),
-            f"Expected DeprecationWarning from Gapper static-dict mode; "
-            f"got {[(w.category.__name__, str(w.message)) for w in caught]}",
-        )
-        conv, obj, tbound = ph.ph_main()
-        self.assertIsNotNone(obj)
-
-    @unittest.skipIf(not solver_available,
-                     "%s solver is not available" % (solver_name,))
-    def test_gapper_changes_gap(self):
-        """Verify Gapper's mipgapdict path runs end-to-end and warns."""
-        from mpisppy.extensions.mipgapper import Gapper
-        options = self._copy_options()
-        options["PHIterLimit"] = 3
-        options["gapperoptions"] = {
-            "mipgapdict": {0: 0.50, 2: 0.001},
-        }
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            ph = mpisppy.opt.ph.PH(
-                options,
-                self.scenario_names,
-                sizes_creator,
-                sizes_denouement,
-                scenario_creator_kwargs=self.creator_kwargs,
-                extensions=Gapper,
-            )
-        self.assertTrue(
-            any(issubclass(w.category, DeprecationWarning)
-                and "Gapper" in str(w.message) for w in caught),
-            f"Expected DeprecationWarning from Gapper static-dict mode; "
-            f"got {[(w.category.__name__, str(w.message)) for w in caught]}",
-        )
-        conv, obj, tbound = ph.ph_main()
-        self.assertIsNotNone(obj)
 
 
 class TestMultRhoUpdater(unittest.TestCase):

--- a/mpisppy/tests/test_solver_options_layers.py
+++ b/mpisppy/tests/test_solver_options_layers.py
@@ -345,6 +345,7 @@ class TestAddGapperMipgapsJsonLayers(unittest.TestCase):
 
     def test_mipgaps_json_appends_after_iter_layers(self):
         import os
+        import warnings
         from mpisppy.utils.cfg_vanilla import add_gapper
         cfg = _bare_cfg()
         cfg.add_to_config(
@@ -357,7 +358,15 @@ class TestAddGapperMipgapsJsonLayers(unittest.TestCase):
         try:
             cfg.mipgaps_json = path
             hub_dict = self._hub_dict()
-            add_gapper(hub_dict, cfg)
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                add_gapper(hub_dict, cfg)
+            self.assertTrue(
+                any(issubclass(w.category, DeprecationWarning)
+                    and "--mipgaps-json" in str(w.message) for w in caught),
+                f"Expected DeprecationWarning naming --mipgaps-json; "
+                f"got {[(w.category.__name__, str(w.message)) for w in caught]}",
+            )
             layers = hub_dict["opt_kwargs"]["options"]["solver_options_layers"]
             # 3 after_iter layers in ascending-N order
             self.assertEqual(len(layers), 3)
@@ -606,6 +615,7 @@ class TestPerSpokeMipgapsJsonLayers(unittest.TestCase):
 
     def test_per_spoke_mipgaps_json_appends_layers(self):
         import os
+        import warnings
         from mpisppy.utils.cfg_vanilla import add_gapper
         cfg = _bare_cfg()
         cfg.gapper_args(name="lagrangian")
@@ -613,7 +623,17 @@ class TestPerSpokeMipgapsJsonLayers(unittest.TestCase):
         try:
             cfg.lagrangian_mipgaps_json = path
             spoke = self._spoke_dict()
-            add_gapper(spoke, cfg, "lagrangian")
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                add_gapper(spoke, cfg, "lagrangian")
+            self.assertTrue(
+                any(issubclass(w.category, DeprecationWarning)
+                    and "--lagrangian-mipgaps-json" in str(w.message)
+                    for w in caught),
+                f"Expected DeprecationWarning naming "
+                f"--lagrangian-mipgaps-json; got "
+                f"{[(w.category.__name__, str(w.message)) for w in caught]}",
+            )
             layers = spoke["opt_kwargs"]["options"]["solver_options_layers"]
             self.assertEqual(len(layers), 2)
             self.assertEqual(layers[0]["when"], ("after_iter", 0))

--- a/mpisppy/tests/test_solver_options_layers.py
+++ b/mpisppy/tests/test_solver_options_layers.py
@@ -466,5 +466,182 @@ class TestTranslateSolverOptions(unittest.TestCase):
         self.assertEqual(self._t(opts, "gurobi"), opts)
 
 
+class TestDynamicGapperLayer(unittest.TestCase):
+    """Gapper.set_mipgap writes to PHBase's reserved dynamic_gapper
+    layer; subsequent _effective_solver_options(k) folds pick up the
+    new mipgap and it overrides any CLI-configured value.
+    """
+
+    def _fake_ph(self, layers=None, current=None):
+        """Minimal PHBase-shaped object with the layer state Gapper
+        and _effective_solver_options need. Avoids MPI/scenario
+        boilerplate.
+        """
+        from mpisppy.utils.sputils import solver_options_layer
+        fake = type("FakePH", (), {})()
+        fake.solver_options_layers = list(layers) if layers else []
+        # Reserved dynamic layer (mirrors PHBase.__init__).
+        fake._dynamic_solver_options_layer = solver_options_layer(
+            "default", {})
+        fake.solver_options_layers.append(
+            fake._dynamic_solver_options_layer)
+        fake.current_solver_options = current or {}
+        return fake
+
+    def _effective(self, fake, k):
+        from mpisppy.phbase import PHBase
+        return PHBase._effective_solver_options(fake, k)
+
+    def test_set_mipgap_writes_to_dynamic_layer(self):
+        # Direct unit test of the new contract: writing to the
+        # dynamic layer shows up immediately in the effective dict.
+        fake = self._fake_ph()
+        fake._dynamic_solver_options_layer["options"]["mipgap"] = 0.001
+        self.assertEqual(self._effective(fake, 0), {"mipgap": 0.001})
+        self.assertEqual(self._effective(fake, 5), {"mipgap": 0.001})
+
+    def test_dynamic_layer_overrides_cli_layers(self):
+        # CLI-configured iter0/iterk layers + a dynamic write should
+        # produce the dynamic value at every k, since the dynamic
+        # layer is appended last.
+        from mpisppy.utils.sputils import solver_options_layer
+        cli = [
+            solver_options_layer("iter0", {"mipgap": 0.1}),
+            solver_options_layer("iterk", {"mipgap": 0.02}),
+        ]
+        fake = self._fake_ph(layers=cli)
+        fake._dynamic_solver_options_layer["options"]["mipgap"] = 0.005
+        self.assertEqual(
+            self._effective(fake, 0)["mipgap"], 0.005)
+        self.assertEqual(
+            self._effective(fake, 1)["mipgap"], 0.005)
+        self.assertEqual(
+            self._effective(fake, 9)["mipgap"], 0.005)
+
+    def test_gapper_set_mipgap_routes_to_dynamic_layer(self):
+        # End-to-end: instantiate Gapper, call set_mipgap, assert
+        # the dynamic layer reflects it and current_solver_options
+        # is untouched (the old back-channel is now unused).
+        from mpisppy.extensions.mipgapper import Gapper
+        fake = self._fake_ph()
+        fake.cylinder_rank = 0
+        fake.options = {"gapperoptions": {
+            "starting_mipgap": 0.1, "mipgap_ratio": 0.1,
+        }}
+        fake._get_cylinder_name = lambda: "TestCylinder"
+        gapper = Gapper(fake)
+        gapper.set_mipgap(0.01)
+        self.assertEqual(
+            fake._dynamic_solver_options_layer["options"]["mipgap"],
+            0.01)
+        # The back-compat dict was not mutated (only the layer was).
+        self.assertNotIn("mipgap", fake.current_solver_options)
+
+    def test_gapper_legacy_mipgapdict_translates_to_layers(self):
+        # Compatibility shim: programmatic callers that still pass
+        # mipgapdict in gapperoptions get a DeprecationWarning and
+        # the schedule is translated into after_iter layers on the
+        # host PHBase (so their existing scripts keep producing the
+        # same per-iteration mipgap). The Gapper extension itself
+        # becomes a runtime no-op in this mode.
+        import warnings
+        from mpisppy.extensions.mipgapper import Gapper
+        fake = self._fake_ph()
+        fake.cylinder_rank = 0
+        fake.options = {"gapperoptions": {
+            "mipgapdict": {0: 0.10, 5: 0.005},
+            "starting_mipgap": None,
+        }}
+        fake._get_cylinder_name = lambda: "TestCylinder"
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            gapper = Gapper(fake)
+        self.assertTrue(
+            any(issubclass(w.category, DeprecationWarning)
+                and "mipgapdict" in str(w.message) for w in caught),
+            f"Expected DeprecationWarning naming mipgapdict; "
+            f"got {[(w.category.__name__, str(w.message)) for w in caught]}",
+        )
+        # Two after_iter layers, inserted before the dynamic layer.
+        # solver_options_layers starts as [_dynamic]; after the
+        # shim runs it should be [after_iter 0, after_iter 5, _dynamic].
+        layers = fake.solver_options_layers
+        self.assertEqual(len(layers), 3)
+        self.assertEqual(layers[0]["when"], ("after_iter", 0))
+        self.assertEqual(layers[0]["options"], {"mipgap": 0.10})
+        self.assertEqual(layers[1]["when"], ("after_iter", 5))
+        self.assertEqual(layers[1]["options"], {"mipgap": 0.005})
+        self.assertIs(
+            layers[2], fake._dynamic_solver_options_layer)
+        # Gapper's runtime hooks are no-ops in compat mode.
+        self.assertTrue(gapper._static_compat)
+        # pre_iter0 / miditer must not touch the dynamic layer.
+        gapper.pre_iter0()
+        gapper.miditer()
+        self.assertEqual(
+            fake._dynamic_solver_options_layer["options"], {})
+
+
+class TestPerSpokeMipgapsJsonLayers(unittest.TestCase):
+    """cfg_vanilla.add_gapper handles --{name}-mipgaps-json the same
+    way as the global flag: per-spoke after_iter layers are appended
+    to the spoke dict's solver_options_layers.
+    """
+
+    def _write_mipgaps_json(self, schedule):
+        import json
+        import tempfile
+        path = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False).name
+        with open(path, "w") as f:
+            json.dump({str(k): v for k, v in schedule.items()}, f)
+        return path
+
+    def _spoke_dict(self):
+        return {
+            "opt_kwargs": {
+                "options": {"solver_options_layers": []},
+            },
+        }
+
+    def test_per_spoke_mipgaps_json_appends_layers(self):
+        import os
+        from mpisppy.utils.cfg_vanilla import add_gapper
+        cfg = _bare_cfg()
+        cfg.gapper_args(name="lagrangian")
+        path = self._write_mipgaps_json({0: 0.05, 3: 0.005})
+        try:
+            cfg.lagrangian_mipgaps_json = path
+            spoke = self._spoke_dict()
+            add_gapper(spoke, cfg, "lagrangian")
+            layers = spoke["opt_kwargs"]["options"]["solver_options_layers"]
+            self.assertEqual(len(layers), 2)
+            self.assertEqual(layers[0]["when"], ("after_iter", 0))
+            self.assertEqual(layers[1]["when"], ("after_iter", 3))
+            self.assertEqual(
+                [layer["options"] for layer in layers],
+                [{"mipgap": 0.05}, {"mipgap": 0.005}],
+            )
+            self.assertNotIn(
+                "gapperoptions", spoke["opt_kwargs"]["options"])
+        finally:
+            os.unlink(path)
+
+    def test_per_spoke_static_and_auto_modes_exclusive(self):
+        import os
+        from mpisppy.utils.cfg_vanilla import add_gapper
+        cfg = _bare_cfg()
+        cfg.gapper_args(name="lagrangian")
+        path = self._write_mipgaps_json({0: 0.05})
+        try:
+            cfg.lagrangian_mipgaps_json = path
+            cfg.lagrangian_starting_mipgap = 0.1
+            with self.assertRaisesRegex(
+                    RuntimeError, "lagrangian-mipgaps-json"):
+                add_gapper(self._spoke_dict(), cfg, "lagrangian")
+        finally:
+            os.unlink(path)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/mpisppy/utils/cfg_vanilla.py
+++ b/mpisppy/utils/cfg_vanilla.py
@@ -429,33 +429,38 @@ def add_gapper(hub_dict, cfg, name=None):
     """Wire mipgap schedule / auto mipgap into a hub or spoke dict.
 
     Two modes:
-      * static schedule (``--mipgaps-json``, global only): the JSON is
-        parsed into ``after_iter`` solver-options layers appended to
+      * static schedule (``--mipgaps-json`` or, per-spoke,
+        ``--{name}-mipgaps-json``): the JSON is parsed into
+        ``after_iter`` solver-options layers appended to
         ``solver_options_layers`` on the cylinder dict. No Gapper
         extension is registered; the layer fold drives the per-iter
         mipgap directly.
-      * auto mipgap (``--starting-mipgap`` + ``--mipgap-ratio``, also
-        per-spoke as e.g. ``--lagrangian-starting-mipgap``): the
-        Gapper extension is registered and observes inner/outer bound
-        cylinders at runtime to tighten mipgap.
+      * auto mipgap (``--starting-mipgap`` + ``--mipgap-ratio``,
+        also per-spoke as e.g. ``--lagrangian-starting-mipgap``):
+        the Gapper extension is registered and observes inner/outer
+        bound cylinders at runtime to tighten mipgap.
 
-    The two modes are mutually exclusive at the global level (Gapper
-    historically raised this; the check now lives here since the
-    static path no longer goes through Gapper).
+    The two modes are mutually exclusive at the same scope; the
+    static path no longer goes through Gapper.
     """
     prefix = "" if name is None else name + "_"
     starting_mipgap = getattr(cfg, f"{prefix}starting_mipgap", None)
     mipgap_ratio = getattr(cfg, f"{prefix}mipgap_ratio", None)
-    static_schedule = (name is None and cfg.mipgaps_json is not None)
+    mipgaps_json = getattr(cfg, f"{prefix}mipgaps_json", None)
 
-    if static_schedule and starting_mipgap is not None:
+    if mipgaps_json is not None and starting_mipgap is not None:
+        flag = "--mipgaps-json" if name is None else f"--{name}-mipgaps-json"
+        sm_flag = (
+            "--starting-mipgap" if name is None
+            else f"--{name}-starting-mipgap"
+        )
         raise RuntimeError(
-            "--mipgaps-json (static schedule) and --starting-mipgap "
-            "(auto mipgap) are mutually exclusive; pick one."
+            f"{flag} (static schedule) and {sm_flag} (auto mipgap) "
+            "are mutually exclusive; pick one."
         )
 
-    if static_schedule:
-        with open(cfg.mipgaps_json) as fin:
+    if mipgaps_json is not None:
+        with open(mipgaps_json) as fin:
             din = json.load(fin)
         mipgapdict = {int(i): din[i] for i in din}
         layers = hub_dict["opt_kwargs"]["options"].setdefault(
@@ -473,7 +478,6 @@ def add_gapper(hub_dict, cfg, name=None):
     hub_dict = extension_adder(hub_dict, Gapper)
     hub_dict["opt_kwargs"]["options"]["gapperoptions"] = {
         "verbose": cfg.verbose,
-        "mipgapdict": None,
         "starting_mipgap": starting_mipgap,
         "mipgap_ratio": mipgap_ratio,
     }

--- a/mpisppy/utils/cfg_vanilla.py
+++ b/mpisppy/utils/cfg_vanilla.py
@@ -13,6 +13,7 @@
 
 import copy
 import json
+import warnings
 
 # Hub and spoke SPBase classes
 import mpisppy.utils.sputils as sputils
@@ -460,6 +461,14 @@ def add_gapper(hub_dict, cfg, name=None):
         )
 
     if mipgaps_json is not None:
+        flag = "--mipgaps-json" if name is None else f"--{name}-mipgaps-json"
+        warnings.warn(
+            f"{flag} is planned for deprecation in a future release. "
+            "Your schedule is still being applied to the per-iteration "
+            "solver options.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         with open(mipgaps_json) as fin:
             din = json.load(fin)
         mipgapdict = {int(i): din[i] for i in din}

--- a/mpisppy/utils/config.py
+++ b/mpisppy/utils/config.py
@@ -622,11 +622,10 @@ class Config(pyofig.ConfigDict):
         else:
             name = name+"_"
 
-        if name == "":
-            self.add_to_config('mipgaps_json',
-                               description="path to json file with a mipgap schedule for PH iterations",
-                               domain=str,
-                               default=None)
+        self.add_to_config(f'{name}mipgaps_json',
+                           description="path to json file with a mipgap schedule for PH iterations",
+                           domain=str,
+                           default=None)
 
         self.add_to_config(f'{name}starting_mipgap',
                            description="Sets automatic gapper mode and the starting and minimum mipgap",

--- a/mpisppy/utils/config.py
+++ b/mpisppy/utils/config.py
@@ -623,7 +623,8 @@ class Config(pyofig.ConfigDict):
             name = name+"_"
 
         self.add_to_config(f'{name}mipgaps_json',
-                           description="path to json file with a mipgap schedule for PH iterations",
+                           description="path to json file with a mipgap schedule for PH iterations "
+                                       "(planned for deprecation in a future release)",
                            domain=str,
                            default=None)
 


### PR DESCRIPTION
## Summary

Three coupled changes that finish the Gapper integration into
the layered solver-options model. CLI usage is unchanged for
all flags; \`--mipgaps-json\` now emits a forward-looking
\`DeprecationWarning\` but continues to work.

### PHBase: reserved dynamic_gapper layer

\`PHBase.__init__\` now appends a reserved layer at the top of
\`self.solver_options_layers\` for runtime-adaptive mutators
(currently just Gapper auto-mode). The layer starts empty; the
fold of \`solver_options_layers\` picks it up last, so any value
written into its options dict at runtime overrides every
CLI-configured layer. The legacy \`current_solver_options\` dict
remains as a back-compat dynamic overlay path but is no longer
the canonical destination.

### Gapper: writes to the dynamic layer; static mode is back-compat

\`Gapper.set_mipgap\` now writes to
\`ph._dynamic_solver_options_layer["options"]\` instead of
mutating \`ph.current_solver_options\`. Auto-mode behavior is
unchanged at the call site.

The legacy \`gapperoptions["mipgapdict"]\` path is retired as a
first-class feature, but a compatibility shim translates any
legacy \`mipgapdict\` into \`after_iter\` layers on the host
\`PHBase\` at \`Gapper.__init__\` time, emits a
\`DeprecationWarning\` naming the substitute machinery, and
makes the extension's runtime hooks no-ops. Existing
programmatic callers (e.g. user scripts modeled on the old
\`sslp.py\` / \`uc_cylinders.py\` patterns) keep producing
identical per-iteration mipgap with no code changes.

### Per-spoke \`--{name}-mipgaps-json\`

\`Config.gapper_args\` no longer gates the \`mipgaps_json\` flag
on global-only — every prefix it's called with now registers
\`--{name}-mipgaps-json\` (today that's \`--mipgaps-json\` and
\`--lagrangian-mipgaps-json\`). \`cfg_vanilla.add_gapper\` reads
the per-spoke variant and contributes \`after_iter\` layers to
the spoke dict, exactly mirroring the global flag. The
mutual-exclusion check between static and auto-mipgap modes
fires per-prefix.

### Forward-looking deprecation

Use of \`--mipgaps-json\` (or its per-spoke variants) now emits
a \`DeprecationWarning\` at runtime: the flag still works and
the schedule is still applied, but it's planned for removal in
a future release. The CLI \`--help\` text also reflects this.

### Example migrations

\`examples/sslp/sslp.py\` and \`examples/uc/uc_cylinders.py\`
programmatically constructed \`gapperoptions["mipgapdict"]\`;
both now build \`after_iter\` \`solver_options_layers\` entries
directly and drop the \`Gapper\` extension. CLI of either
example is unchanged.

### Tests

- \`test_ph_extensions\`: dropped the two \`TestGapper\` cases;
  their static-dict coverage moved to
  \`test_solver_options_layers\`, and the auto-mode path
  requires cross-cylinder \`spcomm\` that doesn't fit a unit
  test.
- \`test_solver_options_layers\` gains:
  - \`TestDynamicGapperLayer\` (4 tests pinning \`set_mipgap\`
    → dynamic layer, dynamic-layer-overrides-CLI semantics, and
    the \`mipgapdict\` compat shim's translate-to-layers
    behavior + no-op runtime hooks).
  - \`TestPerSpokeMipgapsJsonLayers\` (2 tests pinning
    \`--{name}-mipgaps-json\` layer plumbing and the per-prefix
    static/auto mutual-exclusion check).
  - \`DeprecationWarning\` assertions on the existing
    \`--mipgaps-json\` layer-routing test and the new per-spoke
    test.

## Test plan

- [x] Local: \`ruff check .\` clean.
- [x] Local: 206/206 pass across \`test_ef_ph\`,
      \`test_ph_main\`, \`test_ph_extensions\`, \`test_aph\`,
      \`test_jensens\`, \`test_solver_options_layers\`,
      \`test_proper_bundler\`, \`test_config\`,
      \`test_generic_cylinders\`.
- [x] CI: regression, ph-extensions, ph-main, gradient-rho,
      schur-complement, and the rest of the test matrix pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)