### PR TITLE
test: call set_instance() on persistent solvers in proper_bundler test

### DIFF
--- a/mpisppy/tests/test_proper_bundler.py
+++ b/mpisppy/tests/test_proper_bundler.py
@@ -313,6 +313,13 @@ class TestPHWithFixedFirstStageBundledAndUnbundled(unittest.TestCase):
             scenario_creator_kwargs={},
         )
         ef_solver = pyo.SolverFactory(solver_name)
+        if "_persistent" in solver_name:
+            # Persistent solvers require the model be attached
+            # before solve(); without this the call raises
+            # "Please use set_instance to set the instance before
+            # calling solve". See test_ef_ph.py:158-159 for the
+            # canonical pattern.
+            ef_solver.set_instance(ef)
         ef_solver.solve(ef)
         ef_obj = pyo.value(ef.EF_Obj)
         self.assertTrue(_math_isfinite(ef_obj))


### PR DESCRIPTION
## Summary

\`TestPHWithFixedFirstStageBundledAndUnbundled.test_bundled_matches_unbundled_with_fixed_first_stage\`
built its EF reference solver via
\`pyo.SolverFactory(solver_name)\` and called \`.solve(ef)\`
directly. When \`solver_name\` resolved to a persistent variant
(e.g. \`gurobi_persistent\` or \`cplex_persistent\`), this raised
\`Please use set_instance to set the instance before calling
solve\` because persistent solvers require the model to be
attached separately.

\`get_solver()\` in \`mpisppy/tests/utils.py\` prefers persistent
variants first, so the failure surfaces whenever a persistent
backend is the first available solver — which has been the case
locally (\`gurobi_persistent\` via the pip install). It was
also masking signal in the wider sweep during the solver-options
redesign work; every PR run had this test marked failed.

## Fix

Mirrors the canonical pattern from \`test_ef_ph.py:158-159\`:

\`\`\`python
ef_solver = pyo.SolverFactory(solver_name)
if "_persistent" in solver_name:
    ef_solver.set_instance(ef)
ef_solver.solve(ef)
\`\`\`

Single test file, 7 lines added.

## Test plan

- [x] Local: \`mpisppy/tests/test_proper_bundler.py\` 7/7 pass
      (was 6/7).
- [x] \`ruff check .\` clean.
- [ ] CI: confirms the previously-failing test goes green
      across all solver-job permutations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)