### PR TITLE
sslp example: make scenario_names_creator start a 0-based offset (#705)

### DIFF
--- a/examples/sslp/sslp.py
+++ b/examples/sslp/sslp.py
@@ -64,12 +64,16 @@ def scenario_denouement(rank, scenario_name, scenario):
 ########## helper functions ########
 
 #=========
-def scenario_names_creator(num_scens,start=None):
-    # one-based scenarios
-    # if start!=None, the list starts with the 'start' labeled scenario
-    if (start is None) :
-        start=1
-    return [f"Scenario{i}" for i in range(start, start+num_scens)]
+def scenario_names_creator(num_scens, start=None):
+    # one-based scenario labels (Scenario1, Scenario2, ...) -- the on-disk
+    # data dir is 1-indexed (Scenario1.dat ... ScenarioN.dat).
+    # `start` follows the mpi-sppy convention used by farmer/aircond/uc:
+    # 0-based offset = count of already-used scenarios. proper_bundler
+    # calls this with start=firstnum-inum (== 0 for the first bundle),
+    # so the offset must be 0-based even though the *labels* are 1-based.
+    if start is None:
+        start = 0
+    return [f"Scenario{i+1}" for i in range(start, start+num_scens)]
 
 
 #=========


### PR DESCRIPTION
## Summary

- Fixes #705. `proper_bundler` invokes `scenario_names_creator(N, start=firstnum-inum)` — `start` is meant to be the count of already-used scenarios (0 for the first bundle), matching the convention used by farmer/aircond/uc.
- sslp was instead treating `start` as the literal first scenario number (defaulting to 1), so `--scenarios-per-bundle 20` asked for `Scenario0.dat`, which does not exist (sslp data files are 1-indexed).
- This PR rewrites `scenario_names_creator` so the emitted labels stay 1-indexed (matching the on-disk `Scenario{1..K}.dat`) while `start` becomes a 0-based offset. Non-bundling callers (`scenario_names_creator(N)` with no `start`) are unaffected.

## Test plan

- [x] Reproducer from #705 (1000-scenario sslp with `--scenarios-per-bundle 20 --lagrangian --xhatshuffle`) now runs to wall-time cap instead of dying with `Cannot find file 'Scenario0.dat'`.
- [x] `scenario_names_creator(1)` still returns `[Scenario1]`, so `proper_bundler`'s `inum=1` inference is unchanged.
- [x] No other callers in the repo pass a literal `start=` to sslp's `scenario_names_creator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)