### PR TITLE
fix(decomp): gate default_rho check on PH-based cylinders

### DIFF
--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -1007,6 +1007,18 @@ jobs:
           cd mpisppy/tests
           mpiexec -np 2 coverage run $COV_ARGS -m mpi4py test_cg_with_cylinders.py
 
+      - name: run DCG serial tests
+        timeout-minutes: 10
+        run: |
+          cd mpisppy/tests
+          coverage run $COV_ARGS test_dualcg_main.py
+
+      - name: run DCG cylinder tests
+        timeout-minutes: 10
+        run: |
+          cd mpisppy/tests
+          mpiexec -np 2 coverage run $COV_ARGS -m mpi4py test_dualcg_with_cylinders.py
+
       - name: Upload coverage data
         if: always()
         uses: actions/upload-artifact@v4

--- a/mpisppy/generic/decomp.py
+++ b/mpisppy/generic/decomp.py
@@ -86,9 +86,21 @@ def _get_rho_setter(module, cfg):
     if cfg.default_rho is None and rho_setter is None:
         if cfg.sep_rho or cfg.coeff_rho or cfg.sensi_rho:
             cfg.default_rho = 1
-        else:
-            print("Warning: No rho_setter so a default must be specified via --default-rho")
+        elif _needs_rho(cfg):
+            raise RuntimeError("No rho_setter so a default must be specified via --default-rho")
     return rho_setter
+
+
+def _needs_rho(cfg):
+    """True if the chosen hub or any enabled spoke needs a rho value.
+
+    CG-based hubs (cg_hub, dualcg_hub) do not need rho on their own; the
+    requirement only kicks in when a PH-based spoke (currently ph_xfeas_spoke)
+    is attached.
+    """
+    if cfg.cg_hub or cfg.dualcg_hub:
+        return bool(cfg.ph_xfeas_spoke)
+    return True
 
 
 def _get_converger(cfg):

--- a/mpisppy/tests/test_generic_cylinders.py
+++ b/mpisppy/tests/test_generic_cylinders.py
@@ -15,8 +15,10 @@ import sys
 import runpy
 import tempfile
 import unittest
+from types import SimpleNamespace
 from unittest.mock import patch
 
+from mpisppy.generic.decomp import _get_rho_setter
 from mpisppy.tests.utils import get_solver
 
 solver_available, solver_name, _, _ = get_solver()
@@ -86,6 +88,60 @@ class TestGenericCylindersWtracker(unittest.TestCase):
             # Sanity: farmer has 3 nonants; with 3 scens we have 9 traces,
             # reportlen=5 caps rows at 5
             self.assertLessEqual(len(rows) - 1, 5)
+
+
+def _make_rho_cfg(**overrides):
+    base = dict(
+        default_rho=None,
+        sep_rho=False,
+        coeff_rho=False,
+        sensi_rho=False,
+        cg_hub=False,
+        dualcg_hub=False,
+        ph_xfeas_spoke=False,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+class _NoRhoSetterModule:
+    pass
+
+
+class TestGetRhoSetter(unittest.TestCase):
+    """The default_rho-required check should fire only for PH-based cylinders."""
+
+    def test_ph_hub_no_rho_raises(self):
+        cfg = _make_rho_cfg()
+        with self.assertRaises(RuntimeError):
+            _get_rho_setter(_NoRhoSetterModule(), cfg)
+
+    def test_cg_hub_alone_does_not_require_rho(self):
+        cfg = _make_rho_cfg(cg_hub=True)
+        self.assertIsNone(_get_rho_setter(_NoRhoSetterModule(), cfg))
+        self.assertIsNone(cfg.default_rho)
+
+    def test_dualcg_hub_alone_does_not_require_rho(self):
+        cfg = _make_rho_cfg(dualcg_hub=True)
+        self.assertIsNone(_get_rho_setter(_NoRhoSetterModule(), cfg))
+
+    def test_cg_hub_with_ph_spoke_requires_rho(self):
+        cfg = _make_rho_cfg(cg_hub=True, ph_xfeas_spoke=True)
+        with self.assertRaises(RuntimeError):
+            _get_rho_setter(_NoRhoSetterModule(), cfg)
+
+    def test_module_rho_setter_satisfies_check(self):
+        class M:
+            @staticmethod
+            def _rho_setter():
+                pass
+        cfg = _make_rho_cfg()
+        self.assertIsNotNone(_get_rho_setter(M(), cfg))
+
+    def test_sep_rho_sets_default(self):
+        cfg = _make_rho_cfg(sep_rho=True)
+        _get_rho_setter(_NoRhoSetterModule(), cfg)
+        self.assertEqual(cfg.default_rho, 1)
 
 
 if __name__ == "__main__":

--- a/run_coverage.bash
+++ b/run_coverage.bash
@@ -141,6 +141,12 @@ run_phase "test_cg_main (serial)" \
 run_phase "test_cg_with_cylinders (mpiexec -np 2)" \
     mpiexec -np 2 coverage run --rcfile="$PROJ_DIR/.coveragerc" -m mpi4py mpisppy/tests/test_cg_with_cylinders.py
 
+run_phase "test_dualcg_main (serial)" \
+    coverage run --rcfile=.coveragerc mpisppy/tests/test_dualcg_main.py
+
+run_phase "test_dualcg_with_cylinders (mpiexec -np 2)" \
+    mpiexec -np 2 coverage run --rcfile="$PROJ_DIR/.coveragerc" -m mpi4py mpisppy/tests/test_dualcg_with_cylinders.py
+
 # ---------- Tests that spawn mpiexec internally ----------
 
 PYARGS="-m coverage run --parallel-mode --rcfile=$PROJ_DIR/.coveragerc --data-file=$PROJ_DIR/.coverage"


### PR DESCRIPTION
## Summary
- **Rho check** — restore the fail-fast `RuntimeError` for PH-based hubs/spokes when no rho-setter and no `--default-rho` are supplied. CG (`cg_hub`) and DCG (`dualcg_hub`) hubs with no PH spoke skip the check, since column generation does not consume rho.
- **DCG coverage wiring** — `test_dualcg_main.py` and `test_dualcg_with_cylinders.py` were added in PR #618 but never registered in `run_coverage.bash` or `.github/workflows/test_pr_and_main.yml`, so codecov never saw their contribution to `dualcg.py` patch coverage. Adds the missing entries to both surfaces.

## Why
PR #618 softened the rho check from `RuntimeError` to a `print` warning because the unconditional fail-fast blocked valid CG/DCG configurations. The fix is to gate the check on whether a PH-based cylinder is actually in use, restoring the diagnostic for PH users without re-breaking CG. The coverage wiring is a separate cleanup observed while reviewing the merged PR.

Closes #719.

## Test plan
- [x] `ruff check mpisppy/generic/decomp.py mpisppy/tests/test_generic_cylinders.py`
- [x] `python -m pytest mpisppy/tests/test_generic_cylinders.py::TestGetRhoSetter -v` (6 new tests pass)
- [x] `python -m pytest mpisppy/tests/test_generic_cylinders.py mpisppy/tests/test_cg_main.py mpisppy/tests/test_dualcg_main.py` (19 tests pass)
- [x] `bash -n run_coverage.bash` and YAML syntax check pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)