### PR TITLE
xhatspecific_spoke: wire scenario_dict and all_nodenames (#586)

### DIFF
--- a/examples/aircond/aircond_cylinders.py
+++ b/examples/aircond/aircond_cylinders.py
@@ -315,7 +315,7 @@ def main():
             sd["opt_kwargs"]["options"]["iterk_solver_options"].update(soptions)
 
         if with_xhatspecific:
-            xhatspecific_spoke["opt_kwargs"]["options"]["xhat_looper_options"]["xhat_solver_options"].update(soptions)
+            xhatspecific_spoke["opt_kwargs"]["options"]["xhat_specific_options"]["xhat_solver_options"].update(soptions)
         if with_xhatshuffle:
             xhatshuffle_spoke["opt_kwargs"]["options"]["xhat_looper_options"]["xhat_solver_options"].update(soptions)
     # special code to get a trace for xhatshuffle

--- a/mpisppy/utils/cfg_vanilla.py
+++ b/mpisppy/utils/cfg_vanilla.py
@@ -1237,10 +1237,16 @@ def xhatspecific_spoke(
         scenario_creator,
         scenario_denouement,
         all_scenario_names,
+        all_nodenames=all_nodenames,
         scenario_creator_kwargs=scenario_creator_kwargs,
         ph_extensions=ph_extensions,
         extension_kwargs=extension_kwargs,
     )
+    xhatspecific_dict["opt_kwargs"]["options"]["xhat_specific_options"] = {
+        "xhat_solver_options": xhatspecific_dict["opt_kwargs"]["options"]["iterk_solver_options"],
+        "xhat_scenario_dict": scenario_dict,
+        "csvname": "specific.csv",
+    }
     _maybe_attach_jensens(xhatspecific_dict, cfg, "xhatspecific",
                           average_scenario_creator, scenario_creator_kwargs)
     return xhatspecific_dict


### PR DESCRIPTION
## Summary

- Fixes #586. `xhatspecific_spoke` in `mpisppy/utils/cfg_vanilla.py` declared `scenario_dict` and `all_nodenames` parameters but discarded both before building the spoke dict, so callers got runtime errors (the `XhatSpecificInnerBound` bounder reads `opt.options['xhat_specific_options']['xhat_scenario_dict']` at startup, and nothing was setting it).
- Forwards `all_nodenames` to `_Xhat_Eval_spoke_foundation` (matching `xhatshuffle_spoke`).
- Populates `opt_kwargs.options.xhat_specific_options` with `xhat_scenario_dict` (from the argument) and `xhat_solver_options` (reusing `iterk_solver_options`, matching `xhatlooper_spoke`'s pattern).
- Also fixes the only known caller, `examples/aircond/aircond_cylinders.py`: when `--solver-options` was passed alongside `--xhatspecific`, the override loop reached into `xhat_looper_options` (which xhatspecific does not have) instead of `xhat_specific_options`. Post-factory-fix that line would still `KeyError`; renamed to the correct key.

## Test plan

- [x] `ruff check .` clean on changed files
- [x] `python -c "from mpisppy.utils import cfg_vanilla"` imports cleanly
- [ ] CI on this PR (no existing direct test for `xhatspecific_spoke`; aircond example exercises it indirectly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)