### PR TITLE
Rename Field.NONANT -> XBAR (and RELAXED_NONANT -> RELAXED_XBAR)

### DIFF
--- a/mpisppy/cylinders/cross_scen_spoke.py
+++ b/mpisppy/cylinders/cross_scen_spoke.py
@@ -19,7 +19,7 @@ import pyomo.environ as pyo
 class CrossScenarioCutSpoke(Spoke):
 
     send_fields = (*Spoke.send_fields, Field.CROSS_SCENARIO_CUT)
-    receive_fields = (*Spoke.receive_fields, Field.NONANT, Field.CROSS_SCENARIO_COST)
+    receive_fields = (*Spoke.receive_fields, Field.XBAR, Field.CROSS_SCENARIO_COST)
 
     def register_send_fields(self) -> None:
 
@@ -49,7 +49,7 @@ class CrossScenarioCutSpoke(Spoke):
     def register_receive_fields(self):
         super().register_receive_fields()
 
-        nonant_ranks = self.opt.spcomm.fields_to_ranks[Field.NONANT]
+        nonant_ranks = self.opt.spcomm.fields_to_ranks[Field.XBAR]
         cs_cost_ranks = self.opt.spcomm.fields_to_ranks[Field.CROSS_SCENARIO_COST]
 
         assert len(nonant_ranks) == 1
@@ -57,7 +57,7 @@ class CrossScenarioCutSpoke(Spoke):
         assert nonant_ranks[0] == cs_cost_ranks[0]
         source_rank = nonant_ranks[0]
 
-        self.all_nonants = self.register_recv_field(Field.NONANT, source_rank)
+        self.all_nonants = self.register_recv_field(Field.XBAR, source_rank)
         self.all_etas = self.register_recv_field(Field.CROSS_SCENARIO_COST, source_rank)
 
     def prep_cs_cuts(self):

--- a/mpisppy/cylinders/hub.py
+++ b/mpisppy/cylinders/hub.py
@@ -212,12 +212,12 @@ class PHPrimalHub(Hub):
     spokes like Lagrangian to a specific dual (W) buffer.
     """
 
-    send_fields = (*Hub.send_fields, Field.NONANT, )
+    send_fields = (*Hub.send_fields, Field.XBAR, )
     receive_fields = (*Hub.receive_fields,)
 
     @property
     def nonant_field(self):
-        return Field.NONANT
+        return Field.XBAR
 
     def setup_hub(self):
         ## Generate some warnings if nothing is giving bounds
@@ -341,7 +341,7 @@ class PHHub(PHPrimalHub):
 
 class LShapedHub(Hub):
 
-    send_fields = (*Hub.send_fields, Field.NONANT,)
+    send_fields = (*Hub.send_fields, Field.XBAR,)
     receive_fields = (*Hub.receive_fields,)
 
     def setup_hub(self):
@@ -391,7 +391,7 @@ class LShapedHub(Hub):
         """ Gather nonants and send them to the appropriate spokes
         """
         ci = 0  ## index to self.nonant_send_buffer
-        nonant_send_buffer = self.send_buffers[Field.NONANT]
+        nonant_send_buffer = self.send_buffers[Field.XBAR]
         for k, s in self.opt.local_scenarios.items():
             nonant_to_root_var_map = s._mpisppy_model.subproblem_to_root_vars_map
             for xvar in s._mpisppy_data.nonant_indices.values():
@@ -400,7 +400,7 @@ class LShapedHub(Hub):
                 ci += 1
         logging.debug("hub is sending X nonants={}".format(nonant_send_buffer))
 
-        self.put_send_buffer(nonant_send_buffer, Field.NONANT)
+        self.put_send_buffer(nonant_send_buffer, Field.XBAR)
 
         return
     
@@ -408,7 +408,7 @@ class LShapedHub(Hub):
 
 class CGHub(Hub):
 
-    send_fields = (*Hub.send_fields, Field.NONANT,)
+    send_fields = (*Hub.send_fields, Field.XBAR,)
     receive_fields = (*Hub.receive_fields,Field.RECENT_XHATS, Field.XFEAS )
 
     def register_receive_fields(self):
@@ -485,7 +485,7 @@ class CGHub(Hub):
      
     @property
     def nonant_field(self):
-        return Field.NONANT 
+        return Field.XBAR 
     
 
 class DCGHub(CGHub):

--- a/mpisppy/cylinders/relaxed_ph_spoke.py
+++ b/mpisppy/cylinders/relaxed_ph_spoke.py
@@ -14,12 +14,12 @@ import pyomo.environ as pyo
 
 class RelaxedPHSpoke(_PHDualSpokeBase):
 
-    send_fields = (*_PHDualSpokeBase.send_fields, Field.RELAXED_NONANT, )
+    send_fields = (*_PHDualSpokeBase.send_fields, Field.RELAXED_XBAR, )
     receive_fields = (*_PHDualSpokeBase.receive_fields, )
 
     @property
     def nonant_field(self):
-        return Field.RELAXED_NONANT
+        return Field.RELAXED_XBAR
 
     def main(self):
         # relax the integers

--- a/mpisppy/cylinders/spoke.py
+++ b/mpisppy/cylinders/spoke.py
@@ -357,7 +357,7 @@ class _BoundNonantSpoke(_BoundNonantLenSpoke):
     """
 
     def nonant_len_type(self) -> Field:
-        return Field.NONANT
+        return Field.XBAR
 
     @property
     def localnonants(self):
@@ -383,7 +383,7 @@ class InnerBoundNonantSpoke(_BoundNonantSpoke, InnerBoundSpoke):
     """
 
     send_fields = (*InnerBoundSpoke.send_fields, )
-    receive_fields = (*InnerBoundSpoke.receive_fields, Field.NONANT)
+    receive_fields = (*InnerBoundSpoke.receive_fields, Field.XBAR)
 
     converger_spoke_char = 'I'
 
@@ -396,7 +396,7 @@ class OuterBoundNonantSpoke(_BoundNonantSpoke):
     """
 
     send_fields = (*_BoundNonantSpoke.send_fields, Field.OBJECTIVE_OUTER_BOUND, )
-    receive_fields = (*_BoundNonantSpoke.receive_fields, Field.NONANT)
+    receive_fields = (*_BoundNonantSpoke.receive_fields, Field.XBAR)
 
     converger_spoke_char = 'A'  # probably Lagrangian
 

--- a/mpisppy/cylinders/spwindow.py
+++ b/mpisppy/cylinders/spwindow.py
@@ -21,9 +21,9 @@ import pyomo.environ as pyo
 
 class Field(enum.IntEnum):
     SHUTDOWN=-1000
-    NONANT=1
+    XBAR=1
     DUALS=2
-    RELAXED_NONANT=3
+    RELAXED_XBAR=3
     BEST_OBJECTIVE_BOUNDS=100 # Both inner and outer bounds from the hub. Layout: [OUTER INNER ID]
     OBJECTIVE_INNER_BOUND=101
     OBJECTIVE_OUTER_BOUND=102
@@ -50,9 +50,9 @@ field_length_components.total_number_recent_xhats = pyo.Param(mutable=True, init
 
 _field_lengths = {
         Field.SHUTDOWN : 1,
-        Field.NONANT : field_length_components._local_nonant_length,
+        Field.XBAR : field_length_components._local_nonant_length,
         Field.DUALS : field_length_components._local_nonant_length,
-        Field.RELAXED_NONANT : field_length_components._local_nonant_length,
+        Field.RELAXED_XBAR : field_length_components._local_nonant_length,
         Field.BEST_OBJECTIVE_BOUNDS : 2,
         Field.OBJECTIVE_INNER_BOUND : 1,
         Field.OBJECTIVE_OUTER_BOUND : 1,

--- a/mpisppy/debug_utils/buffer_inspect.py
+++ b/mpisppy/debug_utils/buffer_inspect.py
@@ -241,7 +241,7 @@ def _check_shutdown(buf, report: Report, ctx: InspectContext) -> None:
 
 
 def _check_nonant(buf, report: Report, ctx: InspectContext) -> None:
-    # NONANT buffers are sized to the *publisher's* sum of per-scenario
+    # XBAR buffers are sized to the *publisher's* sum of per-scenario
     # nonant counts across that publisher's local scenarios:
     #     len(data) == nonant_count * len(publisher.local_scenarios).
     # When the publisher holds many scenarios (e.g. all 24 leaves of a
@@ -255,7 +255,7 @@ def _check_nonant(buf, report: Report, ctx: InspectContext) -> None:
     n = ctx.get_nonant_count()
     if n is not None and n > 0 and (len(data) == 0 or len(data) % n != 0):
         report.add(
-            f"NONANT data length {len(data)} is not a positive multiple "
+            f"XBAR data length {len(data)} is not a positive multiple "
             f"of nonant_count {n}",
             severity="error",
         )
@@ -269,7 +269,7 @@ def _check_nonant(buf, report: Report, ctx: InspectContext) -> None:
         bad = np.where(data < lo)[0]
         if bad.size:
             report.add(
-                f"NONANT below lower bound at {bad.size} index(es); "
+                f"XBAR below lower bound at {bad.size} index(es); "
                 f"first: idx {int(bad[0])} value {float(data[bad[0]])!r} "
                 f"< lo {float(lo[bad[0]])!r}"
             )
@@ -277,7 +277,7 @@ def _check_nonant(buf, report: Report, ctx: InspectContext) -> None:
         bad = np.where(data > hi)[0]
         if bad.size:
             report.add(
-                f"NONANT above upper bound at {bad.size} index(es); "
+                f"XBAR above upper bound at {bad.size} index(es); "
                 f"first: idx {int(bad[0])} value {float(data[bad[0]])!r} "
                 f"> hi {float(hi[bad[0]])!r}"
             )
@@ -375,7 +375,7 @@ def _check_best_xhat(buf, report: Report, ctx: InspectContext) -> None:
 
 CHECKERS: dict[Field, Callable[[Any, Report, InspectContext], None]] = {
     Field.SHUTDOWN: _check_shutdown,
-    Field.NONANT: _check_nonant,
+    Field.XBAR: _check_nonant,
     Field.NONANT_LOWER_BOUNDS: _check_lower_bounds,
     Field.NONANT_UPPER_BOUNDS: _check_upper_bounds,
     Field.OBJECTIVE_INNER_BOUND: _check_objective_scalar,

--- a/mpisppy/extensions/cross_scen_extension.py
+++ b/mpisppy/extensions/cross_scen_extension.py
@@ -150,7 +150,7 @@ class CrossScenarioExtension(Extension):
                 ## End for
             ## End for
 
-            self.opt.spcomm.put_send_buffer(all_nonants, Field.NONANT)
+            self.opt.spcomm.put_send_buffer(all_nonants, Field.XBAR)
 
         ## End if
 
@@ -229,11 +229,11 @@ class CrossScenarioExtension(Extension):
         spcomm = self.opt.spcomm
         nscen = len(self.opt.all_scenario_names)
         local_scen_count = len(self.opt.local_scenario_names)
-        if spcomm.is_send_field_registered(Field.NONANT):
+        if spcomm.is_send_field_registered(Field.XBAR):
             self.send_nonants = False
         else:
             self.all_nonants = spcomm.register_send_field(
-                Field.NONANT,
+                Field.XBAR,
                 local_scen_count * self.opt.nonant_length
             )
             self.send_nonants = True

--- a/mpisppy/extensions/relaxed_ph_fixer.py
+++ b/mpisppy/extensions/relaxed_ph_fixer.py
@@ -39,20 +39,20 @@ class RelaxedPHFixer(Extension):
     def iter0_post_solver_creation(self):
         # wait for relaxed iter0:
         if self.relaxed_nonant_buf.id() == 0:
-            while not self.opt.spcomm.get_receive_buffer(self.relaxed_nonant_buf, Field.RELAXED_NONANT, self.relaxed_ph_spoke_index):
+            while not self.opt.spcomm.get_receive_buffer(self.relaxed_nonant_buf, Field.RELAXED_XBAR, self.relaxed_ph_spoke_index):
                 continue
         self.relaxed_ph_fixing(self.relaxed_nonant_buf.value_array(), pre_iter0=True)
 
     def register_receive_fields(self):
         spcomm = self.opt.spcomm
-        relaxed_ph_ranks = spcomm.fields_to_ranks[Field.RELAXED_NONANT]
+        relaxed_ph_ranks = spcomm.fields_to_ranks[Field.RELAXED_XBAR]
         assert len(relaxed_ph_ranks) == 1
         index = relaxed_ph_ranks[0]
 
         self.relaxed_ph_spoke_index = index
 
         self.relaxed_nonant_buf = spcomm.register_recv_field(
-            Field.RELAXED_NONANT,
+            Field.RELAXED_XBAR,
             self.relaxed_ph_spoke_index,
         )
 
@@ -61,7 +61,7 @@ class RelaxedPHFixer(Extension):
     def miditer(self):
         self.opt.spcomm.get_receive_buffer(
             self.relaxed_nonant_buf,
-            Field.RELAXED_NONANT,
+            Field.RELAXED_XBAR,
             self.relaxed_ph_spoke_index,
         )
         self.relaxed_ph_fixing(self.relaxed_nonant_buf.value_array(), pre_iter0=False)

--- a/mpisppy/tests/test_buffer_inspect.py
+++ b/mpisppy/tests/test_buffer_inspect.py
@@ -41,41 +41,41 @@ class TestGenericChecks(unittest.TestCase):
 
     def test_fresh_send_buffer_passes(self):
         buf = SendArray(5)
-        rep = inspect_buffer(buf, Field.NONANT,
+        rep = inspect_buffer(buf, Field.XBAR,
                              ctx=InspectContext(nonant_count=5), send=True)
         self.assertTrue(rep.ok, msg=str(rep))
 
     def test_fresh_recv_buffer_passes(self):
         buf = RecvArray(5)
-        rep = inspect_buffer(buf, Field.NONANT,
+        rep = inspect_buffer(buf, Field.XBAR,
                              ctx=InspectContext(nonant_count=5), send=False)
         self.assertTrue(rep.ok, msg=str(rep))
 
     def test_padding_overrun_detected(self):
         buf = RecvArray(2)
         buf._full_array[5] = 42.0   # write into padding region
-        rep = inspect_buffer(buf, Field.NONANT, send=False)
+        rep = inspect_buffer(buf, Field.XBAR, send=False)
         self.assertFalse(rep.ok)
         self.assertTrue(any("padding region modified" in f for f in rep.findings))
 
     def test_write_id_must_be_integer_valued(self):
         buf = RecvArray(1)
         buf._array[-1] = 3.5
-        rep = inspect_buffer(buf, Field.NONANT, send=False)
+        rep = inspect_buffer(buf, Field.XBAR, send=False)
         self.assertFalse(rep.ok)
         self.assertTrue(any("not integer-valued" in f for f in rep.findings))
 
     def test_write_id_must_be_finite(self):
         buf = RecvArray(1)
         buf._array[-1] = np.inf
-        rep = inspect_buffer(buf, Field.NONANT, send=False)
+        rep = inspect_buffer(buf, Field.XBAR, send=False)
         self.assertFalse(rep.ok)
         self.assertTrue(any("non-finite" in f for f in rep.findings))
 
     def test_write_id_must_be_non_negative(self):
         buf = RecvArray(1)
         buf._array[-1] = -2.0
-        rep = inspect_buffer(buf, Field.NONANT, send=False)
+        rep = inspect_buffer(buf, Field.XBAR, send=False)
         self.assertFalse(rep.ok)
         self.assertTrue(any("negative" in f for f in rep.findings))
 
@@ -84,7 +84,7 @@ class TestGenericChecks(unittest.TestCase):
         _publish(buf, [1.0, 2.0, 3.0])
         # Tamper with the trailing slot post-publish
         buf._array[-1] = 99.0
-        rep = inspect_buffer(buf, Field.NONANT, send=True)
+        rep = inspect_buffer(buf, Field.XBAR, send=True)
         self.assertFalse(rep.ok)
         self.assertTrue(any("!= buf.id()" in f for f in rep.findings))
 
@@ -117,7 +117,7 @@ class TestGenericChecks(unittest.TestCase):
     def test_nan_in_data_after_publish_is_finding(self):
         buf = SendArray(3)
         buf._next_write_id()    # publish without setting values: data stays NaN
-        rep = inspect_buffer(buf, Field.NONANT,
+        rep = inspect_buffer(buf, Field.XBAR,
                              ctx=InspectContext(nonant_count=3), send=True)
         self.assertFalse(rep.ok)
         self.assertTrue(any("contains NaN" in f for f in rep.findings))
@@ -128,7 +128,7 @@ class TestGenericChecks(unittest.TestCase):
         buf[1] = np.inf
         buf[2] = 3.0
         buf._next_write_id()
-        rep = inspect_buffer(buf, Field.NONANT,
+        rep = inspect_buffer(buf, Field.XBAR,
                              ctx=InspectContext(nonant_count=3), send=True)
         self.assertFalse(rep.ok)
         self.assertTrue(any("contains inf" in f for f in rep.findings))
@@ -185,7 +185,7 @@ class TestNonantChecks(unittest.TestCase):
     def test_length_mismatch_via_explicit_count(self):
         buf = SendArray(5)
         _publish(buf, [0.0] * 5)
-        rep = inspect_buffer(buf, Field.NONANT,
+        rep = inspect_buffer(buf, Field.XBAR,
                              ctx=InspectContext(nonant_count=7), send=True)
         self.assertFalse(rep.ok)
         self.assertTrue(any("data length 5" in f for f in rep.findings))
@@ -194,7 +194,7 @@ class TestNonantChecks(unittest.TestCase):
         buf = SendArray(5)
         _publish(buf, [0.0] * 5)
         ctx = InspectContext(spbase=_FakeSP(nonant_length=7))
-        rep = inspect_buffer(buf, Field.NONANT, ctx=ctx, send=True)
+        rep = inspect_buffer(buf, Field.XBAR, ctx=ctx, send=True)
         self.assertFalse(rep.ok)
         self.assertTrue(any("data length 5" in f for f in rep.findings))
 
@@ -202,22 +202,22 @@ class TestNonantChecks(unittest.TestCase):
         buf = SendArray(5)
         _publish(buf, [0.0] * 5)
         ctx = InspectContext(nonant_count=5, spbase=_FakeSP(nonant_length=7))
-        rep = inspect_buffer(buf, Field.NONANT, ctx=ctx, send=True)
+        rep = inspect_buffer(buf, Field.XBAR, ctx=ctx, send=True)
         self.assertTrue(rep.ok, msg=str(rep))
 
     def test_multi_scenario_buffer_passes(self):
-        # Publisher with K scenarios publishes a NONANT buffer of length
+        # Publisher with K scenarios publishes a XBAR buffer of length
         # nonant_count * K. The checker must accept any positive multiple.
         buf = SendArray(24)  # e.g., 4 scenarios * 6 nonants
         _publish(buf, [0.0] * 24)
-        rep = inspect_buffer(buf, Field.NONANT,
+        rep = inspect_buffer(buf, Field.XBAR,
                              ctx=InspectContext(nonant_count=6), send=True)
         self.assertTrue(rep.ok, msg=str(rep))
 
     def test_non_multiple_length_caught(self):
         buf = SendArray(10)  # 10 is not a multiple of 6
         _publish(buf, [0.0] * 10)
-        rep = inspect_buffer(buf, Field.NONANT,
+        rep = inspect_buffer(buf, Field.XBAR,
                              ctx=InspectContext(nonant_count=6), send=True)
         self.assertFalse(rep.ok)
         self.assertTrue(any("not a positive multiple" in f for f in rep.findings))
@@ -227,7 +227,7 @@ class TestNonantChecks(unittest.TestCase):
         _publish(buf, [0.5, 7.0, 2.0, -1.0])
         lo = np.array([0.0, 0.0, 0.0, 0.0])
         hi = np.array([5.0, 5.0, 5.0, 5.0])
-        rep = inspect_buffer(buf, Field.NONANT,
+        rep = inspect_buffer(buf, Field.XBAR,
                              ctx=InspectContext(nonant_count=4,
                                                 nonant_lower=lo,
                                                 nonant_upper=hi),
@@ -241,7 +241,7 @@ class TestNonantChecks(unittest.TestCase):
         buf = SendArray(3)
         lo = np.array([0.0, 0.0, 0.0])
         hi = np.array([1.0, 1.0, 1.0])
-        rep = inspect_buffer(buf, Field.NONANT,
+        rep = inspect_buffer(buf, Field.XBAR,
                              ctx=InspectContext(nonant_count=3,
                                                 nonant_lower=lo,
                                                 nonant_upper=hi),
@@ -468,7 +468,7 @@ class TestSpokeGotKillSignalWarning(unittest.TestCase):
         self.assertTrue(fired)
 
     def test_sweep_inspects_every_buffer(self):
-        # SHUTDOWN legit + healthy NONANT recv + healthy NONANT send: no warnings.
+        # SHUTDOWN legit + healthy XBAR recv + healthy XBAR send: no warnings.
         # Then add a stomped OBJECTIVE_INNER_BOUND recv: exactly one warning,
         # naming that field.
         good_shutdown = RecvArray(1)
@@ -490,10 +490,10 @@ class TestSpokeGotKillSignalWarning(unittest.TestCase):
         bad_inner._full_array[3] = 7.0  # write into padding region
 
         extra_recv = {
-            (Field.NONANT, 1): good_nonant_recv,
+            (Field.XBAR, 1): good_nonant_recv,
             (Field.OBJECTIVE_INNER_BOUND, 1): bad_inner,
         }
-        send = {Field.NONANT: good_nonant_send}
+        send = {Field.XBAR: good_nonant_send}
         stub = _make_spoke_stub(
             good_shutdown,
             inspect_on=True,
@@ -543,11 +543,11 @@ class TestSpokeGotKillSignalWarning(unittest.TestCase):
             good_shutdown,
             inspect_on=True,
             extra_recv={
-                (Field.NONANT, 1): good_nonant_recv,
+                (Field.XBAR, 1): good_nonant_recv,
                 (Field.OBJECTIVE_INNER_BOUND, 1): good_inner_recv,
             },
             send={
-                Field.NONANT: good_nonant_send,
+                Field.XBAR: good_nonant_send,
                 Field.OBJECTIVE_OUTER_BOUND: good_outer_send,
             },
             nonant_length=3,


### PR DESCRIPTION
## What

Renames two `Field` enum members in `mpisppy/cylinders/spwindow.py`:

- `Field.NONANT` -> `Field.XBAR`
- `Field.RELAXED_NONANT` -> `Field.RELAXED_XBAR`

...and updates all references across the cylinders, extensions, debug
utils, and tests.

## Why

The hub-published field carries **xbar** (the per-non-leaf-node
consensus value). The old name described the *variable layout* (values
shaped like `nonant_indices`), not the *content* — `xbar` is what is
actually in the buffer. Naming the content is clearer and is groundwork
for the field-canonicalization work behind flexible rank assignments.

## Scope / safety

- **Pure no-op.** Symmetric token rename (53 insertions / 53 deletions),
  no layout or behavior change.
- `NONANT_LOWER_BOUNDS` / `NONANT_UPPER_BOUNDS` are **unrelated fields**
  and are left untouched.
- Lowercase `nonant` / `nonant_indices` identifiers genuinely describe
  the variable shape and are deliberately **not** renamed.
- Field-name references in `buffer_inspect` diagnostics follow the
  rename; the lowercase shape term `nonant_count` is kept.

## Verification

- Touched modules import cleanly
- `ruff check` clean on all touched files
- `mpisppy/tests/test_buffer_inspect.py`: 42/42 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)