### PR TITLE
Solver options: DeprecationWarning at lagranger_spoke() setup

### DIFF
--- a/doc/designs/solver_options_redesign.md
+++ b/doc/designs/solver_options_redesign.md
@@ -718,13 +718,12 @@ spoke's section of `solver_options_layers`.
 
 ### 5.8 Lagranger deprecation
 
-Per §4 q4: emit a `DeprecationWarning` at `lagranger_spoke()` setup
-saying lagranger is slated for removal in a future release because it
-does not seem to perform as well as the other outer-bound options.
-No removal timeline committed in this redesign. Internal wiring is
-*not* refactored to fold into `apply_solver_specs` in this round —
-that's tracked separately and is conditional on whether lagranger
-survives at all.
+**Shipped.** `lagranger_spoke()` emits a `DeprecationWarning` at
+setup naming the other outer-bound options as alternatives. No
+removal timeline is committed. Internal wiring is *not* refactored
+to fold into `apply_solver_specs` in this round — that's tracked
+separately and is conditional on whether lagranger survives at
+all.
 
 ### 5.9 Component-level changes
 

--- a/mpisppy/tests/test_solver_options_layers.py
+++ b/mpisppy/tests/test_solver_options_layers.py
@@ -1036,5 +1036,36 @@ class TestSolverOptionsFilePerSpoke(unittest.TestCase):
             os.unlink(path)
 
 
+class TestLagrangerDeprecation(unittest.TestCase):
+    """lagranger_spoke() emits a DeprecationWarning at setup naming
+    alternative outer-bound options. The internal wiring is not
+    refactored; the warning is the migration cue.
+    """
+
+    def test_lagranger_spoke_emits_deprecation_warning(self):
+        import warnings
+        from unittest.mock import patch
+        from mpisppy.utils import cfg_vanilla
+        # The warning fires before _PHBase_spoke_foundation is
+        # called, so a side_effect on the foundation lets us exit
+        # the function early without needing a full cfg.
+        sentinel = RuntimeError("stop after the warning")
+        with patch.object(cfg_vanilla, "_PHBase_spoke_foundation",
+                           side_effect=sentinel):
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                with self.assertRaises(RuntimeError):
+                    cfg_vanilla.lagranger_spoke(None, None, None, [])
+        self.assertTrue(
+            any(issubclass(w.category, DeprecationWarning)
+                and "lagranger" in str(w.message)
+                and "future release" in str(w.message)
+                for w in caught),
+            f"Expected DeprecationWarning naming lagranger and 'future "
+            f"release'; got "
+            f"{[(w.category.__name__, str(w.message)) for w in caught]}",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/mpisppy/utils/cfg_vanilla.py
+++ b/mpisppy/utils/cfg_vanilla.py
@@ -934,6 +934,15 @@ def lagranger_spoke(
     extension_kwargs=None,
     average_scenario_creator=None,
 ):
+    warnings.warn(
+        "The lagranger spoke is slated for removal in a future "
+        "release: it does not seem to perform as well as the other "
+        "outer-bound options (--lagrangian, --ph-dual, --subgradient, "
+        "--fwph). No removal timeline is committed yet; this warning "
+        "is the heads-up.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     from mpisppy.cylinders.lagranger_bounder import LagrangerOuterBound
     lagranger_spoke = _PHBase_spoke_foundation(
         LagrangerOuterBound,


### PR DESCRIPTION
## Summary

Per design doc §5.8: emit a \`DeprecationWarning\` at
\`lagranger_spoke()\` setup saying lagranger is slated for removal
in a future release because it does not seem to perform as well
as the other outer-bound options (\`--lagrangian\`, \`--ph-dual\`,
\`--subgradient\`, \`--fwph\`).

No removal timeline is committed. Internal wiring is not
refactored — that's a separate work item, conditional on whether
lagranger survives at all.

## Tests

\`TestLagrangerDeprecation\` in
\`mpisppy/tests/test_solver_options_layers.py\` pins the warning
behavior via a mock that short-circuits
\`_PHBase_spoke_foundation\` after the warning fires, so the test
does not need to wire up a full cfg.

## Docs

§5.8 marked Shipped in
\`doc/designs/solver_options_redesign.md\`.

## Test plan

- [x] Local: \`ruff check .\` clean.
- [x] Local: 225/225 pass across the full local sweep.
- [ ] CI: regression, ph-extensions, ph-main, gradient-rho,
      schur-complement, and the rest pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)