### PR TITLE
remove dead options["subsolvedirectives"] = None lines (#227)

### DIFF
--- a/examples/hydro/hydro.py
+++ b/examples/hydro/hydro.py
@@ -283,7 +283,6 @@ if __name__ == "__main__":
     options["PHIterLimit"] = 200
     options["defaultPHrho"] = 1
     options["convthresh"] = 0.0001
-    options["subsolvedirectives"] = None
     options["verbose"] = False
     options["display_timing"] = True
     options["display_progress"] = True

--- a/examples/sizes/sizes_demo.py
+++ b/examples/sizes/sizes_demo.py
@@ -37,7 +37,6 @@ if __name__ == "__main__":
     options["PHIterLimit"] = 100
     options["defaultPHrho"] = 1
     options["convthresh"] = 0.001
-    options["subsolvedirectives"] = None
     options["verbose"] = False
     options["display_timing"] = True
     options["display_progress"] = True

--- a/examples/sslp/sslp.py
+++ b/examples/sslp/sslp.py
@@ -205,7 +205,6 @@ if __name__ == "__main__":
     options["PHIterLimit"] = maxit
     options["defaultPHrho"] = rho
     options["convthresh"] = -1
-    options["subsolvedirectives"] = None
     options["verbose"] = False
     options["display_timing"] = False
     options["display_progress"] = True

--- a/mpisppy/tests/examples/hydro/hydro.py
+++ b/mpisppy/tests/examples/hydro/hydro.py
@@ -249,7 +249,6 @@ if __name__ == "__main__":
     options["PHIterLimit"] = 200
     options["defaultPHrho"] = 1
     options["convthresh"] = 0.0001
-    options["subsolvedirectives"] = None
     options["verbose"] = False
     options["display_timing"] = True
     options["display_progress"] = True

--- a/mpisppy/tests/test_agnostic.py
+++ b/mpisppy/tests/test_agnostic.py
@@ -65,7 +65,6 @@ def _get_ph_base_options():
     Baseoptions["PHIterLimit"] = 3
     Baseoptions["defaultPHrho"] = 1
     Baseoptions["convthresh"] = 0.001
-    Baseoptions["subsolvedirectives"] = None
     Baseoptions["verbose"] = False
     Baseoptions["display_timing"] = False
     Baseoptions["display_progress"] = False

--- a/mpisppy/tests/test_aph.py
+++ b/mpisppy/tests/test_aph.py
@@ -42,7 +42,6 @@ class Test_aph_sizes(unittest.TestCase):
         self.Baseoptions["PHIterLimit"] = 10
         self.Baseoptions["defaultPHrho"] = 1
         self.Baseoptions["convthresh"] = 0.001
-        self.Baseoptions["subsolvedirectives"] = None
         self.Baseoptions["verbose"] = False
         self.Baseoptions["display_timing"] = False
         self.Baseoptions["display_progress"] = False
@@ -172,7 +171,6 @@ class Test_aph_farmer(unittest.TestCase):
         self.Baseoptions["PHIterLimit"] = 10
         self.Baseoptions["defaultPHrho"] = 1
         self.Baseoptions["convthresh"] = 0.001
-        self.Baseoptions["subsolvedirectives"] = None
         self.Baseoptions["verbose"] = False
         self.Baseoptions["display_timing"] = False
         self.Baseoptions["display_progress"] = False

--- a/mpisppy/tests/test_ef_ph.py
+++ b/mpisppy/tests/test_ef_ph.py
@@ -44,7 +44,6 @@ def _get_ph_base_options():
     Baseoptions["PHIterLimit"] = 10
     Baseoptions["defaultPHrho"] = 1
     Baseoptions["convthresh"] = 0.001
-    Baseoptions["subsolvedirectives"] = None
     Baseoptions["verbose"] = False
     Baseoptions["display_timing"] = False
     Baseoptions["display_progress"] = False

--- a/mpisppy/tests/test_options_reach_solver.py
+++ b/mpisppy/tests/test_options_reach_solver.py
@@ -116,7 +116,6 @@ class TestOptionsReachSolver(unittest.TestCase):
         shoptions["display_progress"] = False
         shoptions["smoothed"] = 0
         shoptions["asynchronousPH"] = False
-        shoptions["subsolvedirectives"] = None
         shoptions["toc"] = False
         if extra:
             shoptions.update(extra)

--- a/mpisppy/tests/test_ph_extensions.py
+++ b/mpisppy/tests/test_ph_extensions.py
@@ -43,7 +43,6 @@ class TestMultRhoUpdater(unittest.TestCase):
             "iterk_solver_options": {"mipgap": 0.02},
             "smoothed": 0,
             "asynchronousPH": False,
-            "subsolvedirectives": None,
             "toc": False,
         }
         self.scenario_names = [f"Scenario{i+1}" for i in range(3)]
@@ -113,7 +112,6 @@ class TestWtrackerExtension(unittest.TestCase):
             "iterk_solver_options": None,
             "smoothed": 0,
             "asynchronousPH": False,
-            "subsolvedirectives": None,
             "toc": False,
         }
         self.scenario_names = [f"Scenario{i+1}" for i in range(3)]

--- a/mpisppy/tests/test_ph_main.py
+++ b/mpisppy/tests/test_ph_main.py
@@ -48,7 +48,6 @@ class TestPHMainFarmer(unittest.TestCase):
             "iterk_solver_options": None,
             "smoothed": 0,
             "asynchronousPH": False,
-            "subsolvedirectives": None,
             "toc": False,
         }
         self.scenario_names = [f"Scenario{i+1}" for i in range(3)]
@@ -229,7 +228,6 @@ class TestPHMainSizes(unittest.TestCase):
             "iterk_solver_options": {"mipgap": 0.02},
             "smoothed": 0,
             "asynchronousPH": False,
-            "subsolvedirectives": None,
             "toc": False,
         }
         self.scenario_names = [f"Scenario{i+1}" for i in range(3)]

--- a/mpisppy/tests/test_solver_options_layers.py
+++ b/mpisppy/tests/test_solver_options_layers.py
@@ -1088,7 +1088,7 @@ class TestProgrammaticAPIDeprecation(unittest.TestCase):
             "convthresh": 1e-8,
             "verbose": False, "display_timing": False, "display_progress": False,
             "smoothed": 0, "asynchronousPH": False,
-            "subsolvedirectives": None, "toc": False,
+            "toc": False,
             "iter0_solver_options": {"mipgap": 0.01},
             "iterk_solver_options": {"mipgap": 0.001},
         }

--- a/mpisppy/utils/w_utils/wtracker.py
+++ b/mpisppy/utils/w_utils/wtracker.py
@@ -218,7 +218,6 @@ if __name__ == "__main__":
     options["PHIterLimit"] = 10
     options["defaultPHrho"] = 1
     options["convthresh"] = 0.001
-    options["subsolvedirectives"] = None
     options["verbose"] = False
     options["display_timing"] = False
     options["display_progress"] = False


### PR DESCRIPTION
## Summary

- Fixes #227. \`subsolvedirectives\` was never read anywhere in the codebase — \`grep\` finds zero consumers in \`mpisppy/spbase.py\`, \`mpisppy/spopt.py\`, \`mpisppy/phbase.py\`, or anywhere else. Every reference was a no-op \`options[\"subsolvedirectives\"] = None\` copied from old templates.
- Drops the occurrences across **active** tests and live examples (12 files).
- Files in \`examples/<model>/archive/\` subdirs (e.g. \`examples/farmer/archive/cs_farmer.py\`, \`examples/sizes/archive/sizes_ph.py\`) and the loose-bundles-banner \`acopf3\` scripts (which were annotated as obsolete in commit \`fc9e88a6\`) are intentionally left alone — they're frozen artifacts; modifying them just adds noise.

## Note on the other half of #227

The first half of the issue (asking for a hierarchy of solver options with a service function to manage fallbacks like \`EF_solvername\` → \`solvername\`) has been substantially overtaken by the solver-options layers redesign that landed via PRs #695..#703 — see \`_effective_solver_options\` and the \`shared_options\` / \`apply_solver_specs\` flow in \`cfg_vanilla.py\`. This PR cleans up the second half (dead key in examples).

## Test plan

- [x] \`ruff check .\` clean
- [x] All 12 modified files parse cleanly (\`ast.parse\`)
- [x] No remaining \`subsolvedirectives\` references in the changed scope
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)