### PR TITLE
Solver options: migrate PHBase-based readers off current_solver_options

### DIFF
--- a/doc/designs/solver_options_redesign.md
+++ b/doc/designs/solver_options_redesign.md
@@ -841,7 +841,7 @@ Action items (all complete):
 |----------------------------------------------------------|-------------------------------------|----------------------------------------------------------------------------------|---------------|
 | `options["iter0_solver_options"]`, `options["iterk_solver_options"]` (input to PHBase) | **DeprecationWarning fires when non-empty; legacy dicts still folded into `solver_options_layers`** | unchanged target (`solver_options_layers`) | future, TBD   |
 | `PHBase.iter0_solver_options`, `iterk_solver_options` (attribute reads) | **DeprecationWarning fires on every read; both are property shims returning `fold_solver_options_layers(layers, 0|1)`** | use `_effective_solver_options(k)` | future, TBD |
-| `PHBase.current_solver_options` (attribute reads / writes) | active; still used internally as the back-compat dynamic-overrides overlay by several spokes (fwph, aph, xhat_eval, cross_scen, lshaped) | not deprecated in phase 8 — pending those spokes migrating to the layer system | future, TBD |
+| `PHBase.current_solver_options` (attribute reads / writes) | active; fwph, aph, cross_scen_extension now use `_effective_solver_options(k)`; xhat_eval and lshaped_bounder (both SPOpt-based, not PHBase-based) still read `current_solver_options` — pending `_effective_solver_options` being pushed up to SPOpt | future, TBD |
 | `option_string_to_dict`                                  | active                              | unchanged                                                                         | n/a           |
 | `option_dict_to_string`                                  | active                              | unchanged                                                                         | n/a           |
 

--- a/mpisppy/extensions/cross_scen_extension.py
+++ b/mpisppy/extensions/cross_scen_extension.py
@@ -93,7 +93,7 @@ class CrossScenarioExtension(Extension):
              and opt.options["tee-rank0-solves"]
         )
         opt.solve_loop(
-                solver_options=opt.current_solver_options,
+                solver_options=opt._effective_solver_options(opt._PHIter),
                 dtiming=opt.options["display_timing"],
                 gripe=True,
                 disable_pyomo_signal_handling=False,

--- a/mpisppy/opt/aph.py
+++ b/mpisppy/opt/aph.py
@@ -934,7 +934,7 @@ class APH(ph_base.PHBase):
                 self.dispatch_frac = 1   # to get a decent w for everyone
             logging.debug('pre APH_solve_loop on rank {}'.format(self.cylinder_rank))
             dlist = self.APH_solve_loop(solver_options = \
-                                        self.current_solver_options,
+                                        self._effective_solver_options(self._PHIter),
                                         dtiming=dtiming,
                                         gripe=True,
                                         disable_pyomo_signal_handling=True,

--- a/mpisppy/opt/fwph.py
+++ b/mpisppy/opt/fwph.py
@@ -145,7 +145,7 @@ class FWPH(mpisppy.phbase.PHBase):
             )
             # teeme = True
             self.fwph_solve_loop(
-                mip_solver_options=self.current_solver_options,
+                mip_solver_options=self._effective_solver_options(self._PHIter),
                 dtiming=self.options["display_timing"],
                 tee=teeme,
                 verbose=self.options["verbose"],
@@ -238,7 +238,7 @@ class FWPH(mpisppy.phbase.PHBase):
                 break
 
             self.fwph_solve_loop(
-                mip_solver_options=self.current_solver_options,
+                mip_solver_options=self._effective_solver_options(self._PHIter),
                 dtiming=dtiming,
                 tee=teeme,
                 verbose=verbose


### PR DESCRIPTION
## Summary

Replaces the remaining \`self.current_solver_options\` reads in
PHBase-based code with
\`self._effective_solver_options(self._PHIter)\` (or
\`opt._effective_solver_options(opt._PHIter)\` from extensions).
This pulls fwph, aph, and the cross-scenario extension onto the
layered representation alongside PH's own iter0/iterk solves.

## Latent bug this also fixes

\`current_solver_options\` defaults to \`{}\` after the phase-2
changes (it's now the back-compat dynamic-overrides overlay; only
Gapper auto-mode writes to it). So user-supplied
\`--solver-options "..."\`, \`--iter0-mipgap=X\`,
\`--iterk-mipgap=X\`, the full \`--solver-options-file\`, etc.
were being silently dropped on fwph, aph, and cross_scen solves.
With the migration, those solve paths now receive the full
per-iteration fold returned by \`_effective_solver_options\`.

The migration is mechanical: each line previously passed
\`current_solver_options\` (a plain dict) and now passes the fold
returned by \`_effective_solver_options\`. The fold's final layer
is still \`current_solver_options\` (the back-compat overlay
path), so any Gapper auto-mode mipgap written there still flows
through.

## Touched

- \`mpisppy/opt/fwph.py\` — 2 callsites in fwph_main.
- \`mpisppy/opt/aph.py\` — 1 callsite in APH_solve_loop call.
- \`mpisppy/extensions/cross_scen_extension.py\` — 1 callsite in
  the extension's solve.

## Not in scope

\`xhat_eval\` and \`lshaped_bounder\` are the other two
\`current_solver_options\` readers, but they are **SPOpt-based**
(not PHBase-based) so they don't have
\`_effective_solver_options\` available. Migrating them requires
pushing the method (and \`solver_options_layers\` /
\`_dynamic_solver_options_layer\` state) up from PHBase to SPOpt.
That's a separate follow-up; design doc §6.3 updated to reflect
the new split.

## Tests

No new dedicated tests in this PR:

- The migration is a pure replacement at four call sites
  (\`current_solver_options\` was already a dict;
  \`_effective_solver_options\` returns a dict).
- The existing \`test_aph.py\` exercises the APH iteration loop
  that contains the migrated line; full PH-with-cylinders
  example runs (\`examples/run_all.py\`) exercise fwph and
  cross_scen_extension.
- \`_effective_solver_options\` itself is heavily tested in
  \`test_solver_options_layers\` and \`test_options_reach_solver\`.

## Test plan

- [x] Local: \`ruff check .\` clean.
- [x] Local: 118/118 pass across
      \`test_solver_options_layers\`,
      \`test_options_reach_solver\`, \`test_ef_ph\`,
      \`test_ph_main\`, \`test_aph\`.
- [x] CI: regression, ph-extensions, ph-main, aph,
      gradient-rho, schur-complement, run_all parts 1 & 2, and
      the rest of the test matrix pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)