### PR TITLE
Tests: end-to-end verify solver_options_layers reach gurobi at solve time

### DIFF
--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -436,7 +436,7 @@ jobs:
       - name: Install dependencies
         run: |
           conda install mpi4py pandas setuptools
-          pip install pyomo gurobipy dill matplotlib scipy coverage
+          pip install pyomo gurobipy dill matplotlib scipy coverage pytest
 
       - name: setup the program
         run: |

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -452,6 +452,10 @@ jobs:
           cd mpisppy/tests
           coverage run $COV_ARGS straight_tests.py --python-args="$PYARGS"
 
+      - name: Options-reach-solver end-to-end tests
+        run: |
+          coverage run $COV_ARGS -m pytest mpisppy/tests/test_options_reach_solver.py -v
+
       - name: Upload coverage data
         if: always()
         uses: actions/upload-artifact@v4

--- a/mpisppy/spopt.py
+++ b/mpisppy/spopt.py
@@ -180,6 +180,30 @@ class SPOpt(SPBase):
             results = self.extobject.pre_solve(s)
 
         solve_start_time = time.time()
+
+        # Switch the solver's log destination BEFORE writing other
+        # solver options. For persistent Gurobi, setParam writes a
+        # "Set parameter X to value Y" line at parameter-set time to
+        # whatever LogFile is currently active. If we set MIPGap and
+        # other options first and then redirect LogFile, the
+        # parameter-set lines for THIS iteration land in the PREVIOUS
+        # iteration's still-open log file — which mis-attributes
+        # parameters to the wrong iteration and breaks log-driven
+        # debugging of per-iteration options.
+        solve_keyword_args = dict()
+        if self.options.get("solver_log_dir", None):
+            if k not in self._subproblem_solve_index:
+                self._subproblem_solve_index[k] = 0
+            dir_name = self.options["solver_log_dir"]
+            file_name = f"{self._get_cylinder_name()}_{k}_{self._subproblem_solve_index[k]}.log"
+            # Workaround for Pyomo/pyomo#3589: Setting 'keepfiles' to True is required
+            # for proper functionality when using the GurobiDirect / GurobiPersistent solver.
+            if isinstance(s._solver_plugin, GurobiDirect):
+                s._solver_plugin.options["LogFile"] = os.path.join(dir_name, file_name)
+            else:
+                solve_keyword_args["logfile"] = os.path.join(dir_name, file_name)
+            self._subproblem_solve_index[k] += 1
+
         if (solver_options):
             # Translate canonical option keys to the solver's native
             # spelling at the latest moment, so stored options on
@@ -191,7 +215,6 @@ class SPOpt(SPBase):
             for option_key,option_value in translated_options.items():
                 s._solver_plugin.options[option_key] = option_value
 
-        solve_keyword_args = dict()
         if self.cylinder_rank == 0:
             if tee is not None and tee is True:
                 solve_keyword_args["tee"] = True
@@ -209,19 +232,6 @@ class SPOpt(SPBase):
         if disable_pyomo_signal_handling:
             # solve_keyword_args["use_signal_handling"] = False
             pass
-
-        if self.options.get("solver_log_dir", None):
-            if k not in self._subproblem_solve_index:
-                self._subproblem_solve_index[k] = 0
-            dir_name = self.options["solver_log_dir"]
-            file_name = f"{self._get_cylinder_name()}_{k}_{self._subproblem_solve_index[k]}.log"
-            # Workaround for Pyomo/pyomo#3589: Setting 'keepfiles' to True is required
-            # for proper functionality when using the GurobiDirect / GurobiPersistent solver.
-            if isinstance(s._solver_plugin, GurobiDirect):
-                s._solver_plugin.options["LogFile"] = os.path.join(dir_name, file_name)
-            else:
-                solve_keyword_args["logfile"] = os.path.join(dir_name, file_name)
-            self._subproblem_solve_index[k] += 1
 
         Ag = getattr(self, "Ag", None)  # agnostic
         if Ag is not None:

--- a/mpisppy/tests/test_options_reach_solver.py
+++ b/mpisppy/tests/test_options_reach_solver.py
@@ -1,0 +1,341 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+"""End-to-end tests that verify solver_options_layers actually reach the
+solver. Each test sets ONE option through a specific layer path (CLI
+flag, JSON options file, etc.) via the Config / cfg_vanilla surface,
+runs farmer PH for a couple of iterations against gurobi_persistent
+with solver_log_dir pointing at a tmpdir, and then greps the
+per-solve Gurobi log file for the ``Set parameter X to value Y`` line
+that proves the parameter was actually applied.
+
+Gurobi-only because it's the solver we install via pip in CI (the
+size-limited trial license is sufficient for farmer) AND because the
+gurobi log format is stable enough to grep cheaply. These tests are at
+the mercy of upstream gurobi log-format changes; treat that as a
+known cost.
+"""
+
+import copy
+import json
+import os
+import re
+import shutil
+import tempfile
+import unittest
+
+import pyomo.environ as pyo
+
+import mpisppy.opt.ph
+import mpisppy.tests.examples.farmer as farmer
+from mpisppy.utils import config
+from mpisppy.utils.cfg_vanilla import (
+    apply_solver_specs,
+    shared_options,
+)
+
+
+SOLVER_NAME = "gurobi_persistent"
+
+
+def setUpModule():
+    # A stale GRB_LICENSE_FILE on the developer's machine (pointing at
+    # a license bound to a different hostid) silently overrides the
+    # pip-installed gurobipy trial license and causes
+    # ``s.available()`` to raise. Pop it for this process so that
+    # local runs use the trial license like CI does. No-op in CI
+    # where the env var is unset.
+    os.environ.pop("GRB_LICENSE_FILE", None)
+
+
+# Module-level probe for gurobi_persistent. ``s.available()`` actually
+# attempts to construct a Gurobi model, so this catches a stale or
+# missing license too.
+try:
+    _gurobi_available = pyo.SolverFactory(SOLVER_NAME).available()
+except Exception:
+    _gurobi_available = False
+
+
+def _bare_cfg():
+    """Minimal Config with the flags shared_options reads."""
+    cfg = config.Config()
+    cfg.popular_args()
+    cfg.add_mipgap_specs()
+    cfg.add_solver_specs("")
+    cfg.gapper_args()
+    return cfg
+
+
+def _spoke_cfg(spoke_name):
+    cfg = _bare_cfg()
+    cfg.add_solver_specs(prefix=spoke_name)
+    cfg.add_mipgap_specs(prefix=spoke_name)
+    cfg.gapper_args(name=spoke_name)
+    return cfg
+
+
+@unittest.skipUnless(
+    _gurobi_available,
+    "gurobi_persistent is required for these end-to-end tests",
+)
+class TestOptionsReachSolver(unittest.TestCase):
+    """Common harness shared by every option-path test in this file."""
+
+    def setUp(self):
+        # Fresh tempdir per test; solver_log_dir must not exist before
+        # the SPOpt constructor creates it.
+        self._tmpdir = tempfile.mkdtemp(prefix="mpisppy_solver_log_")
+        self.log_dir = os.path.join(self._tmpdir, "logs")
+        self.scenario_names = [f"Scenario{i+1}" for i in range(3)]
+        self.creator_kwargs = {"crops_multiplier": 1}
+
+    def tearDown(self):
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    # ----- harness primitives -----
+
+    def _options_from(self, cfg, *, iter_limit=2, extra=None):
+        """Build the options dict shared_options would produce and
+        layer the PH-only knobs (rho, iter limit, etc.) on top. Any
+        keys in *extra* override what shared_options put there.
+        """
+        shoptions = shared_options(cfg, is_hub=True)
+        shoptions["solver_name"] = SOLVER_NAME
+        shoptions["solver_log_dir"] = self.log_dir
+        shoptions["PHIterLimit"] = iter_limit
+        shoptions["defaultPHrho"] = 1.0
+        shoptions["convthresh"] = 0  # don't terminate on convergence
+        shoptions["verbose"] = False
+        shoptions["display_timing"] = False
+        shoptions["display_progress"] = False
+        shoptions["smoothed"] = 0
+        shoptions["asynchronousPH"] = False
+        shoptions["subsolvedirectives"] = None
+        shoptions["toc"] = False
+        if extra:
+            shoptions.update(extra)
+        return shoptions
+
+    def _spoke_options_from(self, cfg, spoke_name, **kw):
+        """Drive apply_solver_specs to fold per-spoke layers into a
+        spoke dict's options, then return those options as if they
+        were the hub's options. In-process PH uses them to verify
+        that the per-spoke fold reaches the solver — the spoke's
+        actual solve path is layered identically to the hub's.
+        """
+        sh = self._options_from(cfg, **kw)
+        spoke = {"opt_kwargs": {"options": copy.deepcopy(sh)}}
+        apply_solver_specs(spoke_name, spoke, cfg)
+        return spoke["opt_kwargs"]["options"]
+
+    def _run_ph(self, options):
+        ph = mpisppy.opt.ph.PH(
+            options,
+            self.scenario_names,
+            farmer.scenario_creator,
+            farmer.scenario_denouement,
+            scenario_creator_kwargs=self.creator_kwargs,
+        )
+        ph.ph_main()
+
+    def _log_path(self, iter_idx, scen_name="Scenario1"):
+        # spopt.solve_one names log files
+        # "{cylinder_name}_{scenario_name}_{idx}.log" where idx counts
+        # the times that scenario has been solved (so it is 0 at PH
+        # iteration 0, 1 at iteration 1, ...). Standalone PH's cylinder
+        # name is "PH".
+        return os.path.join(
+            self.log_dir, f"PH_{scen_name}_{iter_idx}.log")
+
+    def _log_text(self, iter_idx, scen_name="Scenario1"):
+        with open(self._log_path(iter_idx, scen_name)) as f:
+            return f.read()
+
+    def _gurobi_param(self, log_text, param):
+        """Pull the value Gurobi reported it set the given parameter
+        to. Returns the value as a string (Gurobi prints e.g. "0.001"
+        or "1e-05") or None if no such line is present (which Gurobi
+        does when the parameter is left at its default).
+        """
+        m = re.search(rf"Set parameter {param} to value\s+(\S+)", log_text)
+        return m.group(1) if m else None
+
+    # ----- inline --solver-options -----
+
+    def test_inline_mipgap_reaches_solver(self):
+        cfg = _bare_cfg()
+        cfg.solver_options = "mipgap=0.005"
+        self._run_ph(self._options_from(cfg))
+        self.assertEqual(
+            self._gurobi_param(self._log_text(0), "MIPGap"), "0.005")
+        self.assertEqual(
+            self._gurobi_param(self._log_text(1), "MIPGap"), "0.005")
+
+    def test_inline_threads_translates_to_native_name(self):
+        # mpi-sppy stores threads canonically; gurobi's native key is
+        # "Threads" (capital T). The translation table in sputils
+        # should rename it before reaching the solver.
+        cfg = _bare_cfg()
+        cfg.solver_options = "threads=2"
+        self._run_ph(self._options_from(cfg))
+        self.assertEqual(
+            self._gurobi_param(self._log_text(0), "Threads"), "2")
+
+    def test_inline_presolve_passes_through_unchanged(self):
+        cfg = _bare_cfg()
+        cfg.solver_options = "presolve=2"
+        self._run_ph(self._options_from(cfg))
+        self.assertEqual(
+            self._gurobi_param(self._log_text(0), "Presolve"), "2")
+
+    # ----- iter0 / iterk sugar flags -----
+
+    def test_iter0_iterk_mipgap_apply_to_correct_iterations(self):
+        cfg = _bare_cfg()
+        cfg.iter0_mipgap = 0.001
+        cfg.iterk_mipgap = 0.05
+        self._run_ph(self._options_from(cfg))
+        self.assertEqual(
+            self._gurobi_param(self._log_text(0), "MIPGap"), "0.001")
+        self.assertEqual(
+            self._gurobi_param(self._log_text(1), "MIPGap"), "0.05")
+
+    # ----- --mipgaps-json (planned-deprecation path) -----
+
+    def test_mipgaps_json_after_iter_layer_applies(self):
+        # Per-iter schedule. Three iters: k=0 maps to default-layer
+        # mipgap=0.1 (since N=0 is routed to `default` predicate);
+        # k=2 onwards uses 0.001.
+        import warnings
+        path = os.path.join(self._tmpdir, "mipgaps.json")
+        with open(path, "w") as f:
+            json.dump({"0": 0.1, "2": 0.001}, f)
+        cfg = _bare_cfg()
+        cfg.mipgaps_json = path
+        # add_gapper is what wires --mipgaps-json into layers; call it
+        # the way the spoke / hub orchestrators do.
+        from mpisppy.utils.cfg_vanilla import add_gapper
+        sh = self._options_from(cfg, iter_limit=3)
+        hub_dict = {"opt_kwargs": {"options": sh}}
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            add_gapper(hub_dict, cfg)
+        self._run_ph(sh)
+        self.assertEqual(
+            self._gurobi_param(self._log_text(0), "MIPGap"), "0.1")
+        self.assertEqual(
+            self._gurobi_param(self._log_text(1), "MIPGap"), "0.1")
+        self.assertEqual(
+            self._gurobi_param(self._log_text(2), "MIPGap"), "0.001")
+
+    # ----- --solver-options-file: each sub-block -----
+
+    def _write_file(self, payload):
+        path = os.path.join(self._tmpdir, "opts.json")
+        with open(path, "w") as f:
+            json.dump(payload, f)
+        return path
+
+    def test_options_file_default_subblock_applies_everywhere(self):
+        cfg = _bare_cfg()
+        cfg.solver_options_file = self._write_file(
+            {"default": {"mipgap": 0.01}})
+        self._run_ph(self._options_from(cfg))
+        self.assertEqual(
+            self._gurobi_param(self._log_text(0), "MIPGap"), "0.01")
+        self.assertEqual(
+            self._gurobi_param(self._log_text(1), "MIPGap"), "0.01")
+
+    def test_options_file_iter0_and_iterk_subblocks_fire_separately(self):
+        # iter0 sub-block applies only at k=0; iterk applies only at
+        # k>=1. Pair them with distinct values so each iter's value is
+        # observable in the per-solve log. (Asserting that iterk has
+        # NO MIPGap line when iter0 sets one is unreliable: gurobi
+        # persists parameter state across solves on the same model
+        # instance, and re-emits "Set parameter MIPGap" whenever
+        # LogFile is changed for the next solve. The clean signal is
+        # that the value differs between iters per the layer fold.)
+        cfg = _bare_cfg()
+        cfg.solver_options_file = self._write_file({
+            "iter0": {"mipgap": 0.0001},
+            "iterk": {"mipgap": 0.005},
+        })
+        self._run_ph(self._options_from(cfg))
+        self.assertEqual(
+            self._gurobi_param(self._log_text(0), "MIPGap"), "0.0001")
+        self.assertEqual(
+            self._gurobi_param(self._log_text(1), "MIPGap"), "0.005")
+
+    def test_options_file_starting_at_iter_fires_from_N_onward(self):
+        cfg = _bare_cfg()
+        cfg.solver_options_file = self._write_file({
+            "default": {"mipgap": 0.01},
+            "starting_at_iter": {"2": {"mipgap": 0.0001}},
+        })
+        self._run_ph(self._options_from(cfg, iter_limit=3))
+        self.assertEqual(
+            self._gurobi_param(self._log_text(0), "MIPGap"), "0.01")
+        self.assertEqual(
+            self._gurobi_param(self._log_text(1), "MIPGap"), "0.01")
+        self.assertEqual(
+            self._gurobi_param(self._log_text(2), "MIPGap"), "0.0001")
+
+    def test_options_file_below_cli_sugar_in_precedence(self):
+        # Axis 2: --iter0-mipgap and --iterk-mipgap override the
+        # file's iter0/iterk entries at the same predicate.
+        cfg = _bare_cfg()
+        cfg.solver_options_file = self._write_file({
+            "iter0": {"mipgap": 0.5},
+            "iterk": {"mipgap": 0.5},
+        })
+        cfg.iter0_mipgap = 0.001
+        cfg.iterk_mipgap = 0.005
+        self._run_ph(self._options_from(cfg))
+        self.assertEqual(
+            self._gurobi_param(self._log_text(0), "MIPGap"), "0.001")
+        self.assertEqual(
+            self._gurobi_param(self._log_text(1), "MIPGap"), "0.005")
+
+    # ----- per-spoke files (exercised via apply_solver_specs) -----
+
+    def test_spokes_subblock_inside_global_file_reaches_spoke_solver(self):
+        cfg = _spoke_cfg("lagrangian")
+        cfg.solver_options_file = self._write_file({
+            "spokes": {
+                "lagrangian": {"default": {"mipgap": 0.005}},
+            },
+        })
+        spoke_opts = self._spoke_options_from(cfg, "lagrangian")
+        self._run_ph(spoke_opts)
+        self.assertEqual(
+            self._gurobi_param(self._log_text(0), "MIPGap"), "0.005")
+
+    def test_dedicated_per_spoke_file_reaches_spoke_solver(self):
+        cfg = _spoke_cfg("lagrangian")
+        cfg.lagrangian_solver_options_file = self._write_file(
+            {"default": {"mipgap": 0.002}})
+        spoke_opts = self._spoke_options_from(cfg, "lagrangian")
+        self._run_ph(spoke_opts)
+        self.assertEqual(
+            self._gurobi_param(self._log_text(0), "MIPGap"), "0.002")
+
+    # ----- --max-solver-threads cap -----
+
+    def test_max_solver_threads_wins_over_user_threads(self):
+        # System-level cap must beat any user-supplied threads value.
+        cfg = _bare_cfg()
+        cfg.solver_options = "threads=8"
+        cfg.max_solver_threads = 2
+        self._run_ph(self._options_from(cfg))
+        self.assertEqual(
+            self._gurobi_param(self._log_text(0), "Threads"), "2")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/run_coverage.bash
+++ b/run_coverage.bash
@@ -64,6 +64,9 @@ run_phase "test_component_map_usage (serial)" \
 run_phase "test_solver_options_layers (serial)" \
     coverage run --rcfile=.coveragerc -m pytest mpisppy/tests/test_solver_options_layers.py -v
 
+run_phase "test_options_reach_solver (serial; gurobi-only)" \
+    coverage run --rcfile=.coveragerc -m pytest mpisppy/tests/test_options_reach_solver.py -v
+
 run_phase "test_nonant_validation (serial)" \
     coverage run --rcfile=.coveragerc -m pytest mpisppy/tests/test_nonant_validation.py -v
 


### PR DESCRIPTION
## Summary

A gurobi-only test module
\`mpisppy/tests/test_options_reach_solver.py\` exercises every
layer-source path from the solver-options redesign: each test sets
one option through a specific surface (CLI flag,
\`--solver-options-file\` sub-block, per-spoke file,
\`--max-solver-threads\` cap, deprecated \`--mipgaps-json\`) via
the Config / cfg_vanilla flow, runs farmer PH for a couple of
iterations against \`gurobi_persistent\` with \`solver_log_dir\`
set to a tmpdir, then greps the per-solve Gurobi log files for the
\`Set parameter X to value Y\` line that proves the parameter
actually reached the solver at the expected iteration.

12 tests covering:

- \`--solver-options\` inline — mipgap, threads (canonical→native
  rename via the translation table), and a non-translated key
  (presolve).
- \`--iter0-mipgap\` and \`--iterk-mipgap\` apply at the right
  iteration.
- \`--mipgaps-json\` (deprecated path) — per-iteration schedule
  fires at the right N; the N=0 entry is routed through the
  \`default\` predicate per the validator.
- \`--solver-options-file\` per sub-block — \`default\` applies
  everywhere; \`iter0\` and \`iterk\` fire at their predicates
  separately; \`starting_at_iter\` fires from N onward; CLI sugar
  flags override file entries at the same predicate per axis 2.
- Per-spoke layers — global file's \`spokes.<name>\` sub-block
  AND dedicated \`--{name}-solver-options-file\` both reach the
  spoke's solver (exercised through \`apply_solver_specs\` so the
  test stays single-process).
- \`--max-solver-threads\` cap wins over any user-supplied
  \`threads\` value.

The test class is gated on \`gurobi_persistent.available()\` so it
cleanly skips when gurobi isn't installed.

## Bonus production fix surfaced by the test development

\`spopt.solve_one\` now sets \`s._solver_plugin.options["LogFile"]\`
**before** writing the rest of the solver options. With
\`GurobiPersistent\`, the model instance is reused across
iterations and \`setParam\` writes \`Set parameter X to value Y\`
to the *currently active* LogFile. With the previous order
(options first, then LogFile), each iteration's parameter-set
lines landed in the previous iteration's still-open log,
mis-attributing per-iteration options to the wrong log file —
which is what made the new tests fail until the reorder.

No behavior change for the actual solves; only log-file
attribution. This bug was effectively hidden until you actually
went and read the per-iteration logs.

## CI wiring

Added under the existing \`straight-tests-gurobi\` job (which is
already gated on the gurobi-via-pip install plus the
\`Probe gurobi_persistent availability\` step). The new test file
runs as its own pytest step after \`straight_tests.py\` and
uploads into the same \`coverage-straight-tests-gurobi\` artifact,
so codecov picks it up. \`run_coverage.bash\` also runs it
locally.

## Caveats

- Tests are at the mercy of upstream Gurobi log-format changes
  (the \`Set parameter X to value Y\` line). Treat that as a
  known cost — the alternative is no end-to-end coverage of the
  fold→translate→solve chain.
- \`setUpModule\` pops \`GRB_LICENSE_FILE\` so a stale
  developer-machine license env var doesn't override the pip
  trial license. No-op in CI.

## Test plan

- [x] Local: 12/12 pass in
      \`test_options_reach_solver.py\`.
- [x] Local: 237/238 pass in the wider sweep (the one failure
      is pre-existing on main in \`test_proper_bundler\`,
      unrelated).
- [x] \`ruff check .\` clean.
- [ ] CI: \`straight_tests.py (gurobi via pip)\` job runs
      \`test_options_reach_solver.py\` and stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)