### PR TITLE
docs(xhatshufflelooper): fix stale new_nonants divergence comment

### DIFF
--- a/mpisppy/cylinders/xhatshufflelooper_bounder.py
+++ b/mpisppy/cylinders/xhatshufflelooper_bounder.py
@@ -115,8 +115,12 @@ class XhatShuffleInnerBound(_JensensMixin, XhatInnerBoundBase):
                 continue
 
             if new_nonants:
-                # similar to above, not all ranks will agree on
-                # when there are new nonants (in the same loop)
+                # All cylinder_comm ranks agree on new_nonants because
+                # update_nonants -> get_receive_buffer(synchronize=True)
+                # gates on a cross-rank write_id Allreduce, so the
+                # collectives inside this branch (Eobjective Allreduce,
+                # comms["ROOT"].bcast in _try_one, the inner
+                # got_kill_signal) are entered in lockstep.
                 logger.debug(f'   *Xhatshuffle loop iter={xh_iter}')
                 logger.debug(f'   *got a new one! on rank {self.global_rank}')
                 logger.debug(f'   *localnonants={str(self.localnonants)}')


### PR DESCRIPTION
## Summary
- Comment in `XhatShuffleInnerBound.main`'s `if new_nonants:` branch dated from 2020 and claimed ranks would not agree on `new_nonants` within the same loop iteration.
- That predates the write_id coherence machinery in `get_receive_buffer(..., synchronize=True)` (`spcommunicator.py:474-499`): every rank either accepts the new value together (cross-rank write_id Allreduce passes AND `new_id > last_id`) or rejects it together. The branch is taken in lockstep.
- The body contains collectives (`Eobjective` Allreduce, `comms[\"ROOT\"].bcast` in `_try_one`, an inner `got_kill_signal`). The stale comment suggested they were entered divergently, which would deadlock — but they're actually entered in lockstep.
- Replace the comment with one that explains the real invariant.

## Test plan
- [x] `ruff check` clean on the touched file.
- [x] Comment-only change; no test changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)