### PR TITLE
fix: treat empty-string solver_options_file as unset

### DIFF
--- a/mpisppy/tests/test_solver_options_layers.py
+++ b/mpisppy/tests/test_solver_options_layers.py
@@ -910,6 +910,15 @@ class TestSolverOptionsFileWiredIntoSharedOptions(unittest.TestCase):
         finally:
             os.unlink(path)
 
+    def test_empty_string_solver_options_file_is_treated_as_unset(self):
+        # Callers that default solver_options_file to "" (e.g. as a
+        # YAML/JSON sentinel for "no file") should not trigger a file
+        # load. Regression for FileNotFoundError on open("").
+        cfg = _bare_cfg()
+        cfg.solver_options_file = ""
+        sh = shared_options(cfg)
+        self.assertEqual(sh["solver_options_layers"], [])
+
 
 class TestSolverOptionsFilePerSpoke(unittest.TestCase):
     """Per-spoke layers from (a) the global file's "spokes" sub-block
@@ -1030,10 +1039,20 @@ class TestSolverOptionsFilePerSpoke(unittest.TestCase):
                 opts["solver_options_layers"], 0)
             self.assertEqual(folded["mipgap"], 0.001)  # inline wins
             self.assertEqual(folded["presolve"], 1)    # file survives
-
-
         finally:
             os.unlink(path)
+
+    def test_empty_string_spoke_solver_options_file_is_treated_as_unset(self):
+        # Mirrors the top-level empty-string regression: a caller that
+        # sets --{name}-solver-options-file to "" should not trigger
+        # a file load.
+        cfg = _spoke_cfg("lagrangian")
+        cfg.lagrangian_solver_options_file = ""
+        sh = shared_options(cfg)
+        spoke = self._spoke_dict_from(sh)
+        apply_solver_specs("lagrangian", spoke, cfg)  # must not raise
+        self.assertEqual(
+            spoke["opt_kwargs"]["options"]["solver_options_layers"], [])
 
 
 class TestLagrangerDeprecation(unittest.TestCase):

--- a/mpisppy/utils/cfg_vanilla.py
+++ b/mpisppy/utils/cfg_vanilla.py
@@ -91,7 +91,7 @@ def shared_options(cfg, is_hub=False):
     # axis 2: any CLI flags below override file entries at the same
     # predicate. Load and apply it first so the rest of the axis-2
     # chain can overlay on top.
-    if _hasit(cfg, "solver_options_file"):
+    if cfg.get("solver_options_file"):  # treats None and "" as unset
         file_data = sputils.load_solver_options_file(cfg.solver_options_file)
         shoptions["iter0_solver_options"].update(file_data["default"])
         shoptions["iter0_solver_options"].update(file_data["iter0"])
@@ -175,7 +175,7 @@ def apply_solver_specs(name, spoke, cfg):
         options["iterk_solver_options"].update(spoke_file_blocks["iterk"])
         options["solver_options_layers"].extend(
             sputils.options_file_section_to_layers(spoke_file_blocks))
-    if _hasit(cfg, name+"_solver_options_file"):
+    if cfg.get(name+"_solver_options_file"):  # treats None and "" as unset
         spoke_file_data = sputils.load_solver_options_file(
             cfg.get(name+"_solver_options_file"))
         # Per-spoke files only consume their own predicates; the


### PR DESCRIPTION
## Summary
- `shared_options()` and `apply_solver_specs()` gated the `load_solver_options_file()` call on `_hasit(cfg, ...)`, which returns `True` for any non-None value — including `\"\"`.
- Callers that default `solver_options_file` (or any `{name}_solver_options_file`) to `\"\"` as a \"no file\" sentinel were hitting `FileNotFoundError: [Errno 2] No such file or directory: ''`.
- Replace `_hasit` with a plain truthiness check on the path. Both `None` and `\"\"` are now treated as unset, matching conventional file-path-arg semantics. No other `_hasit` semantics changed.

## Test plan
- [x] Two regression tests added in `test_solver_options_layers.py` (one for the global flag, one for the per-spoke `{name}_solver_options_file`); both pass.
- [x] `python -m pytest mpisppy/tests/test_solver_options_layers.py` — 64/64 pass.
- [x] `ruff check` clean on touched files.
- [x] Manual: a `Config` with `cfg.solver_options_file = \"\"` no longer raises `FileNotFoundError` from `shared_options`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)