### PR TITLE
Solver options: --solver-options-file (JSON schema) + rename after_iter → starting_at_iter

### DIFF
--- a/doc/designs/solver_options_redesign.md
+++ b/doc/designs/solver_options_redesign.md
@@ -495,7 +495,8 @@ Schema (by example):
   },
   "spokes": {
     "lagrangian": {
-      "default": {"mipgap": 0.01}
+      "default":    {"mipgap": 0.01},
+      "after_iter": {"5": {"mipgap": 0.001}}
     },
     "reduced_costs": {
       "iter0": {"mipgap": 0.001}

--- a/doc/designs/solver_options_redesign.md
+++ b/doc/designs/solver_options_redesign.md
@@ -527,7 +527,7 @@ last, so most-specific wins):**
    default
       ≺  iter0       (only at k = 0)
       ≺  iterk       (k ≥ 1)
-              ≺  starting_at_iter:N₁    (k ≥ N₁)
+              ≺  starting_at_iter:N₁    (k ≥ N₁, N₁ ≥ 1)
               ≺  starting_at_iter:N₂    (k ≥ N₂, N₁ < N₂)
               ≺  ...              (sorted by ascending N)
 ```
@@ -535,7 +535,9 @@ last, so most-specific wins):**
 `iter0` and `iterk` are disjoint, so the comparison only matters for
 predicates that all match the current `k`. `starting_at_iter:N` is strictly
 more specific than `iterk` whenever it matches, because the user
-named a precise N.
+named a precise N. `N = 0` is not allowed: it would silently outrank
+`iter0` / `iterk` for every iteration; a layer that should apply
+universally must use the `default` predicate instead.
 
 **Axis 2 — Source order, within a single predicate:**
 

--- a/doc/designs/solver_options_redesign.md
+++ b/doc/designs/solver_options_redesign.md
@@ -476,11 +476,11 @@ schedule needs no new predicate; only the integration is new (§5.7).
 
 ### 5.3 New options-file
 
-CLI: `--solver-options-file <path>` — registered alongside
-`--solver-options` in `Config.add_solver_specs()`, so each per-spoke
-prefix automatically gets `--{name}-solver-options-file` too. Format
-is JSON for v1 (stdlib only — no `pyyaml` dependency to add). YAML can
-be added later as an alias if there's demand; this is not a v1 commit.
+**Shipped.** `--solver-options-file <path>` is registered in
+`Config.add_solver_specs()`, so each per-spoke prefix
+automatically gets `--{name}-solver-options-file` too. Format is
+JSON (stdlib only). YAML can be added later as an alias if there's
+demand.
 
 Schema (by example):
 

--- a/doc/designs/solver_options_redesign.md
+++ b/doc/designs/solver_options_redesign.md
@@ -401,7 +401,7 @@ DLW: flat union makes sense
    - Generalize the current pattern: a flag `--after-iter-N-mipgap`
      where `N` is literal (probably awkward).
    - Express it only in the options-file: a top-level section like
-     `{"after_iter": {"5": {"mipgap": 1e-3}}}`.
+     `{"starting_at_iter": {"5": {"mipgap": 1e-3}}}`.
    File-only keeps the CLI surface flat and avoids inventing many new
    flags. Probably the right call if the file format lands first.
 DLW: File only. But the file will have to override iterk values or it won't make sense, right?
@@ -455,13 +455,13 @@ SolverOptionsLayer = TypedDict("SolverOptionsLayer", {
 #   "default"                — always
 #   "iter0"                  — iteration 0 only
 #   "iterk"                  — iterations k >= 1
-#   ("after_iter", N: int)   — iterations k >= N
+#   ("starting_at_iter", N: int)   — iterations k >= N
 ```
 
-`iterk` is sugar for `("after_iter", 1)` and is kept as a separate
+`iterk` is sugar for `("starting_at_iter", 1)` and is kept as a separate
 predicate solely for compatibility with `--iterk-mipgap`. EF and other
 non-iterating solves treat every layer with `when in {"default",
-"iter0"}` as applying, and ignore `iterk` / `after_iter` layers.
+"iter0"}` as applying, and ignore `iterk` / `starting_at_iter` layers.
 
 A method `PHBase._effective_solver_options(k: int) -> dict` walks
 `self.solver_options_layers` in order, picking layers whose predicate
@@ -471,7 +471,7 @@ matches `k`, and returns the merged dict. This replaces the
 The existing `--mipgaps-json` schedule (§1.1, §5.7) folds naturally
 into this model: each `{"<N>": gap}` entry becomes a layer with the
 same predicates the layered system already has — `iter0` for `N=0`,
-`iterk` for `N=1`, `("after_iter", N)` for `N >= 2`. So the static
+`iterk` for `N=1`, `("starting_at_iter", N)` for `N >= 2`. So the static
 schedule needs no new predicate; only the integration is new (§5.7).
 
 ### 5.3 New options-file
@@ -489,14 +489,14 @@ Schema (by example):
   "default":   {"threads": 4, "presolve": 2},
   "iter0":     {"mipgap": 1e-4},
   "iterk":     {"mipgap": 1e-3},
-  "after_iter": {
+  "starting_at_iter": {
     "5":  {"mipgap": 1e-5},
     "10": {"mipgap": 1e-6}
   },
   "spokes": {
     "lagrangian": {
       "default":    {"mipgap": 0.01},
-      "after_iter": {"5": {"mipgap": 0.001}}
+      "starting_at_iter": {"5": {"mipgap": 0.001}}
     },
     "reduced_costs": {
       "iter0": {"mipgap": 0.001}
@@ -505,7 +505,7 @@ Schema (by example):
 }
 ```
 
-`after_iter` keys are JSON strings (since JSON object keys must be
+`starting_at_iter` keys are JSON strings (since JSON object keys must be
 strings); they are coerced to ints at load time. Per-spoke sub-blocks
 mirror the top-level shape.
 
@@ -527,13 +527,13 @@ last, so most-specific wins):**
    default
       ≺  iter0       (only at k = 0)
       ≺  iterk       (k ≥ 1)
-              ≺  after_iter:N₁    (k ≥ N₁)
-              ≺  after_iter:N₂    (k ≥ N₂, N₁ < N₂)
+              ≺  starting_at_iter:N₁    (k ≥ N₁)
+              ≺  starting_at_iter:N₂    (k ≥ N₂, N₁ < N₂)
               ≺  ...              (sorted by ascending N)
 ```
 
 `iter0` and `iterk` are disjoint, so the comparison only matters for
-predicates that all match the current `k`. `after_iter:N` is strictly
+predicates that all match the current `k`. `starting_at_iter:N` is strictly
 more specific than `iterk` whenever it matches, because the user
 named a precise N.
 
@@ -577,24 +577,24 @@ Worked example — the case that motivated this rule:
 
 ```
 CLI:  --iterk-mipgap=0.001
-file: { "after_iter": { "5": { "mipgap": 1e-5 } } }
+file: { "starting_at_iter": { "5": { "mipgap": 1e-5 } } }
 ```
 
 | k | predicates that match    | folded order (axis 1, then 2)                  | result mipgap |
 |---|--------------------------|------------------------------------------------|---------------|
 | 0 | `iter0`                  | (no `iter0` writer here) → unset               | unset         |
 | 3 | `iterk`                  | CLI `--iterk-mipgap`                           | `0.001`       |
-| 7 | `iterk`, `after_iter:5`  | CLI `--iterk-mipgap`, then file `after_iter:5` | `1e-5`        |
+| 7 | `iterk`, `starting_at_iter:5`  | CLI `--iterk-mipgap`, then file `starting_at_iter:5` | `1e-5`        |
 
 The CLI's `--iterk-mipgap` writes first (axis 1 puts `iterk` before
-`after_iter:N`), then the file's `after_iter:5` overwrites it because
+`starting_at_iter:N`), then the file's `starting_at_iter:5` overwrites it because
 it is strictly more specific. CLI does not "win" against a more
 specific predicate — only against a same-predicate file entry.
 
 A natural consequence: if both file and CLI set the *same* key with
 the *same* predicate, CLI wins (axis 2). If file sets a key with a
 *more specific* predicate that matches, file wins (axis 1). This
-matches the §4 q3 follow-up — yes, file's `after_iter:N` overrides
+matches the §4 q3 follow-up — yes, file's `starting_at_iter:N` overrides
 both file `iterk` and CLI `--iterk-mipgap` for `k ≥ N`.
 
 Solver-name-aware translation (§5.6) is applied to the final folded
@@ -668,7 +668,7 @@ the JSON file and append one layer per entry to
 |----------|-------------------------|------------------|
 | `"0"`    | `iter0`                 | `{"mipgap": v}`  |
 | `"1"`    | `iterk`                 | `{"mipgap": v}`  |
-| `"N"` (N≥2) | `("after_iter", N)`  | `{"mipgap": v}`  |
+| `"N"` (N≥2) | `("starting_at_iter", N)`  | `{"mipgap": v}`  |
 
 These layers enter axis 2 at the `--mipgaps-json` source level (§5.4),
 so they overlay any `mipgap` set in the general options-file, while
@@ -696,7 +696,7 @@ Treatment: keep `Gapper` as a runtime extension, but rework
 - At setup, PHBase reserves a layer slot at the very top of axis 2
   (above all CLI sugar) tagged `dynamic_gapper`.
 - Gapper's `set_mipgap(g)` writes `{"mipgap": g}` into that layer's
-  options dict, scoped to predicate `("after_iter", k_now)` (or
+  options dict, scoped to predicate `("starting_at_iter", k_now)` (or
   simpler: `default`, since the dynamic value is meant to apply
   immediately and persist until the next dynamic write).
 - `_effective_solver_options(k)` picks up the dynamic layer last, so
@@ -906,7 +906,7 @@ New unit tests:
 - `test_solver_options_translation.py`: round-trip mipgap/threads
   across each known `solver_name` in the canonical table.
 - `test_solver_options_file.py`: schema acceptance, malformed JSON,
-  per-spoke nesting, `after_iter` int-coercion.
+  per-spoke nesting, `starting_at_iter` int-coercion.
 
 New integration tests (added to existing test files where natural):
 

--- a/doc/src/generic_cylinders.rst
+++ b/doc/src/generic_cylinders.rst
@@ -347,8 +347,11 @@ a JSON file with per-iteration and per-spoke sub-blocks. Schema:
       "iterk":      {"mipgap": 1e-3},
       "after_iter": {"5": {"mipgap": 1e-5}, "10": {"mipgap": 1e-6}},
       "spokes": {
-        "lagrangian":    {"default": {"mipgap": 0.01}},
-        "reduced_costs": {"iter0":   {"mipgap": 0.001}}
+        "lagrangian": {
+          "default":    {"mipgap": 0.01},
+          "after_iter": {"5": {"mipgap": 0.001}}
+        },
+        "reduced_costs": {"iter0": {"mipgap": 0.001}}
       }
     }
 

--- a/doc/src/generic_cylinders.rst
+++ b/doc/src/generic_cylinders.rst
@@ -345,11 +345,11 @@ a JSON file with per-iteration and per-spoke sub-blocks. Schema:
       "default":    {"threads": 4, "presolve": 2},
       "iter0":      {"mipgap": 1e-4},
       "iterk":      {"mipgap": 1e-3},
-      "after_iter": {"5": {"mipgap": 1e-5}, "10": {"mipgap": 1e-6}},
+      "starting_at_iter": {"5": {"mipgap": 1e-5}, "10": {"mipgap": 1e-6}},
       "spokes": {
         "lagrangian": {
           "default":    {"mipgap": 0.01},
-          "after_iter": {"5": {"mipgap": 0.001}}
+          "starting_at_iter": {"5": {"mipgap": 0.001}}
         },
         "reduced_costs": {"iter0": {"mipgap": 0.001}}
       }
@@ -360,9 +360,9 @@ Sub-blocks behave per their names:
 * ``default``    — applies to every iteration.
 * ``iter0``      — only at iteration 0.
 * ``iterk``      — at iteration 1 and beyond.
-* ``after_iter`` — keyed by iteration number ``N``; applies from
+* ``starting_at_iter`` — keyed by iteration number ``N``; applies from
   iteration ``N`` onward (so ``"5"`` first fires at ``k = 5`` and
-  persists until a later ``after_iter`` entry overrides it).
+  persists until a later ``starting_at_iter`` entry overrides it).
 * ``spokes``     — per-spoke overrides keyed by spoke name. Each
   spoke sub-block has the same shape minus ``spokes``.
 
@@ -375,13 +375,13 @@ Precedence at the same iteration / predicate, lowest to highest:
 
 1. ``--solver-options-file`` entries.
 2. Inline ``--solver-options`` (``default`` predicate only).
-3. ``--mipgaps-json`` (``after_iter`` only — planned for
+3. ``--mipgaps-json`` (``starting_at_iter`` only — planned for
    deprecation; superseded by ``--solver-options-file``).
 4. ``--iter0-mipgap`` / ``--iterk-mipgap`` / ``--max-solver-threads``
    (CLI sugar).
 
 More specific predicates always win for any iteration that matches
-both: at ``k = 7``, an ``after_iter: {"5": …}`` entry overrides
+both: at ``k = 7``, an ``starting_at_iter: {"5": …}`` entry overrides
 any ``iterk`` entry, even though both apply.
 
 ``solver-log-dir``

--- a/doc/src/generic_cylinders.rst
+++ b/doc/src/generic_cylinders.rst
@@ -360,9 +360,13 @@ Sub-blocks behave per their names:
 * ``default``    — applies to every iteration.
 * ``iter0``      — only at iteration 0.
 * ``iterk``      — at iteration 1 and beyond.
-* ``starting_at_iter`` — keyed by iteration number ``N``; applies from
-  iteration ``N`` onward (so ``"5"`` first fires at ``k = 5`` and
-  persists until a later ``starting_at_iter`` entry overrides it).
+* ``starting_at_iter`` — keyed by iteration number ``N`` (with
+  ``N >= 1``); applies from iteration ``N`` onward (so ``"5"``
+  first fires at ``k = 5`` and persists until a later
+  ``starting_at_iter`` entry overrides it). For options that
+  should apply at every iteration, use the ``default`` sub-block
+  instead — ``starting_at_iter`` with ``N = 0`` is rejected
+  because it would silently outrank ``iter0`` and ``iterk``.
 * ``spokes``     — per-spoke overrides keyed by spoke name. Each
   spoke sub-block has the same shape minus ``spokes``.
 

--- a/doc/src/generic_cylinders.rst
+++ b/doc/src/generic_cylinders.rst
@@ -326,12 +326,60 @@ any ``mipgap`` set elsewhere.
 
 For iteration-aware mipgap, use ``--iter0-mipgap`` and
 ``--iterk-mipgap`` (plus their per-spoke variants), or
-``--mipgaps-json <path>`` for a full schedule. ``--max-solver-threads``
-sets a system-level thread cap that wins over any inline
-``threads`` value; use it on shared HPC nodes.
+``--mipgaps-json <path>`` for a mipgap-only schedule.
+``--max-solver-threads`` sets a system-level thread cap that wins
+over any inline ``threads`` value; use it on shared HPC nodes.
 
 For solver logging, see ``--solver-log-dir`` below — do not try
 to enable solver logs through ``--solver-options``.
+
+Solver-options file
+^^^^^^^^^^^^^^^^^^^
+
+For richer configurations, ``--solver-options-file <path>`` reads
+a JSON file with per-iteration and per-spoke sub-blocks. Schema:
+
+.. code-block:: json
+
+    {
+      "default":    {"threads": 4, "presolve": 2},
+      "iter0":      {"mipgap": 1e-4},
+      "iterk":      {"mipgap": 1e-3},
+      "after_iter": {"5": {"mipgap": 1e-5}, "10": {"mipgap": 1e-6}},
+      "spokes": {
+        "lagrangian":    {"default": {"mipgap": 0.01}},
+        "reduced_costs": {"iter0":   {"mipgap": 0.001}}
+      }
+    }
+
+Sub-blocks behave per their names:
+
+* ``default``    — applies to every iteration.
+* ``iter0``      — only at iteration 0.
+* ``iterk``      — at iteration 1 and beyond.
+* ``after_iter`` — keyed by iteration number ``N``; applies from
+  iteration ``N`` onward (so ``"5"`` first fires at ``k = 5`` and
+  persists until a later ``after_iter`` entry overrides it).
+* ``spokes``     — per-spoke overrides keyed by spoke name. Each
+  spoke sub-block has the same shape minus ``spokes``.
+
+Per-spoke files (``--lagrangian-solver-options-file <path>``, etc.)
+are also accepted; they apply only to that spoke and have the same
+shape as a global file (the ``spokes`` sub-block, if present, is
+ignored).
+
+Precedence at the same iteration / predicate, lowest to highest:
+
+1. ``--solver-options-file`` entries.
+2. Inline ``--solver-options`` (``default`` predicate only).
+3. ``--mipgaps-json`` (``after_iter`` only — planned for
+   deprecation; superseded by ``--solver-options-file``).
+4. ``--iter0-mipgap`` / ``--iterk-mipgap`` / ``--max-solver-threads``
+   (CLI sugar).
+
+More specific predicates always win for any iteration that matches
+both: at ``k = 7``, an ``after_iter: {"5": …}`` entry overrides
+any ``iterk`` entry, even though both apply.
 
 ``solver-log-dir``
 ------------------

--- a/examples/sslp/sslp.py
+++ b/examples/sslp/sslp.py
@@ -233,15 +233,15 @@ if __name__ == "__main__":
 
     options["fixeroptions"] = fixoptions
 
-    # Per-iteration mipgap schedule: a list of after_iter layers in
+    # Per-iteration mipgap schedule: a list of starting_at_iter layers in
     # solver_options_layers. Layer N (with N >= 0) takes effect at PH
-    # iteration N and persists until a later after_iter layer wins.
+    # iteration N and persists until a later starting_at_iter layer wins.
     _mipgap_schedule = {0: 0.02, 1: 0.02, 5: 0.01, 10: 0.005}
     options.setdefault("solver_options_layers", [])
     for _N in sorted(_mipgap_schedule):
         options["solver_options_layers"].append(
             sputils.solver_options_layer(
-                ("after_iter", _N), {"mipgap": _mipgap_schedule[_N]}))
+                ("starting_at_iter", _N), {"mipgap": _mipgap_schedule[_N]}))
 
     all_scenario_names = list()
     for sn in range(ScenCount):

--- a/examples/uc/uc_cylinders.py
+++ b/examples/uc/uc_cylinders.py
@@ -134,7 +134,7 @@ def main():
 
     # Per-iteration mipgap schedule: route the example's
     # --ph-mipgaps-json into hub solver_options_layers as
-    # after_iter layers so the layer fold drives mipgap at each
+    # starting_at_iter layers so the layer fold drives mipgap at each
     # PH iteration. No Gapper extension is required for static
     # schedules.
     if cfg.ph_mipgaps_json is not None:
@@ -146,7 +146,7 @@ def main():
         for _N in sorted(mipgap_schedule):
             hub_options["solver_options_layers"].append(
                 sputils.solver_options_layer(
-                    ("after_iter", _N), {"mipgap": mipgap_schedule[_N]}))
+                    ("starting_at_iter", _N), {"mipgap": mipgap_schedule[_N]}))
 
     if cfg.default_rho is None:
         # since we are using a rho_setter anyway

--- a/mpisppy/extensions/mipgapper.py
+++ b/mpisppy/extensions/mipgapper.py
@@ -55,10 +55,14 @@ class Gapper(mpisppy.extensions.extension.Extension):
             # so it remains last (and so wins over these for any
             # adaptive writes).
             for N in sorted(mipgapdict):
+                # N == 0 in the legacy mipgapdict means "from iter 0
+                # onward" — which is the `default` predicate. The
+                # validator rejects ("starting_at_iter", 0).
+                when = "default" if int(N) == 0 else ("starting_at_iter", int(N))
                 self.ph.solver_options_layers.insert(
                     -1,
                     sputils.solver_options_layer(
-                        ("starting_at_iter", int(N)),
+                        when,
                         {"mipgap": mipgapdict[N]},
                     ),
                 )

--- a/mpisppy/extensions/mipgapper.py
+++ b/mpisppy/extensions/mipgapper.py
@@ -34,7 +34,7 @@ class Gapper(mpisppy.extensions.extension.Extension):
         # That role is now filled by solver_options_layers
         # (cfg_vanilla.add_gapper does this for --mipgaps-json
         # automatically). Translate any legacy mipgapdict into
-        # after_iter layers on the host PHBase so existing user
+        # starting_at_iter layers on the host PHBase so existing user
         # scripts keep producing the same per-iteration mipgap, and
         # warn so callers migrate over time.
         mipgapdict = self.gapperoptions.get("mipgapdict")
@@ -46,7 +46,7 @@ class Gapper(mpisppy.extensions.extension.Extension):
                 "solver_options_layers automatically; remove the "
                 "Gapper extension and instead pass --mipgaps-json "
                 "on the CLI, or append solver_options_layer("
-                "('after_iter', N), {'mipgap': v}) entries to "
+                "('starting_at_iter', N), {'mipgap': v}) entries to "
                 "options['solver_options_layers'] directly.",
                 DeprecationWarning,
                 stacklevel=2,
@@ -58,7 +58,7 @@ class Gapper(mpisppy.extensions.extension.Extension):
                 self.ph.solver_options_layers.insert(
                     -1,
                     sputils.solver_options_layer(
-                        ("after_iter", int(N)),
+                        ("starting_at_iter", int(N)),
                         {"mipgap": mipgapdict[N]},
                     ),
                 )

--- a/mpisppy/phbase.py
+++ b/mpisppy/phbase.py
@@ -358,7 +358,7 @@ class PHBase(mpisppy.spopt.SPOpt):
         """Read-only fold of solver_options_layers for iteration k>=1.
 
         Returns the fold at k=1; later iterations may differ when
-        after_iter layers are present (callers wanting an exact
+        starting_at_iter layers are present (callers wanting an exact
         per-iteration view should call _effective_solver_options(k)).
         """
         return sputils.fold_solver_options_layers(

--- a/mpisppy/tests/test_solver_options_layers.py
+++ b/mpisppy/tests/test_solver_options_layers.py
@@ -945,6 +945,45 @@ class TestSolverOptionsFilePerSpoke(unittest.TestCase):
         finally:
             os.unlink(path)
 
+    def test_spoke_after_iter_subblock_honored(self):
+        # Spoke sub-blocks support every predicate the top-level
+        # supports, including after_iter. Verify the schema example
+        # in the docs holds at runtime.
+        import os
+        cfg = _spoke_cfg("lagrangian")
+        path = self._write({
+            "spokes": {
+                "lagrangian": {
+                    "default":    {"mipgap": 0.01},
+                    "after_iter": {"5": {"mipgap": 0.001}},
+                },
+            },
+        })
+        try:
+            cfg.solver_options_file = path
+            sh = shared_options(cfg)
+            spoke = self._spoke_dict_from(sh)
+            apply_solver_specs("lagrangian", spoke, cfg)
+            opts = spoke["opt_kwargs"]["options"]
+            self.assertEqual(
+                fold_solver_options_layers(
+                    opts["solver_options_layers"], 0)["mipgap"],
+                0.01)
+            self.assertEqual(
+                fold_solver_options_layers(
+                    opts["solver_options_layers"], 4)["mipgap"],
+                0.01)
+            self.assertEqual(
+                fold_solver_options_layers(
+                    opts["solver_options_layers"], 5)["mipgap"],
+                0.001)
+            self.assertEqual(
+                fold_solver_options_layers(
+                    opts["solver_options_layers"], 9)["mipgap"],
+                0.001)
+        finally:
+            os.unlink(path)
+
     def test_spoke_inline_overrides_spoke_file(self):
         # Axis 2 within a spoke: --{name}-solver-options is above the
         # spoke's file contribution.

--- a/mpisppy/tests/test_solver_options_layers.py
+++ b/mpisppy/tests/test_solver_options_layers.py
@@ -224,8 +224,14 @@ class TestPredicateValidation(unittest.TestCase):
 
     def test_valid_predicates_accepted(self):
         for when in ("default", "iter0", "iterk",
-                     ("starting_at_iter", 0), ("starting_at_iter", 5)):
+                     ("starting_at_iter", 1), ("starting_at_iter", 5)):
             solver_options_layer(when, {"mipgap": 0.01})
+
+    def test_starting_at_iter_zero_rejected(self):
+        # N=0 would silently outrank iter0/iterk in axis-1
+        # specificity; reject with a hint pointing at `default`.
+        with self.assertRaisesRegex(ValueError, "default"):
+            solver_options_layer(("starting_at_iter", 0), {"mipgap": 0.01})
 
     def test_unknown_string_predicate_rejected(self):
         with self.assertRaises(ValueError):
@@ -304,10 +310,12 @@ class TestEffectiveSolverOptions(unittest.TestCase):
 
     def test_starting_at_iter_layers_match_mipgaps_json_semantics(self):
         # cfg_vanilla.add_gapper turns --mipgaps-json {0: G0, 5: G5,
-        # 10: G10} into a list of starting_at_iter layers; assert the fold
-        # gives the expected per-iter mipgap.
+        # 10: G10} into a list of layers; the N=0 entry is rendered
+        # as a `default` layer (since `starting_at_iter:0` is
+        # rejected by the validator), the rest as starting_at_iter:N.
+        # Assert the fold gives the expected per-iter mipgap.
         layers = [
-            solver_options_layer(("starting_at_iter", 0), {"mipgap": 0.10}),
+            solver_options_layer("default", {"mipgap": 0.10}),
             solver_options_layer(("starting_at_iter", 5), {"mipgap": 0.01}),
             solver_options_layer(("starting_at_iter", 10), {"mipgap": 0.005}),
         ]
@@ -368,9 +376,10 @@ class TestAddGapperMipgapsJsonLayers(unittest.TestCase):
                 f"got {[(w.category.__name__, str(w.message)) for w in caught]}",
             )
             layers = hub_dict["opt_kwargs"]["options"]["solver_options_layers"]
-            # 3 starting_at_iter layers in ascending-N order
+            # 3 layers: the N=0 entry is rendered as `default`,
+            # subsequent entries as starting_at_iter:N.
             self.assertEqual(len(layers), 3)
-            self.assertEqual(layers[0]["when"], ("starting_at_iter", 0))
+            self.assertEqual(layers[0]["when"], "default")
             self.assertEqual(layers[1]["when"], ("starting_at_iter", 5))
             self.assertEqual(layers[2]["when"], ("starting_at_iter", 10))
             self.assertEqual(
@@ -571,12 +580,15 @@ class TestDynamicGapperLayer(unittest.TestCase):
             f"Expected DeprecationWarning naming mipgapdict; "
             f"got {[(w.category.__name__, str(w.message)) for w in caught]}",
         )
-        # Two starting_at_iter layers, inserted before the dynamic layer.
-        # solver_options_layers starts as [_dynamic]; after the
-        # shim runs it should be [starting_at_iter 0, starting_at_iter 5, _dynamic].
+        # Two layers, inserted before the dynamic layer. The N=0
+        # entry becomes a `default` layer (since starting_at_iter:0
+        # is rejected by the validator); N=5 becomes
+        # starting_at_iter:5. solver_options_layers starts as
+        # [_dynamic]; after the shim runs it should be
+        # [default, starting_at_iter:5, _dynamic].
         layers = fake.solver_options_layers
         self.assertEqual(len(layers), 3)
-        self.assertEqual(layers[0]["when"], ("starting_at_iter", 0))
+        self.assertEqual(layers[0]["when"], "default")
         self.assertEqual(layers[0]["options"], {"mipgap": 0.10})
         self.assertEqual(layers[1]["when"], ("starting_at_iter", 5))
         self.assertEqual(layers[1]["options"], {"mipgap": 0.005})
@@ -636,7 +648,7 @@ class TestPerSpokeMipgapsJsonLayers(unittest.TestCase):
             )
             layers = spoke["opt_kwargs"]["options"]["solver_options_layers"]
             self.assertEqual(len(layers), 2)
-            self.assertEqual(layers[0]["when"], ("starting_at_iter", 0))
+            self.assertEqual(layers[0]["when"], "default")
             self.assertEqual(layers[1]["when"], ("starting_at_iter", 3))
             self.assertEqual(
                 [layer["options"] for layer in layers],
@@ -743,7 +755,20 @@ class TestLoadSolverOptionsFile(unittest.TestCase):
         from mpisppy.utils.sputils import load_solver_options_file
         path = self._write({"starting_at_iter": {"-3": {"mipgap": 1e-5}}})
         try:
-            with self.assertRaisesRegex(ValueError, ">= 0"):
+            with self.assertRaisesRegex(ValueError, ">= 1"):
+                load_solver_options_file(path)
+        finally:
+            os.unlink(path)
+
+    def test_starting_at_iter_zero_key_rejected_with_hint(self):
+        # N=0 in the file should fail with a message that points the
+        # caller at the `default` sub-block (since "starting at iter 0"
+        # really means "applies always", which is what `default` is for).
+        import os
+        from mpisppy.utils.sputils import load_solver_options_file
+        path = self._write({"starting_at_iter": {"0": {"mipgap": 1e-5}}})
+        try:
+            with self.assertRaisesRegex(ValueError, "default"):
                 load_solver_options_file(path)
         finally:
             os.unlink(path)
@@ -864,8 +889,12 @@ class TestSolverOptionsFileWiredIntoSharedOptions(unittest.TestCase):
     def test_file_starting_at_iter_persists_until_next_starting_at_iter(self):
         import os
         cfg = _bare_cfg()
+        # `default` sets the always-applies base; starting_at_iter:5
+        # kicks in at k>=5 and overrides for the rest of the run.
         path = self._write({
-            "starting_at_iter": {"0": {"mipgap": 0.1}, "5": {"mipgap": 0.01}}})
+            "default": {"mipgap": 0.1},
+            "starting_at_iter": {"5": {"mipgap": 0.01}},
+        })
         try:
             cfg.solver_options_file = path
             sh = shared_options(cfg)

--- a/mpisppy/tests/test_solver_options_layers.py
+++ b/mpisppy/tests/test_solver_options_layers.py
@@ -663,5 +663,310 @@ class TestPerSpokeMipgapsJsonLayers(unittest.TestCase):
             os.unlink(path)
 
 
+class TestLoadSolverOptionsFile(unittest.TestCase):
+    """sputils.load_solver_options_file: schema validation, sub-block
+    defaults, after_iter int-coercion, error messages.
+    """
+
+    def _write(self, payload):
+        import json
+        import tempfile
+        path = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False).name
+        with open(path, "w") as f:
+            json.dump(payload, f)
+        return path
+
+    def test_happy_path_full_schema(self):
+        import os
+        from mpisppy.utils.sputils import load_solver_options_file
+        path = self._write({
+            "default": {"threads": 4},
+            "iter0": {"mipgap": 1e-4},
+            "iterk": {"mipgap": 1e-3},
+            "after_iter": {"5": {"mipgap": 1e-5}, "10": {"mipgap": 1e-6}},
+            "spokes": {
+                "lagrangian": {"default": {"mipgap": 0.01}},
+                "reduced_costs": {"iter0": {"mipgap": 0.001}},
+            },
+        })
+        try:
+            data = load_solver_options_file(path)
+            self.assertEqual(data["default"], {"threads": 4})
+            self.assertEqual(data["iter0"], {"mipgap": 1e-4})
+            self.assertEqual(data["iterk"], {"mipgap": 1e-3})
+            self.assertEqual(
+                data["after_iter"], {5: {"mipgap": 1e-5}, 10: {"mipgap": 1e-6}})
+            self.assertEqual(
+                data["spokes"]["lagrangian"]["default"], {"mipgap": 0.01})
+            self.assertEqual(
+                data["spokes"]["reduced_costs"]["iter0"], {"mipgap": 0.001})
+        finally:
+            os.unlink(path)
+
+    def test_missing_sub_blocks_default_to_empty(self):
+        import os
+        from mpisppy.utils.sputils import load_solver_options_file
+        path = self._write({"iter0": {"mipgap": 0.01}})
+        try:
+            data = load_solver_options_file(path)
+            self.assertEqual(data["default"], {})
+            self.assertEqual(data["iter0"], {"mipgap": 0.01})
+            self.assertEqual(data["iterk"], {})
+            self.assertEqual(data["after_iter"], {})
+            self.assertEqual(data["spokes"], {})
+        finally:
+            os.unlink(path)
+
+    def test_unknown_top_level_key_rejected(self):
+        import os
+        from mpisppy.utils.sputils import load_solver_options_file
+        path = self._write({"defualt": {"mipgap": 0.01}})  # typo
+        try:
+            with self.assertRaisesRegex(ValueError, "defualt"):
+                load_solver_options_file(path)
+        finally:
+            os.unlink(path)
+
+    def test_after_iter_non_integer_key_rejected(self):
+        import os
+        from mpisppy.utils.sputils import load_solver_options_file
+        path = self._write({"after_iter": {"five": {"mipgap": 1e-5}}})
+        try:
+            with self.assertRaisesRegex(ValueError, "five"):
+                load_solver_options_file(path)
+        finally:
+            os.unlink(path)
+
+    def test_after_iter_negative_key_rejected(self):
+        import os
+        from mpisppy.utils.sputils import load_solver_options_file
+        path = self._write({"after_iter": {"-3": {"mipgap": 1e-5}}})
+        try:
+            with self.assertRaisesRegex(ValueError, ">= 0"):
+                load_solver_options_file(path)
+        finally:
+            os.unlink(path)
+
+    def test_unknown_key_in_spoke_subblock_rejected(self):
+        import os
+        from mpisppy.utils.sputils import load_solver_options_file
+        path = self._write({
+            "spokes": {"lagrangian": {"spokes": {"x": {}}}}
+        })
+        try:
+            # Nested "spokes" inside a spoke sub-block is not allowed.
+            with self.assertRaisesRegex(
+                    ValueError, "spokes.lagrangian.*spokes"):
+                load_solver_options_file(path)
+        finally:
+            os.unlink(path)
+
+    def test_malformed_json_raises_valueerror(self):
+        import os
+        import tempfile
+        from mpisppy.utils.sputils import load_solver_options_file
+        path = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False).name
+        try:
+            with open(path, "w") as f:
+                f.write("not json {")
+            with self.assertRaisesRegex(ValueError, "invalid JSON"):
+                load_solver_options_file(path)
+        finally:
+            os.unlink(path)
+
+
+class TestSolverOptionsFileWiredIntoSharedOptions(unittest.TestCase):
+    """End-to-end: --solver-options-file plumbing through
+    cfg_vanilla.shared_options into solver_options_layers + the legacy
+    iter0/iterk dicts.
+    """
+
+    def _write(self, payload):
+        import json
+        import tempfile
+        path = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False).name
+        with open(path, "w") as f:
+            json.dump(payload, f)
+        return path
+
+    def test_file_default_iter0_iterk_appear_as_layers(self):
+        import os
+        cfg = _bare_cfg()
+        path = self._write({
+            "default": {"threads": 2, "presolve": 1},
+            "iter0": {"mipgap": 1e-4},
+            "iterk": {"mipgap": 1e-3},
+            "after_iter": {"5": {"mipgap": 1e-5}},
+        })
+        try:
+            cfg.solver_options_file = path
+            sh = shared_options(cfg)
+            self.assertEqual(
+                fold_solver_options_layers(sh["solver_options_layers"], 0),
+                {"threads": 2, "presolve": 1, "mipgap": 1e-4},
+            )
+            self.assertEqual(
+                fold_solver_options_layers(sh["solver_options_layers"], 3),
+                {"threads": 2, "presolve": 1, "mipgap": 1e-3},
+            )
+            self.assertEqual(
+                fold_solver_options_layers(sh["solver_options_layers"], 7),
+                {"threads": 2, "presolve": 1, "mipgap": 1e-5},
+            )
+        finally:
+            os.unlink(path)
+
+    def test_inline_solver_options_overrides_file_default(self):
+        # Axis 2: --solver-options is above --solver-options-file in
+        # the default predicate, so inline keys win.
+        import os
+        cfg = _bare_cfg()
+        path = self._write({"default": {"mipgap": 0.5, "threads": 2}})
+        try:
+            cfg.solver_options_file = path
+            cfg.solver_options = "mipgap=0.001"
+            sh = shared_options(cfg)
+            folded = fold_solver_options_layers(sh["solver_options_layers"], 0)
+            self.assertEqual(folded["mipgap"], 0.001)  # inline wins
+            self.assertEqual(folded["threads"], 2)     # file survives
+        finally:
+            os.unlink(path)
+
+    def test_iter0_mipgap_sugar_overrides_file_iter0(self):
+        import os
+        cfg = _bare_cfg()
+        path = self._write({"iter0": {"mipgap": 0.5}})
+        try:
+            cfg.solver_options_file = path
+            cfg.iter0_mipgap = 0.001
+            sh = shared_options(cfg)
+            folded = fold_solver_options_layers(sh["solver_options_layers"], 0)
+            self.assertEqual(folded["mipgap"], 0.001)
+        finally:
+            os.unlink(path)
+
+    def test_iterk_mipgap_sugar_overrides_file_iterk(self):
+        import os
+        cfg = _bare_cfg()
+        path = self._write({"iterk": {"mipgap": 0.5}})
+        try:
+            cfg.solver_options_file = path
+            cfg.iterk_mipgap = 0.001
+            sh = shared_options(cfg)
+            folded = fold_solver_options_layers(sh["solver_options_layers"], 3)
+            self.assertEqual(folded["mipgap"], 0.001)
+        finally:
+            os.unlink(path)
+
+    def test_file_after_iter_persists_until_next_after_iter(self):
+        import os
+        cfg = _bare_cfg()
+        path = self._write({
+            "after_iter": {"0": {"mipgap": 0.1}, "5": {"mipgap": 0.01}}})
+        try:
+            cfg.solver_options_file = path
+            sh = shared_options(cfg)
+            self.assertEqual(
+                fold_solver_options_layers(sh["solver_options_layers"], 0)["mipgap"],
+                0.1)
+            self.assertEqual(
+                fold_solver_options_layers(sh["solver_options_layers"], 4)["mipgap"],
+                0.1)
+            self.assertEqual(
+                fold_solver_options_layers(sh["solver_options_layers"], 5)["mipgap"],
+                0.01)
+        finally:
+            os.unlink(path)
+
+
+class TestSolverOptionsFilePerSpoke(unittest.TestCase):
+    """Per-spoke layers from (a) the global file's "spokes" sub-block
+    and (b) a dedicated --{name}-solver-options-file flag.
+    """
+
+    def _write(self, payload):
+        import json
+        import tempfile
+        path = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False).name
+        with open(path, "w") as f:
+            json.dump(payload, f)
+        return path
+
+    def _spoke_dict_from(self, sh):
+        return {"opt_kwargs": {"options": copy.deepcopy(sh)}}
+
+    def test_global_files_spokes_subblock_adds_spoke_layers(self):
+        import os
+        cfg = _spoke_cfg("lagrangian")
+        path = self._write({
+            "default": {"threads": 2},
+            "spokes": {
+                "lagrangian": {
+                    "default": {"mipgap": 0.01},
+                    "iter0": {"mipgap": 0.001},
+                },
+            },
+        })
+        try:
+            cfg.solver_options_file = path
+            sh = shared_options(cfg)
+            spoke = self._spoke_dict_from(sh)
+            apply_solver_specs("lagrangian", spoke, cfg)
+            opts = spoke["opt_kwargs"]["options"]
+            self.assertEqual(
+                fold_solver_options_layers(opts["solver_options_layers"], 0),
+                {"threads": 2, "mipgap": 0.001},
+            )
+            self.assertEqual(
+                fold_solver_options_layers(opts["solver_options_layers"], 1),
+                {"threads": 2, "mipgap": 0.01},
+            )
+        finally:
+            os.unlink(path)
+
+    def test_dedicated_spoke_file_adds_spoke_layers(self):
+        import os
+        cfg = _spoke_cfg("lagrangian")
+        path = self._write({"default": {"mipgap": 0.005}})
+        try:
+            cfg.lagrangian_solver_options_file = path
+            sh = shared_options(cfg)
+            spoke = self._spoke_dict_from(sh)
+            apply_solver_specs("lagrangian", spoke, cfg)
+            opts = spoke["opt_kwargs"]["options"]
+            self.assertEqual(
+                fold_solver_options_layers(
+                    opts["solver_options_layers"], 0)["mipgap"],
+                0.005)
+        finally:
+            os.unlink(path)
+
+    def test_spoke_inline_overrides_spoke_file(self):
+        # Axis 2 within a spoke: --{name}-solver-options is above the
+        # spoke's file contribution.
+        import os
+        cfg = _spoke_cfg("lagrangian")
+        path = self._write({"default": {"mipgap": 0.5, "presolve": 1}})
+        try:
+            cfg.lagrangian_solver_options_file = path
+            cfg.lagrangian_solver_options = "mipgap=0.001"
+            sh = shared_options(cfg)
+            spoke = self._spoke_dict_from(sh)
+            apply_solver_specs("lagrangian", spoke, cfg)
+            opts = spoke["opt_kwargs"]["options"]
+            folded = fold_solver_options_layers(
+                opts["solver_options_layers"], 0)
+            self.assertEqual(folded["mipgap"], 0.001)  # inline wins
+            self.assertEqual(folded["presolve"], 1)    # file survives
+
+
+        finally:
+            os.unlink(path)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/mpisppy/tests/test_solver_options_layers.py
+++ b/mpisppy/tests/test_solver_options_layers.py
@@ -224,27 +224,27 @@ class TestPredicateValidation(unittest.TestCase):
 
     def test_valid_predicates_accepted(self):
         for when in ("default", "iter0", "iterk",
-                     ("after_iter", 0), ("after_iter", 5)):
+                     ("starting_at_iter", 0), ("starting_at_iter", 5)):
             solver_options_layer(when, {"mipgap": 0.01})
 
     def test_unknown_string_predicate_rejected(self):
         with self.assertRaises(ValueError):
             solver_options_layer("sometimes", {})
 
-    def test_after_iter_negative_rejected(self):
+    def test_starting_at_iter_negative_rejected(self):
         with self.assertRaises(ValueError):
-            solver_options_layer(("after_iter", -1), {})
+            solver_options_layer(("starting_at_iter", -1), {})
 
-    def test_after_iter_non_int_rejected(self):
+    def test_starting_at_iter_non_int_rejected(self):
         with self.assertRaises(ValueError):
-            solver_options_layer(("after_iter", 1.5), {})
+            solver_options_layer(("starting_at_iter", 1.5), {})
         with self.assertRaises(ValueError):
-            solver_options_layer(("after_iter", "5"), {})
+            solver_options_layer(("starting_at_iter", "5"), {})
 
-    def test_after_iter_bool_rejected(self):
-        # bool is an int subclass — guard against (after_iter, True)
+    def test_starting_at_iter_bool_rejected(self):
+        # bool is an int subclass — guard against (starting_at_iter, True)
         with self.assertRaises(ValueError):
-            solver_options_layer(("after_iter", True), {})
+            solver_options_layer(("starting_at_iter", True), {})
 
     def test_fold_rejects_invalid_predicate(self):
         # Hand-built layer (bypasses solver_options_layer) is still validated
@@ -262,7 +262,7 @@ class TestEffectiveSolverOptions(unittest.TestCase):
          whose "when" predicate matches k and last-write-wins per key.
       2. current_solver_options is overlaid last (so Gapper auto-mode
          writes to current_solver_options surface in the solve).
-      3. after_iter layers fire on iterations >= N, matching the
+      3. starting_at_iter layers fire on iterations >= N, matching the
          per-iter mipgap semantics --mipgaps-json now produces via
          add_gapper.
     """
@@ -302,14 +302,14 @@ class TestEffectiveSolverOptions(unittest.TestCase):
         self.assertEqual(
             self._effective(layers, current, 5), {"mipgap": 0.001})
 
-    def test_after_iter_layers_match_mipgaps_json_semantics(self):
+    def test_starting_at_iter_layers_match_mipgaps_json_semantics(self):
         # cfg_vanilla.add_gapper turns --mipgaps-json {0: G0, 5: G5,
-        # 10: G10} into a list of after_iter layers; assert the fold
+        # 10: G10} into a list of starting_at_iter layers; assert the fold
         # gives the expected per-iter mipgap.
         layers = [
-            solver_options_layer(("after_iter", 0), {"mipgap": 0.10}),
-            solver_options_layer(("after_iter", 5), {"mipgap": 0.01}),
-            solver_options_layer(("after_iter", 10), {"mipgap": 0.005}),
+            solver_options_layer(("starting_at_iter", 0), {"mipgap": 0.10}),
+            solver_options_layer(("starting_at_iter", 5), {"mipgap": 0.01}),
+            solver_options_layer(("starting_at_iter", 10), {"mipgap": 0.005}),
         ]
         self.assertEqual(self._effective(layers, {}, 0)["mipgap"], 0.10)
         self.assertEqual(self._effective(layers, {}, 4)["mipgap"], 0.10)
@@ -319,10 +319,10 @@ class TestEffectiveSolverOptions(unittest.TestCase):
 
 
 class TestAddGapperMipgapsJsonLayers(unittest.TestCase):
-    """add_gapper's static-schedule path now appends after_iter
+    """add_gapper's static-schedule path now appends starting_at_iter
     layers and skips the Gapper extension. The resulting per-iter
     mipgap behavior is pinned by
-    TestEffectiveSolverOptions.test_after_iter_layers_match_mipgaps_json_semantics
+    TestEffectiveSolverOptions.test_starting_at_iter_layers_match_mipgaps_json_semantics
     above; this class pins the cfg_vanilla wiring that produces
     those layers from the JSON file.
     """
@@ -343,7 +343,7 @@ class TestAddGapperMipgapsJsonLayers(unittest.TestCase):
             json.dump({str(k): v for k, v in schedule.items()}, f)
         return path
 
-    def test_mipgaps_json_appends_after_iter_layers(self):
+    def test_mipgaps_json_appends_starting_at_iter_layers(self):
         import os
         import warnings
         from mpisppy.utils.cfg_vanilla import add_gapper
@@ -368,11 +368,11 @@ class TestAddGapperMipgapsJsonLayers(unittest.TestCase):
                 f"got {[(w.category.__name__, str(w.message)) for w in caught]}",
             )
             layers = hub_dict["opt_kwargs"]["options"]["solver_options_layers"]
-            # 3 after_iter layers in ascending-N order
+            # 3 starting_at_iter layers in ascending-N order
             self.assertEqual(len(layers), 3)
-            self.assertEqual(layers[0]["when"], ("after_iter", 0))
-            self.assertEqual(layers[1]["when"], ("after_iter", 5))
-            self.assertEqual(layers[2]["when"], ("after_iter", 10))
+            self.assertEqual(layers[0]["when"], ("starting_at_iter", 0))
+            self.assertEqual(layers[1]["when"], ("starting_at_iter", 5))
+            self.assertEqual(layers[2]["when"], ("starting_at_iter", 10))
             self.assertEqual(
                 [layer["options"] for layer in layers],
                 [{"mipgap": 0.10}, {"mipgap": 0.01}, {"mipgap": 0.005}],
@@ -549,7 +549,7 @@ class TestDynamicGapperLayer(unittest.TestCase):
     def test_gapper_legacy_mipgapdict_translates_to_layers(self):
         # Compatibility shim: programmatic callers that still pass
         # mipgapdict in gapperoptions get a DeprecationWarning and
-        # the schedule is translated into after_iter layers on the
+        # the schedule is translated into starting_at_iter layers on the
         # host PHBase (so their existing scripts keep producing the
         # same per-iteration mipgap). The Gapper extension itself
         # becomes a runtime no-op in this mode.
@@ -571,14 +571,14 @@ class TestDynamicGapperLayer(unittest.TestCase):
             f"Expected DeprecationWarning naming mipgapdict; "
             f"got {[(w.category.__name__, str(w.message)) for w in caught]}",
         )
-        # Two after_iter layers, inserted before the dynamic layer.
+        # Two starting_at_iter layers, inserted before the dynamic layer.
         # solver_options_layers starts as [_dynamic]; after the
-        # shim runs it should be [after_iter 0, after_iter 5, _dynamic].
+        # shim runs it should be [starting_at_iter 0, starting_at_iter 5, _dynamic].
         layers = fake.solver_options_layers
         self.assertEqual(len(layers), 3)
-        self.assertEqual(layers[0]["when"], ("after_iter", 0))
+        self.assertEqual(layers[0]["when"], ("starting_at_iter", 0))
         self.assertEqual(layers[0]["options"], {"mipgap": 0.10})
-        self.assertEqual(layers[1]["when"], ("after_iter", 5))
+        self.assertEqual(layers[1]["when"], ("starting_at_iter", 5))
         self.assertEqual(layers[1]["options"], {"mipgap": 0.005})
         self.assertIs(
             layers[2], fake._dynamic_solver_options_layer)
@@ -593,7 +593,7 @@ class TestDynamicGapperLayer(unittest.TestCase):
 
 class TestPerSpokeMipgapsJsonLayers(unittest.TestCase):
     """cfg_vanilla.add_gapper handles --{name}-mipgaps-json the same
-    way as the global flag: per-spoke after_iter layers are appended
+    way as the global flag: per-spoke starting_at_iter layers are appended
     to the spoke dict's solver_options_layers.
     """
 
@@ -636,8 +636,8 @@ class TestPerSpokeMipgapsJsonLayers(unittest.TestCase):
             )
             layers = spoke["opt_kwargs"]["options"]["solver_options_layers"]
             self.assertEqual(len(layers), 2)
-            self.assertEqual(layers[0]["when"], ("after_iter", 0))
-            self.assertEqual(layers[1]["when"], ("after_iter", 3))
+            self.assertEqual(layers[0]["when"], ("starting_at_iter", 0))
+            self.assertEqual(layers[1]["when"], ("starting_at_iter", 3))
             self.assertEqual(
                 [layer["options"] for layer in layers],
                 [{"mipgap": 0.05}, {"mipgap": 0.005}],
@@ -665,7 +665,7 @@ class TestPerSpokeMipgapsJsonLayers(unittest.TestCase):
 
 class TestLoadSolverOptionsFile(unittest.TestCase):
     """sputils.load_solver_options_file: schema validation, sub-block
-    defaults, after_iter int-coercion, error messages.
+    defaults, starting_at_iter int-coercion, error messages.
     """
 
     def _write(self, payload):
@@ -684,7 +684,7 @@ class TestLoadSolverOptionsFile(unittest.TestCase):
             "default": {"threads": 4},
             "iter0": {"mipgap": 1e-4},
             "iterk": {"mipgap": 1e-3},
-            "after_iter": {"5": {"mipgap": 1e-5}, "10": {"mipgap": 1e-6}},
+            "starting_at_iter": {"5": {"mipgap": 1e-5}, "10": {"mipgap": 1e-6}},
             "spokes": {
                 "lagrangian": {"default": {"mipgap": 0.01}},
                 "reduced_costs": {"iter0": {"mipgap": 0.001}},
@@ -696,7 +696,7 @@ class TestLoadSolverOptionsFile(unittest.TestCase):
             self.assertEqual(data["iter0"], {"mipgap": 1e-4})
             self.assertEqual(data["iterk"], {"mipgap": 1e-3})
             self.assertEqual(
-                data["after_iter"], {5: {"mipgap": 1e-5}, 10: {"mipgap": 1e-6}})
+                data["starting_at_iter"], {5: {"mipgap": 1e-5}, 10: {"mipgap": 1e-6}})
             self.assertEqual(
                 data["spokes"]["lagrangian"]["default"], {"mipgap": 0.01})
             self.assertEqual(
@@ -713,7 +713,7 @@ class TestLoadSolverOptionsFile(unittest.TestCase):
             self.assertEqual(data["default"], {})
             self.assertEqual(data["iter0"], {"mipgap": 0.01})
             self.assertEqual(data["iterk"], {})
-            self.assertEqual(data["after_iter"], {})
+            self.assertEqual(data["starting_at_iter"], {})
             self.assertEqual(data["spokes"], {})
         finally:
             os.unlink(path)
@@ -728,20 +728,20 @@ class TestLoadSolverOptionsFile(unittest.TestCase):
         finally:
             os.unlink(path)
 
-    def test_after_iter_non_integer_key_rejected(self):
+    def test_starting_at_iter_non_integer_key_rejected(self):
         import os
         from mpisppy.utils.sputils import load_solver_options_file
-        path = self._write({"after_iter": {"five": {"mipgap": 1e-5}}})
+        path = self._write({"starting_at_iter": {"five": {"mipgap": 1e-5}}})
         try:
             with self.assertRaisesRegex(ValueError, "five"):
                 load_solver_options_file(path)
         finally:
             os.unlink(path)
 
-    def test_after_iter_negative_key_rejected(self):
+    def test_starting_at_iter_negative_key_rejected(self):
         import os
         from mpisppy.utils.sputils import load_solver_options_file
-        path = self._write({"after_iter": {"-3": {"mipgap": 1e-5}}})
+        path = self._write({"starting_at_iter": {"-3": {"mipgap": 1e-5}}})
         try:
             with self.assertRaisesRegex(ValueError, ">= 0"):
                 load_solver_options_file(path)
@@ -799,7 +799,7 @@ class TestSolverOptionsFileWiredIntoSharedOptions(unittest.TestCase):
             "default": {"threads": 2, "presolve": 1},
             "iter0": {"mipgap": 1e-4},
             "iterk": {"mipgap": 1e-3},
-            "after_iter": {"5": {"mipgap": 1e-5}},
+            "starting_at_iter": {"5": {"mipgap": 1e-5}},
         })
         try:
             cfg.solver_options_file = path
@@ -861,11 +861,11 @@ class TestSolverOptionsFileWiredIntoSharedOptions(unittest.TestCase):
         finally:
             os.unlink(path)
 
-    def test_file_after_iter_persists_until_next_after_iter(self):
+    def test_file_starting_at_iter_persists_until_next_starting_at_iter(self):
         import os
         cfg = _bare_cfg()
         path = self._write({
-            "after_iter": {"0": {"mipgap": 0.1}, "5": {"mipgap": 0.01}}})
+            "starting_at_iter": {"0": {"mipgap": 0.1}, "5": {"mipgap": 0.01}}})
         try:
             cfg.solver_options_file = path
             sh = shared_options(cfg)
@@ -945,9 +945,9 @@ class TestSolverOptionsFilePerSpoke(unittest.TestCase):
         finally:
             os.unlink(path)
 
-    def test_spoke_after_iter_subblock_honored(self):
+    def test_spoke_starting_at_iter_subblock_honored(self):
         # Spoke sub-blocks support every predicate the top-level
-        # supports, including after_iter. Verify the schema example
+        # supports, including starting_at_iter. Verify the schema example
         # in the docs holds at runtime.
         import os
         cfg = _spoke_cfg("lagrangian")
@@ -955,7 +955,7 @@ class TestSolverOptionsFilePerSpoke(unittest.TestCase):
             "spokes": {
                 "lagrangian": {
                     "default":    {"mipgap": 0.01},
-                    "after_iter": {"5": {"mipgap": 0.001}},
+                    "starting_at_iter": {"5": {"mipgap": 0.001}},
                 },
             },
         })

--- a/mpisppy/utils/cfg_vanilla.py
+++ b/mpisppy/utils/cfg_vanilla.py
@@ -480,7 +480,7 @@ def add_gapper(hub_dict, cfg, name=None):
     Two modes:
       * static schedule (``--mipgaps-json`` or, per-spoke,
         ``--{name}-mipgaps-json``): the JSON is parsed into
-        ``after_iter`` solver-options layers appended to
+        ``starting_at_iter`` solver-options layers appended to
         ``solver_options_layers`` on the cylinder dict. No Gapper
         extension is registered; the layer fold drives the per-iter
         mipgap directly.
@@ -525,7 +525,7 @@ def add_gapper(hub_dict, cfg, name=None):
         for N in sorted(mipgapdict.keys()):
             layers.append(
                 sputils.solver_options_layer(
-                    ("after_iter", N), {"mipgap": mipgapdict[N]}))
+                    ("starting_at_iter", N), {"mipgap": mipgapdict[N]}))
         return
 
     # Auto-mipgap mode: Gapper observes bound cylinders and tightens

--- a/mpisppy/utils/cfg_vanilla.py
+++ b/mpisppy/utils/cfg_vanilla.py
@@ -82,9 +82,9 @@ def shared_options(cfg, is_hub=False):
         "xhat_from_file" : cfg.get("xhat_from_file", None),
     }
     # The options-file (--solver-options-file) sits at the bottom of
-    # axis 2: any inline CLI flags below override file entries at the
-    # same predicate. Load and apply it first so the rest of the
-    # axis-2 chain can overlay on top.
+    # axis 2: any CLI flags below override file entries at the same
+    # predicate. Load and apply it first so the rest of the axis-2
+    # chain can overlay on top.
     if _hasit(cfg, "solver_options_file"):
         file_data = sputils.load_solver_options_file(cfg.solver_options_file)
         shoptions["iter0_solver_options"].update(file_data["default"])
@@ -523,9 +523,14 @@ def add_gapper(hub_dict, cfg, name=None):
         layers = hub_dict["opt_kwargs"]["options"].setdefault(
             "solver_options_layers", [])
         for N in sorted(mipgapdict.keys()):
+            # N == 0 in --mipgaps-json means "from iteration 0 onward"
+            # — which is the `default` predicate. Don't build
+            # ("starting_at_iter", 0); the validator rejects N=0 (it
+            # would silently outrank iter0/iterk in axis 1).
+            when = "default" if N == 0 else ("starting_at_iter", N)
             layers.append(
                 sputils.solver_options_layer(
-                    ("starting_at_iter", N), {"mipgap": mipgapdict[N]}))
+                    when, {"mipgap": mipgapdict[N]}))
         return
 
     # Auto-mipgap mode: Gapper observes bound cylinders and tightens

--- a/mpisppy/utils/cfg_vanilla.py
+++ b/mpisppy/utils/cfg_vanilla.py
@@ -81,10 +81,26 @@ def shared_options(cfg, is_hub=False):
         # Consumed by XhatInnerBoundBase._try_file_xhat.
         "xhat_from_file" : cfg.get("xhat_from_file", None),
     }
+    # The options-file (--solver-options-file) sits at the bottom of
+    # axis 2: any inline CLI flags below override file entries at the
+    # same predicate. Load and apply it first so the rest of the
+    # axis-2 chain can overlay on top.
+    if _hasit(cfg, "solver_options_file"):
+        file_data = sputils.load_solver_options_file(cfg.solver_options_file)
+        shoptions["iter0_solver_options"].update(file_data["default"])
+        shoptions["iter0_solver_options"].update(file_data["iter0"])
+        shoptions["iterk_solver_options"].update(file_data["default"])
+        shoptions["iterk_solver_options"].update(file_data["iterk"])
+        shoptions["solver_options_layers"].extend(
+            sputils.options_file_section_to_layers(file_data))
+        # Stash the per-spoke sub-block so apply_solver_specs can pull
+        # spoke-specific layers from the same file on a per-spoke
+        # call (without re-reading the file).
+        shoptions["_solver_options_file_spokes"] = file_data["spokes"]
     if _hasit(cfg, "solver_options"):
         odict = sputils.option_string_to_dict(cfg.solver_options)
-        shoptions["iter0_solver_options"] = odict
-        shoptions["iterk_solver_options"] = copy.deepcopy(odict)
+        shoptions["iter0_solver_options"].update(odict)
+        shoptions["iterk_solver_options"].update(odict)
         shoptions["solver_options_layers"].append(
             sputils.solver_options_layer("default", odict))
     # note that specific options such as mipgap will override
@@ -138,6 +154,38 @@ def apply_solver_specs(name, spoke, cfg):
     options.setdefault("solver_options_layers", [])
     if _hasit(cfg, name+"_solver_name"):
         options["solver_name"] = cfg.get(name+"_solver_name")
+    # Per-spoke sources, in axis-2 order (lowest priority first):
+    #   1. global options-file's "spokes.<name>" sub-block
+    #   2. --{name}-solver-options-file (dedicated per-spoke file)
+    #   3. --{name}-solver-options (inline)
+    #   4. --{name}-iter0-mipgap / --{name}-iterk-mipgap (sugar)
+    #   5. --max-solver-threads re-apply (system-level cap)
+    spoke_file_blocks = options.get(
+        "_solver_options_file_spokes", {}).get(name)
+    if spoke_file_blocks:
+        options["iter0_solver_options"].update(spoke_file_blocks["default"])
+        options["iter0_solver_options"].update(spoke_file_blocks["iter0"])
+        options["iterk_solver_options"].update(spoke_file_blocks["default"])
+        options["iterk_solver_options"].update(spoke_file_blocks["iterk"])
+        options["solver_options_layers"].extend(
+            sputils.options_file_section_to_layers(spoke_file_blocks))
+    if _hasit(cfg, name+"_solver_options_file"):
+        spoke_file_data = sputils.load_solver_options_file(
+            cfg.get(name+"_solver_options_file"))
+        # Per-spoke files only consume their own predicates; the
+        # nested "spokes" sub-block at this level is meaningless and
+        # rejected by load_solver_options_file's validator when it
+        # appears under "spokes.<name>" -- but a dedicated per-spoke
+        # file is parsed with allow_spokes=True (since that's what
+        # the loader provides). Any nested "spokes" sub-block here
+        # is silently ignored: a spoke's own file applies only to
+        # that spoke.
+        options["iter0_solver_options"].update(spoke_file_data["default"])
+        options["iter0_solver_options"].update(spoke_file_data["iter0"])
+        options["iterk_solver_options"].update(spoke_file_data["default"])
+        options["iterk_solver_options"].update(spoke_file_data["iterk"])
+        options["solver_options_layers"].extend(
+            sputils.options_file_section_to_layers(spoke_file_data))
     if _hasit(cfg, name+"_solver_options"):
         odict = sputils.option_string_to_dict(cfg.get(name+"_solver_options"))
         options["iter0_solver_options"].update(odict)

--- a/mpisppy/utils/config.py
+++ b/mpisppy/utils/config.py
@@ -182,6 +182,14 @@ class Config(pyofig.ConfigDict):
                             domain = str,
                             default=None)
 
+        self.add_to_config(f"{sstr}_options_file",
+                            description= f"{prefix}path to a JSON solver-options file with sections "
+                                         "default/iter0/iterk/after_iter (and a 'spokes' sub-block at the "
+                                         "top level, naming each spoke's overrides). Inline CLI flags "
+                                         "override file entries at the same predicate.",
+                            domain = str,
+                            default=None)
+
     def add_mipgap_specs(self, prefix=""):
         sstr = f"{prefix}_" if prefix else ""
         if prefix:

--- a/mpisppy/utils/config.py
+++ b/mpisppy/utils/config.py
@@ -184,7 +184,7 @@ class Config(pyofig.ConfigDict):
 
         self.add_to_config(f"{sstr}_options_file",
                             description= f"{prefix}path to a JSON solver-options file with sections "
-                                         "default/iter0/iterk/after_iter (and a 'spokes' sub-block at the "
+                                         "default/iter0/iterk/starting_at_iter (and a 'spokes' sub-block at the "
                                          "top level, naming each spoke's overrides). Inline CLI flags "
                                          "override file entries at the same predicate.",
                             domain = str,

--- a/mpisppy/utils/config.py
+++ b/mpisppy/utils/config.py
@@ -185,7 +185,7 @@ class Config(pyofig.ConfigDict):
         self.add_to_config(f"{sstr}_options_file",
                             description= f"{prefix}path to a JSON solver-options file with sections "
                                          "default/iter0/iterk/starting_at_iter (and a 'spokes' sub-block at the "
-                                         "top level, naming each spoke's overrides). Inline CLI flags "
+                                         "top level, naming each spoke's overrides). CLI flags "
                                          "override file entries at the same predicate.",
                             domain = str,
                             default=None)

--- a/mpisppy/utils/sputils.py
+++ b/mpisppy/utils/sputils.py
@@ -718,19 +718,19 @@ def option_dict_to_string(odict):
 #   "default"             — applies at every iteration
 #   "iter0"               — only at iteration 0
 #   "iterk"               — iterations k >= 1
-#   ("after_iter", N)     — iterations k >= N (N is int)
+#   ("starting_at_iter", N)     — iterations k >= N (N is int)
 
 
 def _validate_when(when):
     """Raise ValueError if *when* is not a recognized layer predicate."""
     if when in ("default", "iter0", "iterk"):
         return
-    if isinstance(when, tuple) and len(when) == 2 and when[0] == "after_iter":
+    if isinstance(when, tuple) and len(when) == 2 and when[0] == "starting_at_iter":
         N = when[1]
         # bool is a subclass of int; reject it explicitly
         if isinstance(N, bool) or not isinstance(N, int) or N < 0:
             raise ValueError(
-                f"after_iter predicate requires a non-negative int, got {N!r}")
+                f"starting_at_iter predicate requires a non-negative int, got {N!r}")
         return
     raise ValueError(f"Unknown solver-options layer predicate: {when!r}")
 
@@ -740,7 +740,7 @@ def solver_options_layer(when, options):
 
     Args:
         when: predicate, one of "default", "iter0", "iterk", or
-            ("after_iter", N) with N a non-negative int.
+            ("starting_at_iter", N) with N a non-negative int.
         options (dict): the options to fold in when the predicate matches.
 
     Returns:
@@ -758,7 +758,7 @@ def _layer_matches(when, k):
         return k == 0
     if when == "iterk":
         return k >= 1
-    # only ("after_iter", N) remains, validated above
+    # only ("starting_at_iter", N) remains, validated above
     return k >= when[1]
 
 
@@ -855,7 +855,7 @@ def translate_solver_options(opts, solver_name):
 
 # Recognized keys in a solver-options-file's per-section sub-block
 # (the top-level dict and each per-spoke sub-block share this shape).
-_OPTIONS_FILE_PREDICATES = ("default", "iter0", "iterk", "after_iter")
+_OPTIONS_FILE_PREDICATES = ("default", "iter0", "iterk", "starting_at_iter")
 _OPTIONS_FILE_TOP_KEYS = _OPTIONS_FILE_PREDICATES + ("spokes",)
 _OPTIONS_FILE_SPOKE_KEYS = _OPTIONS_FILE_PREDICATES
 
@@ -866,7 +866,7 @@ def _parse_options_file_section(section, source, *, allow_spokes):
     Used both for the top-level (allow_spokes=True) and each per-spoke
     sub-block (allow_spokes=False). Returns a dict with keys
     "default", "iter0", "iterk" (each a dict, possibly empty),
-    "after_iter" (dict[int, dict], possibly empty), and "spokes"
+    "starting_at_iter" (dict[int, dict], possibly empty), and "spokes"
     (dict[str, dict] when allowed; absent in spoke sub-blocks).
     """
     if not isinstance(section, dict):
@@ -879,10 +879,10 @@ def _parse_options_file_section(section, source, *, allow_spokes):
             f"{source}: unknown key(s) {sorted(extra)}; allowed: "
             f"{sorted(allowed)}")
     out = {p: dict(section.get(p) or {}) for p in ("default", "iter0", "iterk")}
-    raw_after = section.get("after_iter") or {}
+    raw_after = section.get("starting_at_iter") or {}
     if not isinstance(raw_after, dict):
         raise ValueError(
-            f"{source}.after_iter: expected an object mapping iteration "
+            f"{source}.starting_at_iter: expected an object mapping iteration "
             f"numbers to options dicts, got {type(raw_after).__name__}")
     coerced_after = {}
     for k, v in raw_after.items():
@@ -890,16 +890,16 @@ def _parse_options_file_section(section, source, *, allow_spokes):
             N = int(k)
         except (TypeError, ValueError):
             raise ValueError(
-                f"{source}.after_iter: key {k!r} is not an integer") from None
+                f"{source}.starting_at_iter: key {k!r} is not an integer") from None
         if N < 0:
             raise ValueError(
-                f"{source}.after_iter: iteration index must be >= 0; got {N}")
+                f"{source}.starting_at_iter: iteration index must be >= 0; got {N}")
         if not isinstance(v, dict):
             raise ValueError(
-                f"{source}.after_iter[{k}]: expected an options object, "
+                f"{source}.starting_at_iter[{k}]: expected an options object, "
                 f"got {type(v).__name__}")
         coerced_after[N] = dict(v)
-    out["after_iter"] = coerced_after
+    out["starting_at_iter"] = coerced_after
     if allow_spokes:
         raw_spokes = section.get("spokes") or {}
         if not isinstance(raw_spokes, dict):
@@ -926,7 +926,7 @@ def load_solver_options_file(path):
           "default":   {...},
           "iter0":     {...},
           "iterk":     {...},
-          "after_iter": {"5": {...}, "10": {...}},
+          "starting_at_iter": {"5": {...}, "10": {...}},
           "spokes": {
             "lagrangian": {"default": {...}, "iter0": {...}, ...},
             "reduced_costs": {...}
@@ -934,7 +934,7 @@ def load_solver_options_file(path):
         }
 
     All sub-blocks are optional; absent ones default to empty dicts so
-    callers can iterate uniformly. ``after_iter`` keys are JSON strings
+    callers can iterate uniformly. ``starting_at_iter`` keys are JSON strings
     (JSON object keys must be strings) and are coerced to ints here.
 
     Args:
@@ -942,11 +942,11 @@ def load_solver_options_file(path):
 
     Returns:
         dict: parsed structure with keys "default", "iter0", "iterk",
-        "after_iter" (dict[int, dict]), and "spokes" (dict[str, sub-block]).
+        "starting_at_iter" (dict[int, dict]), and "spokes" (dict[str, sub-block]).
 
     Raises:
         ValueError: on unknown keys, malformed sub-blocks, or
-            non-integer ``after_iter`` keys. The exception message
+            non-integer ``starting_at_iter`` keys. The exception message
             names the offending source path inside the file.
     """
     import json
@@ -971,7 +971,7 @@ def options_file_section_to_layers(section):
 
     Returns:
         list[dict]: layers in order [default, iter0, iterk,
-        after_iter:N₁, after_iter:N₂, ...] (after_iter sorted by
+        starting_at_iter:N₁, starting_at_iter:N₂, ...] (starting_at_iter sorted by
         ascending N). Sub-blocks that are empty contribute nothing.
     """
     layers = []
@@ -981,9 +981,9 @@ def options_file_section_to_layers(section):
         layers.append(solver_options_layer("iter0", section["iter0"]))
     if section["iterk"]:
         layers.append(solver_options_layer("iterk", section["iterk"]))
-    for N in sorted(section["after_iter"]):
+    for N in sorted(section["starting_at_iter"]):
         layers.append(
-            solver_options_layer(("after_iter", N), section["after_iter"][N]))
+            solver_options_layer(("starting_at_iter", N), section["starting_at_iter"][N]))
     return layers
 
 

--- a/mpisppy/utils/sputils.py
+++ b/mpisppy/utils/sputils.py
@@ -715,10 +715,16 @@ def option_dict_to_string(odict):
 #
 # A layer is a plain dict {"when": <predicate>, "options": <dict>}.
 # Predicates:
-#   "default"             — applies at every iteration
-#   "iter0"               — only at iteration 0
-#   "iterk"               — iterations k >= 1
-#   ("starting_at_iter", N)     — iterations k >= N (N is int)
+#   "default"               — applies at every iteration
+#   "iter0"                 — only at iteration 0
+#   "iterk"                 — iterations k >= 1
+#   ("starting_at_iter", N) — iterations k >= N (N >= 1)
+#
+# N = 0 is rejected explicitly. A "matches every iteration" layer
+# should use the `default` predicate; using
+# ("starting_at_iter", 0) instead would silently rank the layer
+# above `iter0` / `iterk` in axis-1 specificity, which is rarely
+# what callers intend.
 
 
 def _validate_when(when):
@@ -728,9 +734,12 @@ def _validate_when(when):
     if isinstance(when, tuple) and len(when) == 2 and when[0] == "starting_at_iter":
         N = when[1]
         # bool is a subclass of int; reject it explicitly
-        if isinstance(N, bool) or not isinstance(N, int) or N < 0:
+        if isinstance(N, bool) or not isinstance(N, int) or N < 1:
             raise ValueError(
-                f"starting_at_iter predicate requires a non-negative int, got {N!r}")
+                f"starting_at_iter predicate requires an int >= 1; got "
+                f"{N!r}. Use the 'default' predicate for options that "
+                "apply at every iteration."
+            )
         return
     raise ValueError(f"Unknown solver-options layer predicate: {when!r}")
 
@@ -740,7 +749,8 @@ def solver_options_layer(when, options):
 
     Args:
         when: predicate, one of "default", "iter0", "iterk", or
-            ("starting_at_iter", N) with N a non-negative int.
+            ("starting_at_iter", N) with N an int >= 1. (N = 0 is
+            rejected; use ``"default"`` instead.)
         options (dict): the options to fold in when the predicate matches.
 
     Returns:
@@ -891,9 +901,16 @@ def _parse_options_file_section(section, source, *, allow_spokes):
         except (TypeError, ValueError):
             raise ValueError(
                 f"{source}.starting_at_iter: key {k!r} is not an integer") from None
-        if N < 0:
+        if N < 1:
+            if N == 0:
+                raise ValueError(
+                    f"{source}.starting_at_iter: iteration index 0 is "
+                    "not allowed. Move these options into the 'default' "
+                    "sub-block if they should apply at every iteration."
+                )
             raise ValueError(
-                f"{source}.starting_at_iter: iteration index must be >= 0; got {N}")
+                f"{source}.starting_at_iter: iteration index must be >= 1; "
+                f"got {N}")
         if not isinstance(v, dict):
             raise ValueError(
                 f"{source}.starting_at_iter[{k}]: expected an options object, "

--- a/mpisppy/utils/sputils.py
+++ b/mpisppy/utils/sputils.py
@@ -853,6 +853,140 @@ def translate_solver_options(opts, solver_name):
     return out
 
 
+# Recognized keys in a solver-options-file's per-section sub-block
+# (the top-level dict and each per-spoke sub-block share this shape).
+_OPTIONS_FILE_PREDICATES = ("default", "iter0", "iterk", "after_iter")
+_OPTIONS_FILE_TOP_KEYS = _OPTIONS_FILE_PREDICATES + ("spokes",)
+_OPTIONS_FILE_SPOKE_KEYS = _OPTIONS_FILE_PREDICATES
+
+
+def _parse_options_file_section(section, source, *, allow_spokes):
+    """Validate one block of a solver-options file and normalize it.
+
+    Used both for the top-level (allow_spokes=True) and each per-spoke
+    sub-block (allow_spokes=False). Returns a dict with keys
+    "default", "iter0", "iterk" (each a dict, possibly empty),
+    "after_iter" (dict[int, dict], possibly empty), and "spokes"
+    (dict[str, dict] when allowed; absent in spoke sub-blocks).
+    """
+    if not isinstance(section, dict):
+        raise ValueError(
+            f"{source}: expected a JSON object, got {type(section).__name__}")
+    allowed = _OPTIONS_FILE_TOP_KEYS if allow_spokes else _OPTIONS_FILE_SPOKE_KEYS
+    extra = set(section) - set(allowed)
+    if extra:
+        raise ValueError(
+            f"{source}: unknown key(s) {sorted(extra)}; allowed: "
+            f"{sorted(allowed)}")
+    out = {p: dict(section.get(p) or {}) for p in ("default", "iter0", "iterk")}
+    raw_after = section.get("after_iter") or {}
+    if not isinstance(raw_after, dict):
+        raise ValueError(
+            f"{source}.after_iter: expected an object mapping iteration "
+            f"numbers to options dicts, got {type(raw_after).__name__}")
+    coerced_after = {}
+    for k, v in raw_after.items():
+        try:
+            N = int(k)
+        except (TypeError, ValueError):
+            raise ValueError(
+                f"{source}.after_iter: key {k!r} is not an integer") from None
+        if N < 0:
+            raise ValueError(
+                f"{source}.after_iter: iteration index must be >= 0; got {N}")
+        if not isinstance(v, dict):
+            raise ValueError(
+                f"{source}.after_iter[{k}]: expected an options object, "
+                f"got {type(v).__name__}")
+        coerced_after[N] = dict(v)
+    out["after_iter"] = coerced_after
+    if allow_spokes:
+        raw_spokes = section.get("spokes") or {}
+        if not isinstance(raw_spokes, dict):
+            raise ValueError(
+                f"{source}.spokes: expected an object mapping spoke "
+                f"names to sub-blocks, got {type(raw_spokes).__name__}")
+        out["spokes"] = {
+            spoke_name: _parse_options_file_section(
+                spoke_block,
+                f"{source}.spokes.{spoke_name}",
+                allow_spokes=False,
+            )
+            for spoke_name, spoke_block in raw_spokes.items()
+        }
+    return out
+
+
+def load_solver_options_file(path):
+    """Read a JSON solver-options file and return its parsed structure.
+
+    The file's shape (see doc/designs/solver_options_redesign.md §5.3):
+
+        {
+          "default":   {...},
+          "iter0":     {...},
+          "iterk":     {...},
+          "after_iter": {"5": {...}, "10": {...}},
+          "spokes": {
+            "lagrangian": {"default": {...}, "iter0": {...}, ...},
+            "reduced_costs": {...}
+          }
+        }
+
+    All sub-blocks are optional; absent ones default to empty dicts so
+    callers can iterate uniformly. ``after_iter`` keys are JSON strings
+    (JSON object keys must be strings) and are coerced to ints here.
+
+    Args:
+        path (str): path to a JSON file.
+
+    Returns:
+        dict: parsed structure with keys "default", "iter0", "iterk",
+        "after_iter" (dict[int, dict]), and "spokes" (dict[str, sub-block]).
+
+    Raises:
+        ValueError: on unknown keys, malformed sub-blocks, or
+            non-integer ``after_iter`` keys. The exception message
+            names the offending source path inside the file.
+    """
+    import json
+    with open(path) as fin:
+        try:
+            raw = json.load(fin)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"{path}: invalid JSON ({e})") from None
+    return _parse_options_file_section(raw, path, allow_spokes=True)
+
+
+def options_file_section_to_layers(section):
+    """Build the layer list for one parsed sub-block in axis-1 order.
+
+    The returned list folds (via fold_solver_options_layers) in the
+    order most-general → most-specific so that more-specific
+    predicates naturally win for any iteration that matches both.
+
+    Args:
+        section (dict): output of ``_parse_options_file_section`` (or
+            one of the per-spoke sub-blocks).
+
+    Returns:
+        list[dict]: layers in order [default, iter0, iterk,
+        after_iter:N₁, after_iter:N₂, ...] (after_iter sorted by
+        ascending N). Sub-blocks that are empty contribute nothing.
+    """
+    layers = []
+    if section["default"]:
+        layers.append(solver_options_layer("default", section["default"]))
+    if section["iter0"]:
+        layers.append(solver_options_layer("iter0", section["iter0"]))
+    if section["iterk"]:
+        layers.append(solver_options_layer("iterk", section["iterk"]))
+    for N in sorted(section["after_iter"]):
+        layers.append(
+            solver_options_layer(("after_iter", N), section["after_iter"][N]))
+    return layers
+
+
 ################################################################################
 # Various utilities related to scenario rank maps (some may not be in use)
 


### PR DESCRIPTION
## Summary

Three coupled changes in one phase:

1. **New \`--solver-options-file\` flag** (and per-spoke
   \`--{name}-solver-options-file\`) that reads a JSON file with
   per-iteration and per-spoke sub-blocks. The file's contents
   become layers in the existing layered representation; CLI flags
   override file entries at the same predicate.
2. **Rename of the after-iter predicate** from \`after_iter\` to
   \`starting_at_iter\`. The old name read like "strictly after
   iteration N" but the implementation has always been
   \`k >= N\` (inclusive). Renaming now while the public schema is
   brand new costs essentially nothing.
3. **Reject \`starting_at_iter\` with \`N = 0\`** — route those
   options through the \`default\` predicate instead.
   \`starting_at_iter:0\` would silently outrank \`iter0\` and
   \`iterk\` in axis-1 specificity, which is almost never what a
   caller intends.

## JSON schema

\`\`\`json
{
  "default":         {"threads": 4, "presolve": 2},
  "iter0":           {"mipgap": 1e-4},
  "iterk":           {"mipgap": 1e-3},
  "starting_at_iter":{"5": {"mipgap": 1e-5}, "10": {"mipgap": 1e-6}},
  "spokes": {
    "lagrangian": {
      "default":          {"mipgap": 0.01},
      "starting_at_iter": {"5": {"mipgap": 0.001}}
    },
    "reduced_costs": {"iter0": {"mipgap": 0.001}}
  }
}
\`\`\`

Sub-blocks:

- \`default\` — applies at every iteration.
- \`iter0\` — only at iteration 0.
- \`iterk\` — at iteration 1 and beyond.
- \`starting_at_iter\` — keyed by iteration number \`N\` with
  \`N >= 1\`; applies from iteration \`N\` onward.
- \`spokes\` — per-spoke overrides keyed by spoke name; each spoke
  sub-block has the same shape minus \`spokes\`.

Per-spoke files (\`--lagrangian-solver-options-file\`, etc.) are
also accepted; they apply only to that spoke and have the same
shape as a global file (their \`spokes\` sub-block, if present, is
ignored).

## Precedence (within a single predicate, lowest to highest)

1. \`--solver-options-file\` entries.
2. Inline \`--solver-options\` (default predicate only).
3. \`--mipgaps-json\` (\`starting_at_iter\` only — planned for
   deprecation; superseded by \`--solver-options-file\`).
4. \`--iter0-mipgap\` / \`--iterk-mipgap\` / \`--max-solver-threads\`
   (CLI sugar).

More-specific predicates always win for any iteration that matches
both: at \`k = 7\`, a \`starting_at_iter:{"5": …}\` entry overrides
any \`iterk\` entry.

## Code

- \`mpisppy/utils/sputils.py\`: \`load_solver_options_file(path)\`
  validates the JSON, defaults missing sub-blocks to \`{}\` for
  uniform iteration, and coerces \`starting_at_iter\` string keys
  to ints. Rejects unknown top-level keys, non-integer keys,
  \`N = 0\`, \`N < 0\`, and malformed JSON with source-path-bearing
  error messages. \`options_file_section_to_layers(section)\`
  builds the section's layer list in axis-1 order.
- \`mpisppy/utils/config.py\`: \`--{prefix-}solver-options-file\`
  registered by \`add_solver_specs\` so the global flag and every
  per-spoke prefix auto-pick it up.
- \`mpisppy/utils/cfg_vanilla.py\`: \`shared_options\` applies the
  global file first (so CLI overrides it) and stashes the spokes
  sub-block on shoptions for \`apply_solver_specs\` to read.
  \`apply_solver_specs\` reads the global file's \`spokes.<name>\`
  sub-block first, then any \`--{name}-solver-options-file\`,
  before the spoke's inline CLI flags. The \`--mipgaps-json\` and
  \`gapperoptions["mipgapdict"]\` paths both route an \`N = 0\`
  entry into a \`default\` layer instead of building
  \`("starting_at_iter", 0)\`.

## Tests

24 new in \`test_solver_options_layers.py\`:

- **\`TestLoadSolverOptionsFile\`** (8): schema validation,
  missing sub-blocks default to empty, \`starting_at_iter\`
  int-coercion, unknown top-level key rejected, \`N = 0\` rejected
  with hint pointing at \`default\`, negative \`N\` rejected,
  unknown key in spoke sub-block rejected, malformed JSON.
- **\`TestSolverOptionsFileWiredIntoSharedOptions\`** (5):
  file's \`default\` / \`iter0\` / \`iterk\` / \`starting_at_iter\`
  all appear as layers and fold correctly per iteration; CLI
  overrides at matching predicates.
- **\`TestSolverOptionsFilePerSpoke\`** (4): global file's
  \`spokes.lagrangian\` sub-block adds lagrangian layers;
  \`starting_at_iter\` honored inside a spoke sub-block;
  \`--lagrangian-solver-options-file\` is honored; spoke inline
  overrides spoke file.
- **\`TestPredicateValidation\`** (1 new):
  \`test_starting_at_iter_zero_rejected\` pins the validator's
  N=0 rejection.

Local: 224/224 pass across \`test_ef_ph\`, \`test_ph_main\`,
\`test_ph_extensions\`, \`test_aph\`, \`test_jensens\`,
\`test_solver_options_layers\`, \`test_proper_bundler\`,
\`test_config\`, \`test_generic_cylinders\`. ruff clean. sphinx
clean.

## Docs

- \`doc/src/generic_cylinders.rst\`: new "Solver-options file"
  subsection under "solver-options" with the JSON schema, the
  per-iteration sub-block descriptions, per-spoke files, and the
  precedence rules. \`starting_at_iter\` description notes
  \`N >= 1\` and points at \`default\` for the always-applies
  case.
- \`doc/designs/solver_options_redesign.md\` §5.3 marked Shipped
  and §5.4 axis-1 spec annotated with the \`N >= 1\` requirement
  plus the rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)