### PR TITLE
Solver options: deprecate legacy iter0/iterk_solver_options surfaces (phase 8)

### DIFF
--- a/doc/designs/solver_options_redesign.md
+++ b/doc/designs/solver_options_redesign.md
@@ -839,8 +839,9 @@ Action items (all complete):
 
 | Surface                                                  | Today                              | New                                                                               | Removal       |
 |----------------------------------------------------------|-------------------------------------|----------------------------------------------------------------------------------|---------------|
-| `options["iter0_solver_options"]`, `options["iterk_solver_options"]` (input to PHBase) | active            | accepted; folded into `solver_options_layers`; one `DeprecationWarning` per run  | future, TBD   |
-| `PHBase.iter0_solver_options`, `iterk_solver_options`, `current_solver_options` (attribute reads) | active            | property shims that compute the merged dict for that predicate; warn on first access per run | future, TBD |
+| `options["iter0_solver_options"]`, `options["iterk_solver_options"]` (input to PHBase) | **DeprecationWarning fires when non-empty; legacy dicts still folded into `solver_options_layers`** | unchanged target (`solver_options_layers`) | future, TBD   |
+| `PHBase.iter0_solver_options`, `iterk_solver_options` (attribute reads) | **DeprecationWarning fires on every read; both are property shims returning `fold_solver_options_layers(layers, 0|1)`** | use `_effective_solver_options(k)` | future, TBD |
+| `PHBase.current_solver_options` (attribute reads / writes) | active; still used internally as the back-compat dynamic-overrides overlay by several spokes (fwph, aph, xhat_eval, cross_scen, lshaped) | not deprecated in phase 8 — pending those spokes migrating to the layer system | future, TBD |
 | `option_string_to_dict`                                  | active                              | unchanged                                                                         | n/a           |
 | `option_dict_to_string`                                  | active                              | unchanged                                                                         | n/a           |
 
@@ -883,9 +884,13 @@ green-on-its-own:
    spoke variants); add `load_solver_options_file`; plumb file layers
    in `shared_options` / `apply_solver_specs`.
 7. **Lagranger deprecation warning** (§5.8). Single-line addition.
-8. **Programmatic-API deprecation warnings** (§6.3). Final phase
-   because it touches user code paths and can be done cleanly only
-   once the new shape is stable.
+8. **Programmatic-API deprecation warnings** (§6.3). **Shipped.**
+   `options["iter0_solver_options"]` / `options["iterk_solver_options"]`
+   dict input and `PHBase.iter0_solver_options` /
+   `iterk_solver_options` attribute reads now emit
+   `DeprecationWarning`s. `current_solver_options` is held back
+   until the spokes that still read it migrate to the layer
+   system.
 
 Phases 1–2 land internally with no surface change. Phase 4 is the only
 phase with a release-notes-worthy behavior change. Phases 6 and 7 add

--- a/mpisppy/extensions/mipgapper.py
+++ b/mpisppy/extensions/mipgapper.py
@@ -40,17 +40,20 @@ class Gapper(mpisppy.extensions.extension.Extension):
         mipgapdict = self.gapperoptions.get("mipgapdict")
         self._static_compat = False
         if mipgapdict is not None:
-            warnings.warn(
-                "Gapper's static mipgapdict is deprecated. The "
-                "schedule is being translated to "
-                "solver_options_layers automatically; remove the "
-                "Gapper extension and instead pass --mipgaps-json "
-                "on the CLI, or append solver_options_layer("
-                "('starting_at_iter', N), {'mipgap': v}) entries to "
-                "options['solver_options_layers'] directly.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+            if self.cylinder_rank == 0:
+                # One print per cylinder; without the gate every rank
+                # would emit its own first-occurrence copy.
+                warnings.warn(
+                    "Gapper's static mipgapdict is deprecated. The "
+                    "schedule is being translated to "
+                    "solver_options_layers automatically; remove the "
+                    "Gapper extension and instead pass --mipgaps-json "
+                    "on the CLI, or append solver_options_layer("
+                    "('starting_at_iter', N), {'mipgap': v}) entries to "
+                    "options['solver_options_layers'] directly.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
             # Insert just before the reserved dynamic_gapper layer
             # so it remains last (and so wins over these for any
             # adaptive writes).

--- a/mpisppy/phbase.py
+++ b/mpisppy/phbase.py
@@ -296,7 +296,12 @@ class PHBase(mpisppy.spopt.SPOpt):
             # matches what the legacy dicts described.
             _iter0_dict = options.get("iter0_solver_options") or {}
             _iterk_dict = options.get("iterk_solver_options") or {}
-            if _iter0_dict or _iterk_dict:
+            if (_iter0_dict or _iterk_dict) and self.cylinder_rank == 0:
+                # One print per cylinder (hub and each spoke), not one
+                # per MPI rank. global_rank == 0 would only catch the
+                # hub; a spoke with deprecated input would silently
+                # skip the warning. cylinder_rank == 0 ensures every
+                # cylinder that uses the deprecated API surfaces it.
                 warnings.warn(
                     "Constructing PHBase with options['iter0_solver_options'] "
                     "and/or options['iterk_solver_options'] is deprecated. "
@@ -362,13 +367,14 @@ class PHBase(mpisppy.spopt.SPOpt):
         ``_effective_solver_options(0)`` for the iter-0 fold, which is
         the same value but doesn't go through the deprecation path.
         """
-        warnings.warn(
-            "PHBase.iter0_solver_options is deprecated; call "
-            "_effective_solver_options(0) instead. Both return the "
-            "same fold of solver_options_layers.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
+        if self.cylinder_rank == 0:
+            warnings.warn(
+                "PHBase.iter0_solver_options is deprecated; call "
+                "_effective_solver_options(0) instead. Both return the "
+                "same fold of solver_options_layers.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         return sputils.fold_solver_options_layers(
             self.solver_options_layers, 0)
 
@@ -381,13 +387,14 @@ class PHBase(mpisppy.spopt.SPOpt):
         fold (which can differ from k=1 when starting_at_iter layers
         are present).
         """
-        warnings.warn(
-            "PHBase.iterk_solver_options is deprecated; call "
-            "_effective_solver_options(k) for the exact fold at "
-            "iteration k. The property returns the fold at k=1 only.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
+        if self.cylinder_rank == 0:
+            warnings.warn(
+                "PHBase.iterk_solver_options is deprecated; call "
+                "_effective_solver_options(k) for the exact fold at "
+                "iteration k. The property returns the fold at k=1 only.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         return sputils.fold_solver_options_layers(
             self.solver_options_layers, 1)
 

--- a/mpisppy/phbase.py
+++ b/mpisppy/phbase.py
@@ -9,6 +9,7 @@
 import time
 import logging
 import math
+import warnings
 
 import numpy as np
 import mpisppy.MPI as MPI
@@ -295,6 +296,17 @@ class PHBase(mpisppy.spopt.SPOpt):
             # matches what the legacy dicts described.
             _iter0_dict = options.get("iter0_solver_options") or {}
             _iterk_dict = options.get("iterk_solver_options") or {}
+            if _iter0_dict or _iterk_dict:
+                warnings.warn(
+                    "Constructing PHBase with options['iter0_solver_options'] "
+                    "and/or options['iterk_solver_options'] is deprecated. "
+                    "Build options['solver_options_layers'] instead "
+                    "(typically via mpisppy.utils.cfg_vanilla.shared_options "
+                    "or sputils.solver_options_layer). The legacy dicts are "
+                    "still honored for now.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
             if _iter0_dict:
                 self.solver_options_layers.append(
                     sputils.solver_options_layer("iter0", _iter0_dict))
@@ -346,10 +358,17 @@ class PHBase(mpisppy.spopt.SPOpt):
     def iter0_solver_options(self):
         """Read-only fold of solver_options_layers for iteration 0.
 
-        Derived from solver_options_layers (the source of truth);
-        retained for back-compat with callers that read this attr
-        directly. Solve sites should use _effective_solver_options(k).
+        Deprecated; reads emit a DeprecationWarning. Use
+        ``_effective_solver_options(0)`` for the iter-0 fold, which is
+        the same value but doesn't go through the deprecation path.
         """
+        warnings.warn(
+            "PHBase.iter0_solver_options is deprecated; call "
+            "_effective_solver_options(0) instead. Both return the "
+            "same fold of solver_options_layers.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return sputils.fold_solver_options_layers(
             self.solver_options_layers, 0)
 
@@ -357,10 +376,18 @@ class PHBase(mpisppy.spopt.SPOpt):
     def iterk_solver_options(self):
         """Read-only fold of solver_options_layers for iteration k>=1.
 
-        Returns the fold at k=1; later iterations may differ when
-        starting_at_iter layers are present (callers wanting an exact
-        per-iteration view should call _effective_solver_options(k)).
+        Deprecated; reads emit a DeprecationWarning. Use
+        ``_effective_solver_options(k)`` for an exact per-iteration
+        fold (which can differ from k=1 when starting_at_iter layers
+        are present).
         """
+        warnings.warn(
+            "PHBase.iterk_solver_options is deprecated; call "
+            "_effective_solver_options(k) for the exact fold at "
+            "iteration k. The property returns the fold at k=1 only.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return sputils.fold_solver_options_layers(
             self.solver_options_layers, 1)
 

--- a/mpisppy/tests/test_solver_options_layers.py
+++ b/mpisppy/tests/test_solver_options_layers.py
@@ -1067,5 +1067,123 @@ class TestLagrangerDeprecation(unittest.TestCase):
         )
 
 
+class TestProgrammaticAPIDeprecation(unittest.TestCase):
+    """Programmatic-API deprecation warnings landing in this phase:
+
+    1. options['iter0_solver_options'] / options['iterk_solver_options']
+       supplied (non-empty) at PHBase construction → warn.
+    2. PHBase.iter0_solver_options attribute read → warn.
+    3. PHBase.iterk_solver_options attribute read → warn.
+
+    Each warning is a DeprecationWarning that names the migration path.
+    """
+
+    def _options_with_legacy_dicts(self):
+        # Minimum options PHBase needs that AREN'T solver_options_layers,
+        # so the legacy-dict shim path fires.
+        return {
+            "solver_name": "gurobi_persistent",  # name only; never solved
+            "PHIterLimit": 1,
+            "defaultPHrho": 1.0,
+            "convthresh": 1e-8,
+            "verbose": False, "display_timing": False, "display_progress": False,
+            "smoothed": 0, "asynchronousPH": False,
+            "subsolvedirectives": None, "toc": False,
+            "iter0_solver_options": {"mipgap": 0.01},
+            "iterk_solver_options": {"mipgap": 0.001},
+        }
+
+    def _build_ph(self, options):
+        # Catch warnings during construction so the test class isn't
+        # itself the first thing to trigger them.
+        import mpisppy.opt.ph
+        import mpisppy.tests.examples.farmer as farmer
+        return mpisppy.opt.ph.PH(
+            options,
+            ["Scenario1", "Scenario2", "Scenario3"],
+            farmer.scenario_creator,
+            farmer.scenario_denouement,
+            scenario_creator_kwargs={"crops_multiplier": 1},
+        )
+
+    def test_legacy_dict_input_emits_deprecation_warning(self):
+        import warnings
+        opts = self._options_with_legacy_dicts()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            self._build_ph(opts)
+        self.assertTrue(
+            any(issubclass(w.category, DeprecationWarning)
+                and "iter0_solver_options" in str(w.message)
+                and "solver_options_layers" in str(w.message)
+                for w in caught),
+            "Expected DeprecationWarning naming the legacy dict input "
+            "and pointing at solver_options_layers; "
+            f"got {[(w.category.__name__, str(w.message)) for w in caught]}",
+        )
+
+    def test_empty_legacy_dicts_do_not_warn(self):
+        # An empty {} or None for the legacy keys is what cfg-built
+        # options dicts use; the warning should not fire for them.
+        import warnings
+        opts = self._options_with_legacy_dicts()
+        opts["iter0_solver_options"] = {}
+        opts["iterk_solver_options"] = {}
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            self._build_ph(opts)
+        legacy_warnings = [
+            w for w in caught
+            if issubclass(w.category, DeprecationWarning)
+            and "iter0_solver_options" in str(w.message)
+            and "solver_options_layers" in str(w.message)
+        ]
+        self.assertEqual(legacy_warnings, [])
+
+    def test_iter0_solver_options_property_read_warns(self):
+        import warnings
+        # Build via solver_options_layers so construction itself
+        # doesn't fire the dict-input warning.
+        layers = [solver_options_layer("iter0", {"mipgap": 0.005})]
+        opts = self._options_with_legacy_dicts()
+        opts.pop("iter0_solver_options")
+        opts.pop("iterk_solver_options")
+        opts["solver_options_layers"] = layers
+        ph = self._build_ph(opts)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            _ = ph.iter0_solver_options
+        self.assertTrue(
+            any(issubclass(w.category, DeprecationWarning)
+                and "iter0_solver_options" in str(w.message)
+                and "_effective_solver_options" in str(w.message)
+                for w in caught),
+            "Expected DeprecationWarning on PHBase.iter0_solver_options "
+            "read; got "
+            f"{[(w.category.__name__, str(w.message)) for w in caught]}",
+        )
+
+    def test_iterk_solver_options_property_read_warns(self):
+        import warnings
+        layers = [solver_options_layer("iterk", {"mipgap": 0.005})]
+        opts = self._options_with_legacy_dicts()
+        opts.pop("iter0_solver_options")
+        opts.pop("iterk_solver_options")
+        opts["solver_options_layers"] = layers
+        ph = self._build_ph(opts)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            _ = ph.iterk_solver_options
+        self.assertTrue(
+            any(issubclass(w.category, DeprecationWarning)
+                and "iterk_solver_options" in str(w.message)
+                and "_effective_solver_options" in str(w.message)
+                for w in caught),
+            "Expected DeprecationWarning on PHBase.iterk_solver_options "
+            "read; got "
+            f"{[(w.category.__name__, str(w.message)) for w in caught]}",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/mpisppy/utils/cfg_vanilla.py
+++ b/mpisppy/utils/cfg_vanilla.py
@@ -15,6 +15,7 @@ import copy
 import json
 import warnings
 
+import mpisppy.MPI as MPI
 # Hub and spoke SPBase classes
 import mpisppy.utils.sputils as sputils
 
@@ -510,13 +511,16 @@ def add_gapper(hub_dict, cfg, name=None):
 
     if mipgaps_json is not None:
         flag = "--mipgaps-json" if name is None else f"--{name}-mipgaps-json"
-        warnings.warn(
-            f"{flag} is planned for deprecation in a future release. "
-            "Your schedule is still being applied to the per-iteration "
-            "solver options.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
+        if MPI.COMM_WORLD.Get_rank() == 0:
+            # Setup-time function called on every rank; gate so only
+            # one rank prints (avoids flooding HPC runs).
+            warnings.warn(
+                f"{flag} is planned for deprecation in a future release. "
+                "Your schedule is still being applied to the per-iteration "
+                "solver options.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         with open(mipgaps_json) as fin:
             din = json.load(fin)
         mipgapdict = {int(i): din[i] for i in din}
@@ -934,15 +938,18 @@ def lagranger_spoke(
     extension_kwargs=None,
     average_scenario_creator=None,
 ):
-    warnings.warn(
-        "The lagranger spoke is slated for removal in a future "
-        "release: it does not seem to perform as well as the other "
-        "outer-bound options (--lagrangian, --ph-dual, --subgradient, "
-        "--fwph). No removal timeline is committed yet; this warning "
-        "is the heads-up.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
+    if MPI.COMM_WORLD.Get_rank() == 0:
+        # Setup-time function called on every rank; gate so only
+        # one rank prints (avoids flooding HPC runs).
+        warnings.warn(
+            "The lagranger spoke is slated for removal in a future "
+            "release: it does not seem to perform as well as the other "
+            "outer-bound options (--lagrangian, --ph-dual, --subgradient, "
+            "--fwph). No removal timeline is committed yet; this warning "
+            "is the heads-up.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
     from mpisppy.cylinders.lagranger_bounder import LagrangerOuterBound
     lagranger_spoke = _PHBase_spoke_foundation(
         LagrangerOuterBound,


### PR DESCRIPTION
## Summary

Final phase of the solver-options redesign per design doc §6.3 /
§6.4 phase 8: two new DeprecationWarnings on the legacy
programmatic surfaces, plus rank-gating of every deprecation
warning emitted by this redesign (including three pre-existing
ones from earlier phases).

### Dict-input deprecation

\`PHBase.__init__\`'s legacy shim — which fires when the caller
supplies \`options['iter0_solver_options']\` /
\`options['iterk_solver_options']\` but no
\`options['solver_options_layers']\` — now emits a
\`DeprecationWarning\` naming the canonical migration path
(build \`options['solver_options_layers']\` via
\`mpisppy.utils.cfg_vanilla.shared_options\` or
\`sputils.solver_options_layer\`). The legacy dicts are still
folded into layers; the warning fires only when at least one
of them is non-empty.

### Property-read deprecation

\`PHBase.iter0_solver_options\` and \`iterk_solver_options\`
\`@property\` getters now emit a \`DeprecationWarning\` on every
read, pointing callers at \`_effective_solver_options(k)\` (which
returns the same fold without the deprecation path). Internal
mpi-sppy code does not read these attributes; only external
callers trigger the warning.

### \`current_solver_options\` deferred

\`current_solver_options\` is **not** deprecated in this phase.
Several spokes (fwph, aph, xhat_eval, cross_scen_extension,
lshaped_bounder) still read it as the back-compat
dynamic-overrides overlay; deprecating reads now would flood
every PH-with-cylinders run with warnings from internal code.
§6.3 marks it as a future deprecation target.

### Rank-gating

All five DeprecationWarnings in the redesign — two new in this
PR plus three pre-existing — are now gated so HPC runs see a
single emission instead of one per rank:

| Site | Gate | Why |
|---|---|---|
| \`PHBase.__init__\` legacy-dict input | \`self.cylinder_rank == 0\` | one per cylinder (hub + each spoke that triggers) |
| \`iter0_solver_options\` property | \`self.cylinder_rank == 0\` | same |
| \`iterk_solver_options\` property | \`self.cylinder_rank == 0\` | same |
| \`Gapper.__init__\` mipgapdict compat (phase 5) | \`self.cylinder_rank == 0\` | same |
| \`cfg_vanilla.add_gapper\` \`--mipgaps-json\` (phase 5) | \`MPI.COMM_WORLD.Get_rank() == 0\` | setup-time free function, no cylinder yet |
| \`cfg_vanilla.lagranger_spoke\` (phase 7) | \`MPI.COMM_WORLD.Get_rank() == 0\` | same |

\`global_rank == 0\` is **not** the right gate for cylinder-aware
code: only the hub sits on global_rank 0, so spokes that hit a
deprecated API would silently skip the warning.
\`cylinder_rank == 0\` prints exactly once per cylinder.

### Tests

\`TestProgrammaticAPIDeprecation\` in
\`test_solver_options_layers.py\` pins all four new assertions:

- non-empty legacy-dict input fires the warning;
- empty \`{}\` / \`None\` for the same keys does NOT fire;
- \`ph.iter0_solver_options\` attribute read fires;
- \`ph.iterk_solver_options\` attribute read fires.

Existing test files that pass legacy iter0/iterk_solver_options
dicts to PHBase will see the new warning (~30 hits across
test_ph_main, test_aph, test_jensens, test_ef_ph,
test_proper_bundler, ciutils, examples/hydro fixtures). Tests
still pass; the warnings are informational. Migrating those
test fixtures to cfg_vanilla is a follow-up beyond phase 8's
scope.

### Docs

§6.3 table updated to reflect the now-firing warnings for the
two deprecated surfaces, with \`current_solver_options\` called
out as not yet deprecated. §6.4 phase 8 marked **Shipped**.

## Test plan

- [x] Local: \`ruff check .\` clean.
- [x] Local: 74/74 pass across
      \`test_solver_options_layers\` and
      \`test_options_reach_solver\`.
- [x] Local: 229/229 pass across the wider sweep (with ~31
      expected deprecation warnings).
- [ ] CI: regression, ph-extensions, ph-main, gradient-rho,
      schur-complement, and the rest of the test matrix pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)