### PR TITLE
display_timing: expose via Config and CLI (#290)

### DIFF
--- a/doc/src/hubs.rst
+++ b/doc/src/hubs.rst
@@ -109,7 +109,9 @@ in the farmer example. The ``farmer_cylinders.py`` file has::
    from mpisppy.convergers.norm_rho_converger import NormRhoConverger
 
 and optionally passes ``NormRhoConverger`` to the hub constructor. Note that you can observe
-the behavior of the hub converger using the option ``--with-display-convergence-detail``.
+the behavior of the hub converger using the option ``--with-display-convergence-detail``,
+and can request subproblem-solve timing diagnostics (requires one subproblem per
+rank) with ``--display-timing``.
 
 Unfortunately, the word "converger" is also used to describe spokes that return bounds
 for the purpose of measuring overall convergence (as opposed to convergence within the hub

--- a/doc/src/secretmenu.rst
+++ b/doc/src/secretmenu.rst
@@ -5,33 +5,6 @@ There are many options that are not exposed in ``mpisppy.utils.config.py`` and w
 a few of them here.
 
 
-display_timing
---------------
-
-This is a PH option that adds a barrier step to collect information about
-the time required to solve subproblems. This can be helpful in diagnosis
-and tuning of algorithms because for some problems, the variability in
-time to solve scenario sub-problems can be quite large.
-
-.. Note::
-   This option should be used only when there is exactly one subproblem per rank.
-
-To set the option, use
-
-.. code-block:: python
-                
-   PHoptions["display_timing"] = True
-
-E.g., if you were adding this to ``examples.farmer.farmer_cylinders`` where the
-hub definition dictionary is called ``hub_dict`` you would add
-
-.. code-block:: python
-
-   hub_dict["opt_kwargs"]["PHoptions"]["display_timing"] = True
-
-before passing it to ``spin_the_wheel``.
-
-
 initial_proximal_cut_count
 --------------------------
 

--- a/examples/run_all.py
+++ b/examples/run_all.py
@@ -388,7 +388,7 @@ if not nouc:
            "--num-scens=3 --max-iterations=5 "
            "--iter0-mipgap=0.01 --iterk-mipgap=0.005 "
            "--default-rho=1 --lagrangian --xhatshuffle --fwph "
-           "--solver-name={} --display-progress".format(solver_name))
+           "--solver-name={} --display-progress --display-timing".format(solver_name))
 
     if egret_avail():
         print("\nSlow runs ahead...\n")

--- a/mpisppy/tests/test_ef_ph.py
+++ b/mpisppy/tests/test_ef_ph.py
@@ -15,6 +15,9 @@ version matter a lot, so we often just do smoke tests.
 
 import os
 import glob
+import io
+import contextlib
+import re
 import json
 import shutil
 import unittest
@@ -192,8 +195,75 @@ class Test_sizes(unittest.TestCase):
             scenario_denouement,
             scenario_creator_kwargs={"scenario_count": 3},
         )
-    
+
         conv, obj, tbound = ph.ph_main()
+
+    @unittest.skipIf(not solver_available,
+                     "no solver is available")
+    def test_display_timing_emits_nonzero_solve_times(self):
+        # End-to-end check that display_timing actually reaches the PH
+        # solve loop and produces a non-zero solve-time report. Guards
+        # the user-facing CLI flag (issue #290): if a future refactor
+        # quietly drops the option from self.options or the print path,
+        # this test fails.
+        options = self._copy_of_base_options()
+        options["PHIterLimit"] = 0
+        options["display_timing"] = True
+
+        ph = mpisppy.opt.ph.PH(
+            options,
+            self.all3_scenario_names,
+            scenario_creator,
+            scenario_denouement,
+            scenario_creator_kwargs={"scenario_count": 3},
+        )
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            ph.ph_main()
+        out = buf.getvalue()
+
+        self.assertIn("Pyomo solve times (seconds):", out,
+                      msg=f"display_timing=True but timing header not in output:\n{out}")
+        m = re.search(
+            r"min=([0-9.]+)@\d+ mean=([0-9.]+) max=([0-9.]+)@\d+",
+            out,
+        )
+        self.assertIsNotNone(
+            m,
+            msg=f"display_timing stats line not found in output:\n{out}",
+        )
+        mn, me, mx = float(m.group(1)), float(m.group(2)), float(m.group(3))
+        # max across scenarios must be strictly positive — any real
+        # subproblem solve takes measurable wallclock time. min/mean
+        # could round to 0.00 under %4.2f if subproblems are tiny.
+        self.assertGreater(
+            mx, 0.0,
+            msg=f"max solve time reported as zero: min={mn} mean={me} max={mx}",
+        )
+
+    @unittest.skipIf(not solver_available,
+                     "no solver is available")
+    def test_display_timing_off_suppresses_solve_times(self):
+        # Companion: confirm the timing report is NOT printed when the
+        # flag is False, so we know the assertion above isn't picking up
+        # output emitted unconditionally somewhere.
+        options = self._copy_of_base_options()
+        options["PHIterLimit"] = 0
+        options["display_timing"] = False
+
+        ph = mpisppy.opt.ph.PH(
+            options,
+            self.all3_scenario_names,
+            scenario_creator,
+            scenario_denouement,
+            scenario_creator_kwargs={"scenario_count": 3},
+        )
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            ph.ph_main()
+        self.assertNotIn("Pyomo solve times (seconds):", buf.getvalue())
 
     @unittest.skipIf(not solver_available,
                      "no solver is available")

--- a/mpisppy/utils/cfg_vanilla.py
+++ b/mpisppy/utils/cfg_vanilla.py
@@ -62,6 +62,7 @@ def shared_options(cfg, is_hub=False):
         "verbose": cfg.verbose,
         "display_progress": cfg.display_progress,
         "display_convergence_detail": cfg.display_convergence_detail,
+        "display_timing": cfg.display_timing,
         "iter0_solver_options": dict(),
         "iterk_solver_options": dict(),
         # Layered representation of solver options. Built in parallel
@@ -1017,6 +1018,7 @@ def subgradient_spoke(
     options["PHIterLimit"] = cfg.max_iterations * 1_000_000
     options["display_progress"] = False
     options["display_convergence_detail"] = False
+    options["display_timing"] = False
 
     add_ph_tracking(subgradient_spoke, cfg, spoke=True)
     _maybe_attach_jensens(subgradient_spoke, cfg, "subgradient",
@@ -1059,6 +1061,7 @@ def ph_dual_spoke(
     options["PHIterLimit"] = cfg.max_iterations * 1_000_000
     options["display_progress"] = False
     options["display_convergence_detail"] = False
+    options["display_timing"] = False
 
     add_ph_tracking(ph_dual_spoke, cfg, spoke=True)
 
@@ -1099,6 +1102,7 @@ def relaxed_ph_spoke(
     options["PHIterLimit"] = cfg.max_iterations * 1_000_000
     options["display_progress"] = False
     options["display_convergence_detail"] = False
+    options["display_timing"] = False
 
     add_ph_tracking(relaxed_ph_spoke, cfg, spoke=True)
 

--- a/mpisppy/utils/config.py
+++ b/mpisppy/utils/config.py
@@ -279,6 +279,11 @@ class Config(pyofig.ConfigDict):
                               domain=bool,
                               default=False)
 
+        self.add_to_config('display_timing',
+                              description="display subproblem solve timing (requires exactly one subproblem per rank)",
+                              domain=bool,
+                              default=False)
+
         self.add_to_config("max_solver_threads",
                             description="Limit on threads per solver (default None)",
                             domain=int,


### PR DESCRIPTION
## Summary

- Fixes #290. `display_timing` was a "secret menu" option that callers had to set on the options dict by hand. Move it into `mpisppy.utils.config.Config` next to `display_progress` and `display_convergence_detail` so it shows up under `--help` and propagates through `cfg_vanilla` the same way.
- `shared_options()` now forwards `cfg.display_timing` into the hub's `opt_kwargs.options`.
- `subgradient_spoke`, `ph_dual_spoke`, `relaxed_ph_spoke` hardcode `options["display_timing"] = False`, matching the existing pattern for the other two display flags (spokes should not print per-iteration diagnostics).
- `doc/src/secretmenu.rst`: drop the `display_timing` section now that it's a first-class CLI option. The other two secret-menu entries (`initial_proximal_cut_count`, `subgradient_while_waiting`) remain.
- `doc/src/hubs.rst`: mention the new `--display-timing` flag next to the existing `--with-display-convergence-detail` note so the option stays discoverable from the docs.
- `phbase.py:887-888` keeps its defensive default so `PHBase` can still be instantiated outside the cfg flow.

## Test plan

- [x] `ruff check` clean on changed files
- [x] `Config().popular_args(); cfg.display_timing` works and defaults to `False`
- [x] New unit tests in `mpisppy/tests/test_ef_ph.py::Test_sizes`:
  - `test_display_timing_emits_nonzero_solve_times` runs PH iter0 with `display_timing=True`, captures stdout, asserts the `"Pyomo solve times (seconds):"` header appears, parses the `min/mean/max` stats line, and requires `max > 0`. Guards against a future refactor quietly dropping the option from `self.options` or the print path.
  - `test_display_timing_off_suppresses_solve_times` confirms the timing report is **not** printed when the flag is `False`, so the assertion above isn't catching unconditionally-emitted output.
- [x] CLI smoke test: `examples/run_all.py` now appends `--display-timing` to the existing `sizes/sizes_cylinders.py` run, so the `run_all.py` CI jobs exercise the new flag end-to-end through `generic_cylinders.py`-style invocation.
- [x] Generic cylinders integration: confirmed `mpisppy/generic/parsing.py:120` calls `cfg.popular_args()`, so `--display-timing` automatically appears on `python -m mpisppy.generic_cylinders --module-name ... --help` with no additional wiring.
- [ ] CI run on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)