### PR TITLE
Rename Field.XBAR -> NONANTS_VALS, and rewrite the flexible-rank design doc

### DIFF
--- a/doc/designs/flexible_rank_assignments.md
+++ b/doc/designs/flexible_rank_assignments.md
@@ -486,17 +486,27 @@ source rank.
 - **Global-sized bounds and scalars** (Categories 3 and 4).  Monotone,
   idempotent application; staleness is safe.
 
-#### One field needs a decision: `cross_scen`
-
-`CrossScenarioCutSpoke` reads `NONANTS_VALS` and `CROSS_SCENARIO_COST`
-to build cross-scenario (Benders-like) cuts.  A cut assembled from
-mixed-iteration nonants/costs could in principle be invalid (cut off
-feasible points).  **Open item:** determine whether cross-scenario
-cut construction requires per-iteration coherence across the assembled
-scenarios.  If so, `NONANTS_VALS`/`CROSS_SCENARIO_COST` get strict
-coherence *for this consumer*; if the cut math tolerates per-scenario
-staleness, they stay relaxed.  This should be settled before Phase 3
-wires up `cross_scen` under asymmetric ranks.
+- **`CROSS_SCENARIO_COST`** (and `NONANTS_VALS` *as read by*
+  `CrossScenarioCutSpoke`).  These build cross-scenario (Benders /
+  L-shaped) cuts, and the relevant property is that **a Benders cut
+  built at any first-stage point `x̂` is a valid global underestimator
+  of the recourse value `Q(x)` for all `x`** — `x̂` only sets where the
+  cut is tight, never whether it is valid.  In the code, cut validity
+  comes entirely from `CrossScenarioCutSpoke.make_cut()` *re-solving
+  the real subproblems* inside `opt.root.bender.generate_cut()` (the
+  generator was handed `create_subproblem` callbacks); the received
+  `NONANTS_VALS` / `CROSS_SCENARIO_COST` only steer (1) *which* point
+  the cut is generated at (the "farthest `xhat`" heuristic and the
+  `global_xbar` average) and (2) *trigger conditions* (the `eta_lb`
+  violation test, and whether a generated cut is worth adding).  The
+  `eta_lb` cuts (`eta >= LB`) and feasibility cuts are valid by
+  construction too.  So assembling these fields from ranks at mixed
+  `write_id`s can only cause a cut to be generated at a stale or
+  blended candidate point — still a valid cut.  The cost is slower
+  convergence (less useful cut placement), never an invalid cut or a
+  wrong bound.  Hence: **relaxed coherence.**  (`CrossScenarioExtension`
+  is two-stage only, so there is no multistage cut interaction to
+  worry about.)
 
 #### Recommendation
 
@@ -605,7 +615,9 @@ the first pass bundled into "Phase 0" has already landed separately.
 - Add the strict `write_id` check for `DUALS`.
 - Add single-source first-stage sourcing for `BEST_XHAT` /
   `RECENT_XHATS` in the **two-stage** case; cost portion per-scenario.
-- Settle the `cross_scen` coherence question and wire it accordingly.
+- Wire `cross_scen` with relaxed coherence (resolved — see §Coherence)
+  and make `CrossScenarioCutSpoke` accept a multi-source `NONANTS_VALS`
+  / `CROSS_SCENARIO_COST` (it currently asserts a single source rank).
 - Wire up the rank-ratio CLI options end to end.
 - Test all spoke types with various ratios at two stages.
 - Performance check: does 8+4+2 beat 5+5+5 for a representative

--- a/doc/designs/flexible_rank_assignments.md
+++ b/doc/designs/flexible_rank_assignments.md
@@ -3,34 +3,6 @@
 Status: Design Document (Draft — second pass)
 Date: 2026-05-24
 
-### Correction note (why this is a second pass)
-
-The first pass of this design was built on a wrong premise.  It
-asserted that the hub-published nonant field carries `xbar` (the
-consensus value), with one `xbar` value redundantly copied into every
-scenario's slot, and proposed collapsing it to one canonical vector
-per non-leaf node.
-
-Reading the code disproved this.  The field carries **per-scenario
-nonant variable values** — each scenario's own current iterate —
-and several consumers *depend* on those values being per-scenario
-distinct (see §Field Taxonomy).  `xbar` is a separate quantity,
-stored in the `xbars` Pyomo Param (`phbase.py`), equal to the
-transmitted values only at convergence.
-
-Consequences for this design:
-
-- The field-canonicalization refactor ("BN-2 / BX-2") is **gone**.
-  The hub nonant field cannot and should not be collapsed to one
-  value per node.
-- The misnamed field has already been renamed in tree:
-  `Field.NONANT` → (briefly `XBAR`) → `Field.NONANTS_VALS`, and
-  `Field.RELAXED_NONANT` → `Field.RELAXED_NONANTS_VALS`.  This
-  document uses the final names throughout.
-- The remaining design is **simpler**: one uniform mechanism
-  (overlap maps + multi-source assembly) for every local-sized
-  field, plus a per-field coherence policy.
-
 ### Terminology
 
 - **Window:** An MPI one-sided ("RMA") addressing scope, created
@@ -134,10 +106,9 @@ handled under unequal rank counts.
 
 #### Category 1 — genuinely per-scenario *distinct* data
 
-The buffer holds one independent value (or block) per local scenario,
-and consumers rely on the per-scenario differences.  Multi-source
-assembly across ranks is the correct primitive; there is nothing to
-canonicalize.
+Buffers in this category hold one independent value (or block) per
+local scenario, and consumers rely on the per-scenario differences.
+Multi-source assembly across ranks is the correct primitive.
 
 - **`NONANTS_VALS`** (hub → spokes).  `Hub.send_nonants`
   (`hub.py`) loops over `local_scenarios` and writes `xvar._value`
@@ -165,8 +136,8 @@ canonicalize.
 
 #### Category 2 — per-scenario *layout*, NAC-redundant first-stage
 
-The buffer is laid out per scenario, but its nonant portion is an
-incumbent first-stage decision that is **identical across all
+Buffers in this category are laid out per scenario, but the nonant
+portion is an incumbent first-stage decision that is **identical across all
 scenarios sharing a node** (non-anticipativity holds by construction
 because the first stage is *fixed* across scenarios when the candidate
 is evaluated).  A genuinely per-scenario scalar cost rides alongside.
@@ -661,3 +632,34 @@ satisfied trivially (one source per field).  Because this design makes
 equal ranks — there is no analogue of the first pass's "Phase 0 changes
 the wire format even at equal ranks" caveat.  Verify by running the
 full existing test suite with the new code and default ratios.
+
+
+---
+
+### Correction note (why this is a second pass)
+
+The first pass of this design was built on a wrong premise.  It
+asserted that the hub-published nonant field carries `xbar` (the
+consensus value), with one `xbar` value redundantly copied into every
+scenario's slot, and proposed collapsing it to one canonical vector
+per non-leaf node.
+
+Reading the code disproved this.  The field carries **per-scenario
+nonant variable values** — each scenario's own current iterate —
+and several consumers *depend* on those values being per-scenario
+distinct (see §Field Taxonomy).  `xbar` is a separate quantity,
+stored in the `xbars` Pyomo Param (`phbase.py`), equal to the
+transmitted values only at convergence.
+
+Consequences for this design:
+
+- The field-canonicalization refactor ("BN-2 / BX-2") is **gone**.
+  The hub nonant field cannot and should not be collapsed to one
+  value per node.
+- The misnamed field has already been renamed in tree:
+  `Field.NONANT` → (briefly `XBAR`) → `Field.NONANTS_VALS`, and
+  `Field.RELAXED_NONANT` → `Field.RELAXED_NONANTS_VALS`.  This
+  document uses the final names throughout.
+- The remaining design is **simpler**: one uniform mechanism
+  (overlap maps + multi-source assembly) for every local-sized
+  field, plus a per-field coherence policy.

--- a/doc/designs/flexible_rank_assignments.md
+++ b/doc/designs/flexible_rank_assignments.md
@@ -1,8 +1,35 @@
 # Flexible Rank Assignments for Cylinders
 
-Status: Design Document (Draft)
-Date: 2026-03-16
-Branch: `flexible_rank_assignments`
+Status: Design Document (Draft — second pass)
+Date: 2026-05-24
+
+### Correction note (why this is a second pass)
+
+The first pass of this design was built on a wrong premise.  It
+asserted that the hub-published nonant field carries `xbar` (the
+consensus value), with one `xbar` value redundantly copied into every
+scenario's slot, and proposed collapsing it to one canonical vector
+per non-leaf node.
+
+Reading the code disproved this.  The field carries **per-scenario
+nonant variable values** — each scenario's own current iterate —
+and several consumers *depend* on those values being per-scenario
+distinct (see §Field Taxonomy).  `xbar` is a separate quantity,
+stored in the `xbars` Pyomo Param (`phbase.py`), equal to the
+transmitted values only at convergence.
+
+Consequences for this design:
+
+- The field-canonicalization refactor ("BN-2 / BX-2") is **gone**.
+  The hub nonant field cannot and should not be collapsed to one
+  value per node.
+- The misnamed field has already been renamed in tree:
+  `Field.NONANT` → (briefly `XBAR`) → `Field.NONANTS_VALS`, and
+  `Field.RELAXED_NONANT` → `Field.RELAXED_NONANTS_VALS`.  This
+  document uses the final names throughout.
+- The remaining design is **simpler**: one uniform mechanism
+  (overlap maps + multi-source assembly) for every local-sized
+  field, plus a per-field coherence policy.
 
 ### Terminology
 
@@ -12,17 +39,17 @@ Branch: `flexible_rank_assignments`
   participant's local buffer mutually addressable via `MPI_Get` /
   `MPI_Put`.
 - **Buffer:** A rank's local memory region exposed through a window.
-  Holds that rank's published fields (`NONANT`, `DUALS`,
+  Holds that rank's published fields (`NONANTS_VALS`, `DUALS`,
   `BEST_XHAT`, ...) packed according to the `buffer_layout` in
   `spwindow.py`.
-- **`NONANT` field:** Carries `xbar` values from the hub.  The
-  name reflects the variable layout (values shaped like
-  `nonant_indices`), not the content — `xbar` is what's actually
-  in there.  This design proposes renaming the field to `XBAR`
-  and reframing it as a canonical per-non-leaf-node vector under
-  **Option BN-2** below, in parallel with **Option BX-2** for
-  `BEST_XHAT` / `RECENT_XHATS`.  The related
-  `Field.RELAXED_NONANT` becomes `Field.RELAXED_XBAR`.
+- **Local-sized field:** A field whose buffer length is proportional
+  to the rank's *local* scenario count (`NONANTS_VALS`, `DUALS`,
+  `BEST_XHAT`, `RECENT_XHATS`, `CROSS_SCENARIO_COST`, ...).  These are
+  the fields affected by unequal rank counts.
+- **Global-sized field:** A field whose buffer length is proportional
+  to the *total* nonant count and is identical on every rank
+  (`NONANT_LOWER_BOUNDS`, `NONANT_UPPER_BOUNDS`,
+  `EXPECTED_REDUCED_COST`).  Unaffected by rank asymmetry.
 
 ### Motivation
 
@@ -46,7 +73,7 @@ time for the same number of processors.
 ### User Interface
 
 The user would specify a **target ratio** for each spoke relative to the
-hub.  The hub always serves as the reference (ratio 1.0).  Example
+hub.  The hub always serves as the reference (ratio 1.0).  Example:
 ```
 mpiexec -np 14 python -m mpi4py mpisppy/generic_cylinders.py \
     --module-name farmer --num-scens 100 \
@@ -98,6 +125,84 @@ Interface decisions:
   least one rank.
 
 
+### Field Taxonomy
+
+This is the section that the first pass got wrong, so it is grounded
+in the actual write and consume sites.  Every local-sized field falls
+into one of these categories; the category determines how it is
+handled under unequal rank counts.
+
+#### Category 1 — genuinely per-scenario *distinct* data
+
+The buffer holds one independent value (or block) per local scenario,
+and consumers rely on the per-scenario differences.  Multi-source
+assembly across ranks is the correct primitive; there is nothing to
+canonicalize.
+
+- **`NONANTS_VALS`** (hub → spokes).  `Hub.send_nonants`
+  (`hub.py`) loops over `local_scenarios` and writes `xvar._value`
+  for each scenario's `nonant_indices` — each scenario's *own*
+  subproblem solution.  Consumers depend on the differences:
+    - `slam_heuristic.py` reshapes the buffer to
+      `(num_scen, num_vars)` and takes min/max **across scenarios**;
+    - `cross_scen_spoke.py` sums values **across scenarios**;
+    - the xhat loopers (`xhatlooper`, `xhatshufflelooper`,
+      `xhatspecific`) try **each scenario's** first-stage solution as
+      a candidate xhat.
+
+- **`RELAXED_NONANTS_VALS`** (relaxed-PH spoke → `relaxed_ph_fixer`).
+  `RelaxedPHSpoke` inherits the base `send_nonants`, so this is the
+  same per-scenario layout as `NONANTS_VALS`, carrying the relaxed
+  (LP) iterates.
+
+- **`DUALS`** (hub → spokes).  Each scenario carries its own
+  multiplier `W_s`.  Genuinely per-scenario; multi-source assembly is
+  correct.  Unlike the nonant fields, `DUALS` requires **strict
+  coherence** — see §Coherence.
+
+- **`CROSS_SCENARIO_COST`** (cross-scenario cut source → cut spoke).
+  Per-scenario cost data.
+
+#### Category 2 — per-scenario *layout*, NAC-redundant first-stage
+
+The buffer is laid out per scenario, but its nonant portion is an
+incumbent first-stage decision that is **identical across all
+scenarios sharing a node** (non-anticipativity holds by construction
+because the first stage is *fixed* across scenarios when the candidate
+is evaluated).  A genuinely per-scenario scalar cost rides alongside.
+
+- **`BEST_XHAT`** / **`RECENT_XHATS`** (inner-bound spoke →
+  hub / FWPH).  `send_best_xhat` (`spoke.py`) writes, per local
+  scenario, `[best_solution_cache nonant values, inner_bound]`.
+  Because the candidate fixes the first stage across scenarios, the
+  nonant values are NAC-redundant (one value per node, copied into
+  each scenario's slot), while `inner_bound` is genuinely
+  per-scenario.  `RECENT_XHATS` is a circular buffer of such entries.
+
+The split matters for asymmetric ranks: the **first-stage portion
+must stay NAC-consistent**, so it cannot be assembled from ranks at
+different iterations; the **cost portion** is ordinary per-scenario
+data assembled like Category 1.  See §Coherence for how this is
+handled without canonicalization.
+
+#### Category 3 — global-sized fields
+
+`NONANT_LOWER_BOUNDS`, `NONANT_UPPER_BOUNDS`, `EXPECTED_REDUCED_COST`.
+One canonical vector per sender, identical on every rank, sized by the
+*total* nonant count.  No partitioning, nothing to assemble — a
+no-op under rank asymmetry.  Their receiver-side application is
+monotonic/idempotent (a bound is applied only when it tightens), so
+staleness is safe.
+
+#### Category 4 — scalars
+
+`OBJECTIVE_INNER_BOUND`, `OBJECTIVE_OUTER_BOUND`,
+`BEST_OBJECTIVE_BOUNDS`, `SHUTDOWN`.  One value (or a tiny fixed-size
+record) per cylinder, written on rank 0.  Unaffected by rank
+asymmetry; staleness yields a slightly later termination check, never
+an incorrect one.
+
+
 ### Current Architecture
 
 This section describes the pieces that would need to change.
@@ -105,7 +210,7 @@ This section describes the pieces that would need to change.
 #### Rank Partitioning (`spin_the_wheel.py`)
 
 `WheelSpinner` requires `n_proc % n_spcomms == 0` and creates two
-communicators via `MPI_Comm_split`
+communicators via `MPI_Comm_split`:
 ```
 strata_comm  = fullcomm.Split(color=global_rank // n_spcomms)
 cylinder_comm = fullcomm.Split(color=global_rank % n_spcomms)
@@ -123,74 +228,37 @@ With equal rank counts, there is a clean 1-to-1 correspondence:
 `_calculate_scenario_ranks()` distributes scenarios across
 `self.n_proc` ranks (the cylinder's rank count) using contiguous
 blocks.  All cylinders currently have the same `n_proc`, so rank *i*
-in every cylinder gets the same scenarios.
+in every cylinder gets the same scenarios.  The function already works
+with any `n_proc`; each cylinder just calls it with its own rank
+count.
 
 #### Buffer System (`spwindow.py`, `spcommunicator.py`)
 
 Each rank creates an MPI RMA window with per-field buffers.  Buffer
-sizes for "local" fields (`NONANT`, `DUALS`, `BEST_XHAT`,
-`RECENT_XHATS`, `CROSS_SCENARIO_COST`) are proportional to the
-rank's local scenario count.  Buffer sizes for "global" fields
-(`NONANT_LOWER_BOUNDS`, `NONANT_UPPER_BOUNDS`) are proportional to
-the total nonant count and are the same on every rank.
+sizes for local-sized fields are proportional to the rank's local
+scenario count; global-sized fields are the same on every rank.
 
 On receive, `_validate_recv_field()` checks that the remote buffer
-size matches the local expectation.  This check assumes both sides have
-the same local scenario count.
-
-Note: the per-scenario classification of `BEST_XHAT` /
-`RECENT_XHATS` is itself revisited below (§Coherence options) —
-under Option BX-1 they remain local-sized with added strict
-coherence; under Option BX-2 they are reframed as global-sized
-per-node vectors.
+size matches the local expectation.  This check assumes both sides
+have the same local scenario count and must be relaxed (§Impact).
 
 #### Communication Patterns
 
 All inter-cylinder communication uses one-sided MPI (RMA) through
-`SPWindow`.  The communication graph is:
-
-**Hub sends to spokes:**
-  - `NONANT` (local-sized): current nonant values for PH iterates
-  - `DUALS` (local-sized): W values (dual weights)
-  - `SHUTDOWN`, `BEST_OBJECTIVE_BOUNDS` (scalars on rank 0 only)
-
-**Spokes send to hub:**
-  - `OBJECTIVE_INNER_BOUND`, `OBJECTIVE_OUTER_BOUND` (scalars)
-  - `BEST_XHAT` (local-sized): best feasible solution found
-  - `RECENT_XHATS` (local-sized, circular buffer)
-
-**Spoke-to-spoke (via RMA windows, not point-to-point):**
-  - FWPH spoke reads `BEST_XHAT` and `RECENT_XHATS` from an
-    InnerBoundSpoke
-  - ReducedCostsSpoke sends `NONANT_LOWER_BOUNDS` and
-    `NONANT_UPPER_BOUNDS` (global-sized, already works)
-  - CrossScenarioCutSpoke reads `NONANT` and
-    `CROSS_SCENARIO_COST` from a source
-
-The local-sized fields are the ones affected by unequal rank
-counts.  Of those, only `DUALS` (and per-scenario fields like
-`CROSS_SCENARIO_COST` that carry independent per-scenario data)
-get the multi-source assembly treatment described below.  `NONANT`
-joins `BEST_XHAT` and `RECENT_XHATS` in the NAC-canonicalized
-treatment, because xbar is fundamentally one value per non-leaf
-node, not per-scenario data.  See §Coherence options for the
-`BN-2` / `BX-2` layout reframing.
+`SPWindow`.  The local-sized fields (Categories 1 and 2 above) are the
+ones affected by unequal rank counts; the global-sized and scalar
+fields are not.
 
 
 ### Design: Multi-Rank Mapping
 
-This section describes the design for fields where multi-source
-assembly across scenarios is mathematically valid: `DUALS` (each
-scenario carries its own W_s, genuinely independent per-scenario
-data) and per-scenario fields like `CROSS_SCENARIO_COST`.  Fields
-where per-scenario assembly would violate non-anticipativity
-(`NONANT`, `BEST_XHAT`, `RECENT_XHATS`) are handled separately —
-see §Coherence options.
-
-The core idea (for the applicable fields): when a rank in one
-cylinder needs data from another cylinder with a different rank
-count, it reads from multiple remote ranks and assembles the
-result (or reads from one remote rank and extracts a subset).
+The core idea: when a rank in one cylinder needs a local-sized field
+from another cylinder with a different rank count, it reads from
+multiple remote ranks and assembles the result (or reads from one
+remote rank and extracts a subset).  **The same mechanism applies to
+every local-sized field** — there is no special per-field layout.
+What differs per field is only the *coherence policy* applied to the
+reads (§Coherence).
 
 #### Overlap Maps
 
@@ -219,23 +287,23 @@ Hub rank 0 needs to read from spoke rank 0 (which has scen0--scen4),
 extracting only the portion for scen0--scen1.  Hub rank 2 also reads
 from spoke rank 0, extracting scen4--scen5.
 
-The overlap map for hub rank 0 reading from the spoke would be
+The overlap map for hub rank 0 reading from the spoke would be:
 ```
 [(spoke_rank=0, remote_offset=0, local_offset=0, count=2)]
 ```
 
-For hub rank 2
+For hub rank 2:
 ```
 [(spoke_rank=0, remote_offset=4, local_offset=0, count=2)]
 ```
 
-For hub rank 3
+For hub rank 3:
 ```
 [(spoke_rank=1, remote_offset=0, local_offset=0, count=4)]
 ```
 
 These maps are computed once at startup and reused for every
-communication call.  The data structure could be
+communication call.  The data structure could be:
 ```
 @dataclass
 class OverlapSegment:
@@ -243,10 +311,10 @@ class OverlapSegment:
     remote_offset: int     # nonant offset within remote buffer
     local_offset: int      # nonant offset within local buffer
     count: int             # number of nonants in this segment
-```
 
     # Per (peer_cylinder, field): list of OverlapSegments
     overlap_map: dict[int, list[OverlapSegment]]
+```
 
 Note: offsets are in nonant units (not scenario units) because
 different scenarios could have different numbers of nonants in
@@ -264,133 +332,66 @@ remote ranks by their global rank.  The `strata_buffer_layouts`
 (currently exchanged via `strata_comm.allgather`) would instead be
 exchanged on `fullcomm` or a dedicated intercommunicator.
 
-Pros:
-
-- Simple conceptually: any rank can read from any other rank.
-- No need for multiple communicator splits.
-- A single `MPI_Win_create` call.
-
-Cons:
-
-- The window is large (sum of all ranks' buffers across all cylinders).
-- `MPI_Win_lock` granularity is per-window; concurrent accesses to
-  different cylinders' data may contend.
-- All ranks must participate in window creation even if they never
-  communicate with most other ranks.
+Pros: simple conceptually; any rank can read from any other rank; one
+`MPI_Win_create`.  Cons: large window; all ranks participate even if
+they never communicate.
 
 **Option B: Per-cylinder-pair intercommunicators with separate windows**
 
-For each pair of cylinders that need to communicate, create an
-`MPI_Intercomm` and a window on it.  For example, hub-lagrangian and
-hub-xhat would each get their own window.
-
-Pros:
-
-- Smaller windows, less contention.
-- Clean separation of concerns.
-
-Cons:
-
-- Number of windows grows with the number of communicating pairs.
-  With spoke-to-spoke communication, this could be O(n^2) in the
-  worst case (though in practice most spokes only talk to the hub
-  plus at most one other spoke).
-- More complex setup code.
-- MPI intercomm semantics can be tricky.
+For each communicating pair, create an `MPI_Intercomm` and a window on
+it.  Pros: smaller windows, less contention.  Cons: number of windows
+grows with communicating pairs (O(n^2) worst case with spoke-to-spoke);
+more setup complexity; intercomm semantics are tricky.
 
 **Option C: Keep strata_comm but make it asymmetric**
 
-Create `strata_comm` groupings where ranks from different-sized
-cylinders are grouped together.  Ranks without a counterpart in a
-smaller cylinder would be grouped with the "nearest" rank in that
-cylinder.
-
-For example, with 4 hub ranks and 2 spoke ranks, strata groups would
-be
-```
-strata 0: hub_rank_0, spoke_rank_0
-strata 1: hub_rank_1, spoke_rank_0  (spoke_rank_0 appears twice)
-strata 2: hub_rank_2, spoke_rank_1
-strata 3: hub_rank_3, spoke_rank_1  (spoke_rank_1 appears twice)
-```
-
-Pros:
-
-- Closest to the current architecture; least code change.
-- Each strata_comm still has one rank per cylinder.
-
-Cons:
-
-- A spoke rank appears in multiple strata comms, which may cause
-  issues with MPI (a rank can only be in one communicator of a given
-  color).
-- Actually, this doesn't work with `MPI_Comm_split` because a rank
-  can only appear once per split.  Would need to use
-  `MPI_Comm_create_group` or manual point-to-point addressing
-  instead.
+Group ranks from different-sized cylinders together, with a smaller
+cylinder's rank appearing in multiple strata groups.  This does not
+work with `MPI_Comm_split` (a rank appears once per split) and would
+require `MPI_Comm_create_group` or manual addressing.  Rejected.
 
 **Option D: Replace strata_comm with direct RMA addressing**
 
-Abandon `strata_comm` entirely.  Use `fullcomm` for the
-window, and have each rank directly address remote ranks by their
-global rank.  The overlap maps provide the addressing information.
+Abandon `strata_comm` entirely.  Use `fullcomm` for the window, and
+have each rank directly address remote ranks by their global rank.  The
+overlap maps provide the addressing information.  This is Option A with
+the explicit framing that `strata_comm` is removed rather than
+modified.
 
-This is essentially Option A but with the explicit framing that
-`strata_comm` is removed rather than modified.
+Pros: clean break from the 1-to-1 assumption; most flexible; single
+window creation.  Cons:
 
-Pros:
-
-- Clean break from the current 1-to-1 assumption.
-- Most flexible: any rank can read from any other rank.
-- Single window creation.
-
-Cons:
-
-- Requires rewriting `SPCommunicator` and `SPWindow` to work
-  without `strata_comm`.
-- The buffer layout exchange (currently `strata_comm.allgather`)
-  needs a replacement. The cheapest option is to compute layouts
-  locally on every rank: per-cylinder rank count, the output of
+- Requires rewriting `SPCommunicator` and `SPWindow` to work without
+  `strata_comm`.
+- The buffer layout exchange (currently `strata_comm.allgather`) needs
+  a replacement.  The cheapest option is to compute layouts locally on
+  every rank: per-cylinder rank count, the output of
   `_calculate_scenario_ranks`, and field-registration order are all
   static and deterministic at startup, so no communication is
-  required. If a runtime exchange is genuinely needed (e.g., dynamic
+  required.  If a runtime exchange is genuinely needed (e.g., dynamic
   field registration), prefer a two-level scheme —
   `cylinder_comm.allgather` followed by a small cross-cylinder gather
   over one anchor rank per cylinder — rather than a single
   `fullcomm.allgather`, which scales worse at N=thousands.
-- Single-window structural cost relative to Option B.  Two
-  separable concerns; neither is a deal-breaker.
 
   *Lock granularity.*  `MPI_Win_lock(rank=target, ...)` is per-
-  target-rank in the MPI spec, not per-window — a writer's
-  exclusive lock on its own buffer does not block readers fetching
-  from a different rank's buffer, regardless of cylinder.  Cross-
-  cylinder serialization is therefore a non-issue at the spec
-  level.  Implementation-dependent progress-engine state per
-  window object can cause minor contention in practice, but
-  nothing like "the whole window stalls."  If a workload ever did
-  show measurable contention, splitting hot cylinder pairs into
-  their own window (Option B for those pairs) is an incremental
-  fix that doesn't require abandoning Option D.
+  target-rank in the MPI spec, not per-window — a writer's exclusive
+  lock on its own buffer does not block readers fetching from a
+  different rank's buffer.  Cross-cylinder serialization is a non-issue
+  at the spec level.  If a workload ever showed measurable contention,
+  splitting hot cylinder pairs into their own window (Option B for
+  those pairs) is an incremental fix that does not require abandoning
+  Option D.
 
-  *Bookkeeping.*  MPI-side, the window object on `fullcomm` must
-  track all participating ranks' base addresses, displacement
-  units, and lock state — modest (KB-to-low-MB per rank at
-  N=thousands) but unavoidable.  mpi-sppy-side, a naive
-  `fullcomm.allgather` of buffer layouts would scale poorly,
-  which is why the preceding bullet recommends computing layouts
-  locally from the static rank-count/scenario-map data instead.
-
-**Recommendation:** Option D is the cleanest long-term solution.
-Option A is equivalent but Option D better describes the intent.  The
-window is on `fullcomm` (or a subset), and each rank knows which
-global ranks to read from via the overlap maps.
+**Recommendation:** Option D.  The window is on `fullcomm` (or a
+subset), and each rank knows which global ranks to read from via the
+overlap maps.
 
 
 #### Multi-Source Read Assembly
 
 The current `get_receive_buffer()` reads one contiguous buffer from
-one remote rank.  With multi-rank mapping, it would need to:
+one remote rank.  With multi-rank mapping, it would:
 
 1. For each segment in the overlap map, issue an `MPI_Get` for that
    segment from the appropriate remote rank.
@@ -398,7 +399,7 @@ one remote rank.  With multi-rank mapping, it would need to:
    buffer.
 3. Return the assembled buffer.
 
-Schematically
+Schematically:
 ```
 def get_receive_buffer_multi(self, field, peer_cylinder):
     local_buf = np.empty(self.local_field_length(field))
@@ -417,313 +418,92 @@ This requires `SPWindow.get()` to support partial reads (offset +
 count within a field), which is straightforward with `MPI_Get`
 displacement parameters.
 
-For the common case where both cylinders have the same rank count,
-the overlap map has exactly one segment per peer rank and the offsets
-are identity — so the behavior degenerates to the current code.
+For the common case where both cylinders have the same rank count, the
+overlap map has exactly one segment per peer rank and the offsets are
+identity — so the behavior degenerates to the current code.
 
 
-#### Write-ID Coherence
+### Coherence
 
-The current system uses a `write_id` integer appended to each buffer.
-When a sender writes new data, it increments `write_id`.  The
-receiver checks whether the `write_id` has changed since the last
-read to determine if the data is "new."
+The current system appends a `write_id` integer to each buffer; a
+sender increments it on write, and a receiver checks whether it changed
+to decide if data is "new."  With multi-source reads, a receiver reads
+from multiple remote ranks that may not have updated at the same time
+(the system is asynchronous).  The question — must all contributing
+ranks share a `write_id` before the data is accepted? — is answered
+**per field**, by category.
 
-With multi-source reads, a receiver reads from multiple remote ranks
-in the same cylinder.  These ranks may not have updated their buffers
-at exactly the same time (the system is asynchronous).  This raises
-the question: should we require all ranks in a cylinder to have the
-same `write_id` before accepting the data?
+#### Strict coherence
 
-The answer depends on the field.  Some fields carry coupled data that
-must come from the same iteration to be mathematically valid, while
-others are independent candidates that tolerate staleness.
+Read all `write_id` values for the contributing segments first (cheap:
+one int per segment); accept the data only if they match; otherwise
+retry later.
 
-##### Per-field coherence requirements
+- **`DUALS`.**  The dual normalization `sum_s p_s W_s = 0` holds only
+  within a single iteration.  Assembling `W` from mixed iterations
+  gives `sum_s p_s W_s != 0`, so the Lagrangian value is no longer a
+  valid bound.  Strict coherence is required for bound validity.  This
+  is cheap in practice: the hub is synchronous PH, so all hub ranks
+  finish an iteration before writing `DUALS`, and their `write_id`
+  values naturally agree.
 
-**Fields requiring strict coherence:**
+- **`BEST_XHAT` / `RECENT_XHATS` (first-stage portion).**  The
+  first-stage values must be NAC-consistent.  Two ways to guarantee
+  that without canonicalization, both exploiting that the first-stage
+  portion is *identical across scenarios*:
 
-- `DUALS` (W values from the hub).  W is genuinely scenario-by-
-  scenario data: each scenario has its own multiplier W_s.  Multi-
-  source assembly across ranks is the correct primitive here, but
-  the dual normalization `sum_s p_s W_s = 0` only holds at a single
-  iteration — so mixing iterations gives `sum_s p_s W_s_mixed != 0`
-  and the resulting Lagrangian value is no longer a valid lower
-  bound on the primal.  Coherence is required for bound validity.
+  - **Two-stage:** every scenario carries the same first-stage vector,
+    so the receiver can read the first-stage portion from a **single**
+    remote rank (no cross-rank assembly, hence no coherence question).
+    Only the per-scenario `inner_bound` cost is assembled per-scenario
+    (Category-1 style).
 
-  In practice this is cheap: the hub is synchronous PH, so all hub
-  ranks complete the same iteration before writing their `DUALS`
-  buffers and their `write_id` values naturally agree after each
-  PH iteration.  The receiver just verifies they match before
-  accepting the assembled data.
+  - **Multistage:** a node's first-stage values are shared only by the
+    scenarios passing through that node, which may be spread across
+    ranks.  Source each node's first-stage portion from a single rank
+    that holds a scenario through that node (deterministic from the
+    scenario-to-rank map and the tree).  This is per-node single-source
+    sourcing, computed at startup alongside the overlap maps — not a
+    layout change and not multi-source assembly of the first stage.
 
-**Fields where multi-source assembly breaks non-anticipativity:**
+  The sender side is synchronous in practice (a spoke writes
+  `BEST_XHAT` only after its `cylinder_comm.Allreduce` feasibility
+  verdict), so `write_id` values agree and the single-source reads see
+  a coherent snapshot.
 
-- `NONANT` (xbar from the hub) is per-scenario local-sized, but
-  xbar is fundamentally a node-by-node consensus value.  The hub
-  computes one xbar per non-leaf node via Allreduce in
-  `compute_xbar`, enforcing NAC by construction.  The per-scenario
-  layout then *redundantly* writes that one value into each
-  scenario's slot — 100 scenarios sharing ROOT each carry a copy
-  of ROOT's xbar.  Under multi-source assembly from mixed
-  iterations, those copies disagree, and consumers that need
-  NAC-consistent xbar (e.g., the xbar-based xhatter
-  `XhatXbarSpoke`, augmented-Lagrangian spokes, FWPH inner
-  iterations) see scenario-dependent first-stage values — same
-  failure mode as `BEST_XHAT`.
-- `BEST_XHAT` is per-scenario local-sized, but every scenario's
-  first-stage slot must hold the same first-stage values (NAC).
-  Assembling segments from iteration *k* for some scenarios and
-  iteration *k+1* for others yields a vector where different
-  scenarios' first-stage slots disagree — i.e., not a feasible
-  first-stage point at all.  "Evaluate fresh" does not save this:
-  the receiver fixes first-stage variables across all scenarios
-  from the assembled buffer and would see scenario-dependent
-  first-stage values, violating NAC.  Multistage is worse: stage-2+
-  decisions are conditional on stage-1, so mixing iterations also
-  mixes branches with different parent decisions.
-- `RECENT_XHATS` is the same: a circular buffer of multiple xhat
-  solutions, each entry per-scenario local-sized.  Each entry is a
-  candidate first-stage point and inherits the same NAC problem
-  when assembled from mixed iterations.
+#### Relaxed coherence
 
-There are two ways to address this; both are on the table (but DLW
-favors BX-2, which has a very long description here):
+Accept data from each source rank independently; track `write_id` per
+source rank.
 
-**Option BX-1: Require strict coherence on `BEST_XHAT` /
-`RECENT_XHATS` as well.**  Treat them the same as `NONANT` /
-`DUALS`: read `write_id` values first, verify they match across the
-remote ranks contributing segments, then read data.  The sender
-side is already synchronous in practice (an xhat spoke writes
-`BEST_XHAT` only after its local `_try_one` solve finishes on all
-its ranks), so `write_id` values naturally agree after each xhat
-iteration and the check is almost free.  Minimal change; keeps the
-current per-scenario field layout.
+- **`NONANTS_VALS` / `RELAXED_NONANTS_VALS`.**  These are per-scenario
+  iterates with no cross-scenario invariant on the wire.  The xhat
+  loopers and `slam_heuristic` re-evaluate any candidate fresh
+  (fixing the first stage and solving), so a stale or mixed-iteration
+  per-scenario value just means evaluating a slightly older candidate
+  — always honest, never invalid.
 
-**Option BX-2: Reframe `BEST_XHAT` and `RECENT_XHATS` so each
-non-anticipative decision lives in exactly one place.**  Replace
-the per-scenario layout with one canonical vector per non-leaf
-node.
+- **Global-sized bounds and scalars** (Categories 3 and 4).  Monotone,
+  idempotent application; staleness is safe.
 
-*What the current layout looks like.*  `BEST_XHAT` on a given
-rank is a concatenation, one entry per local scenario, of that
-scenario's `nonant_indices` values (plus a per-scenario scalar
-total cost stored alongside).  Since `nonant_indices` contains
-exactly the NAC-bound variables — those at non-leaf nodes —
-every scenario passing through a given node carries its own copy
-of that node's values.  Two scenarios sharing the ROOT node, for
-example, each store the same stage-1 vector in their own slot;
-nothing in the layout enforces that the two copies agree, even
-though NAC requires they must.
+#### One field needs a decision: `cross_scen`
 
-*What BX-2 changes it to.*  The layout becomes a concatenation,
-one entry per non-leaf node touched by the local scenarios, of
-that node's canonical nonant vector (size = the node's nonant
-count).  Scenarios no longer have private xhat slots; they share
-the per-node entries.  Per-scenario total cost, which is
-genuinely scenario-specific, remains per-scenario in a parallel
-small array.
+`CrossScenarioCutSpoke` reads `NONANTS_VALS` and `CROSS_SCENARIO_COST`
+to build cross-scenario (Benders-like) cuts.  A cut assembled from
+mixed-iteration nonants/costs could in principle be invalid (cut off
+feasible points).  **Open item:** determine whether cross-scenario
+cut construction requires per-iteration coherence across the assembled
+scenarios.  If so, `NONANTS_VALS`/`CROSS_SCENARIO_COST` get strict
+coherence *for this consumer*; if the cut math tolerates per-scenario
+staleness, they stay relaxed.  This should be settled before Phase 3
+wires up `cross_scen` under asymmetric ranks.
 
-*Why non-leaf nodes specifically.*  NAC binds at non-leaf nodes:
-all scenarios sharing a non-leaf node must agree on that node's
-decisions.  Leaf nodes correspond one-to-one with scenarios, so
-their decisions are scenario-specific by construction and are
-not included in `nonant_indices` anyway — there is nothing to
-canonicalize at leaves.
+#### Recommendation
 
-*Concrete example.*  A two-stage problem with 100 scenarios and
-20 stage-1 (root) variables.  The current per-scenario layout
-stores 100 × 20 = 2000 doubles for the nonant portion of
-`BEST_XHAT` (across all ranks combined), even though by NAC all
-100 copies must agree.  BX-2 stores 1 × 20 = 20 doubles for the
-ROOT node — a 100× reduction in this dimension.  Multistage gives
-the same kind of reduction per node, scaled by how many scenarios
-share that node.
-
-*Writer rule (uniform across stages and cylinders):* the writer for
-a non-leaf node is the lowest-rank holder, within the publishing
-cylinder, of any scenario passing through that node.  For two-stage
-this collapses to a single writer per cylinder — rank 0, since rank
-0 holds the first scenario block and ROOT is the only non-leaf
-node.  Hub-side rank-0-special-cases like `SHUTDOWN` and
-`BEST_OBJECTIVE_BOUNDS` are untouched; this rule applies only to
-`BEST_XHAT` / `RECENT_XHATS`.
-
-*Certification and publish.*  A natural question is how the
-elected writer knows that all other ranks in the cylinder have
-certified the candidate xhat as feasible before it publishes the
-canonical vector.  The answer is that certification is not done
-via the SPWindow; it goes through the existing cylinder-internal
-`cylinder_comm.Allreduce` that already runs in every xhat spoke
-today.  Sequence:
-
-1. The hub broadcasts a candidate xhat to the spoke via `NONANT`.
-2. Each spoke rank fixes the first stage to that candidate and
-   solves its locally-held scenarios' subproblems.
-3. The spoke does a `cylinder_comm.Allreduce` combining per-rank
-   feasibility flags and per-scenario costs into a single global
-   verdict plus total cost.  After this Allreduce returns, every
-   rank in the cylinder — including the elected writer — knows
-   whether the candidate is certified.
-4. If certified, the elected writer transcribes the canonical
-   node vector(s) from its in-memory model into its buffer and bumps
-   `write_id`.  Other ranks do not write `BEST_XHAT` at all.
-5. Readers (hub, other spokes) Get from the writer's buffer.
-
-So the writer never has to learn the certification result
-out-of-band: the Allreduce *is* the certification, and it is
-globally synchronous within the cylinder.  Step 4 is just the
-elected scribe transcribing the already-agreed answer.
-
-*Why the writer has the value to transcribe.*  By the writer
-rule, the elected writer for a node holds at least one scenario
-passing through that node, so the node's nonant values are in
-its local Pyomo model.  NAC guarantees that all scenarios through
-that node agree on those values, so it does not matter which
-local scenario's slot the writer reads from when transcribing.
-
-*Read side:*
-
-- **Two-stage:** one Get from the publishing cylinder's writer.  No
-  assembly on either side.
-- **Multistage:** one Get per non-leaf node from that node's
-  writer, then stitch those node vectors into the reader's local
-  view.  Not "no assembly," but structurally different and smaller
-  than the per-scenario layout: O(non-leaf nodes) Gets instead of
-  O(local-scenarios × node-depth) source segments, and no
-  cross-source merging *within* a node.
-
-The chosen-writer table is deterministic from the scenario-to-rank
-map and the scenario tree; compute it at startup alongside the
-overlap maps.
-
-*Benefits independent of asymmetric ranks:* storage drops from
-O(scenarios × all-nodes-len) to O(non-leaf-nodes × node-len), and
-the layout encodes the actual NAC invariant rather than implying
-scenarios can disagree.
-
-*Costs:* field-layout change that touches FWPH (consumes
-`RECENT_XHATS`), any receiver that reads these fields, and the
-writer-assignment plumbing.  Probably the right long-term shape;
-arguably should be done first as a prerequisite refactor.
-
-**Option BN-1: Require strict coherence on `NONANT` (xbar) as
-well.**  Treat it like `DUALS`: at read time, fetch `write_id`
-from every contributing remote rank, check they all match, then
-issue the data Gets.  Mismatch → retry later.  The hub is
-synchronous PH so `write_id` values naturally agree after each
-iteration and the check is almost free.  Minimal layout change;
-keeps the redundant per-scenario layout (one xbar value
-duplicated into every local scenario's slot).
-
-**Option BN-2: Reframe `NONANT` as one canonical xbar vector
-per non-leaf node, and rename the field to `XBAR`.**  Apply the
-same canonicalization treatment as `BX-2` does for `BEST_XHAT` /
-`RECENT_XHATS`: identical writer rule, identical certification
-sequence, identical reader-expansion machinery (replace
-"BEST_XHAT" with "xbar" throughout the BX-2 walkthrough above).
-Specifics that differ for the xbar case:
-
-*Field rename.*  The current name describes the variable layout
-(`nonant_indices`-shaped), not the content.  Under BN-2 the
-layout becomes node-canonical, and the misnomer becomes actively
-misleading — the rename to `XBAR` lands as part of the BN-2 code
-change.  `Field.RELAXED_NONANT`, which is the relaxed-PH spoke's
-analogue of xbar, follows the same treatment and becomes
-`Field.RELAXED_XBAR`.
-
-*Hot path.*  Unlike `BEST_XHAT`, which updates rarely, xbar is
-broadcast on every PH iteration.  The bandwidth savings from
-eliminating the N-copies-of-one-value redundancy compound in
-steady state — every iteration writes O(non-leaf-nodes × node-len)
-instead of O(scenarios × all-nodes-len).
-
-*Consumers needing NAC-consistent xbar.*  The xbar-based xhatter
-(`XhatXbarSpoke` in `xhatxbar_bounder.py`) takes xbar as a
-candidate first-stage decision and evaluates it.  Under BN-2 that
-candidate is NAC-consistent by construction — no strict
-`write_id` check at read time, no retry logic, no possibility of
-a scenario-dependent "xhat."  Augmented-Lagrangian spokes (which
-use xbar in their proximal terms) and FWPH inner iterations are
-similar consumers and benefit identically.
-
-*Cost.*  Larger code touch than BX-2 because there are more
-`NONANT` consumers (the seven files identified in the rename
-scope analysis: `spwindow.py`, `spoke.py`, `hub.py`,
-`cross_scen_spoke.py`, `relaxed_ph_spoke.py`,
-`cross_scen_extension.py`, `relaxed_ph_fixer.py`).  Each reader
-needs an "expand from canonical to per-scenario view" step at
-use time — mechanically identical to what BX-2 already requires
-for FWPH on `RECENT_XHATS`.
-
-**Fields tolerating staleness (relaxed coherence):**
-
-- `NONANT_LOWER_BOUNDS`, `NONANT_UPPER_BOUNDS`.  Already
-  global-sized: one canonical bound vector per sender, no
-  partitioning to assemble.  Staleness is safe because the
-  receiver-side application is monotonic and idempotent —
-  `recv_buf[ci]` is applied only when it tightens the existing
-  local bound (`spcommunicator.py:517` and the upper-bound mirror),
-  so an older snapshot is never "wrong," it just fails to tighten
-  as aggressively as a fresh one would.  Asymmetric ranks are a
-  no-op here.
-- Scalar bounds (`OBJECTIVE_INNER_BOUND`, `OBJECTIVE_OUTER_BOUND`).
-  One float per cylinder.  Nothing to partition, and the receiver's
-  use of these (termination comparison) is monotonically improving
-  on the sender's side.  Staleness yields a slightly later
-  termination check, never an incorrect one.
-
-##### Coherence options
-
-**Option 1: Per-field strict check**
-
-For fields that require coherence (`DUALS`, plus `NONANT` if
-Option BN-1 is chosen, plus `BEST_XHAT` / `RECENT_XHATS` if
-Option BX-1 is chosen): read all `write_id` values first (cheap:
-one int per segment), check they match, then read the data.  If
-they don't match, retry later.
-
-For fields that tolerate staleness (the global-sized bound fields
-and the scalar objective bounds): accept data from each source
-rank independently.  Track `write_id` per source rank.
-
-Pros: correct semantics for each field type.  No unnecessary stalls
-for fields that don't need coherence.
-
-Cons: two code paths for multi-source reads (strict and relaxed).
-
-**Option 2: Cylinder-wide iteration counter (synchronized)**
-
-Each cylinder maintains a shared iteration counter (via
-`cylinder_comm.Allreduce` after each update).  Receivers check
-this counter for fields requiring coherence.
-
-Pros: clean coherence semantics.
-Cons: adds synchronization within the cylinder, which is exactly
-what the async design tries to avoid.  Only acceptable for
-synchronous algorithms (PH, not APH).
-
-**Option 3: Accept staleness everywhere (fully relaxed)**
-
-Accept data from each source rank independently for all fields.
-
-Pros: simplest implementation, no stalls.
-Cons: Lagrangian bounds may be invalid when assembled from mixed
-iterations.
-
-**Recommendation:** Option 1 (per-field strict check) covers
-the remaining per-scenario multi-source-read fields (`DUALS`,
-`CROSS_SCENARIO_COST`), paired with **BN-2 + BX-2** for the
-NAC-canonicalized fields (`NONANT` → `XBAR`, `BEST_XHAT`,
-`RECENT_XHATS`).  BN-2 and BX-2 share writer rule, certification,
-and reader-expansion machinery, so they are the same logic
-applied to two field families; landing them together avoids an
-awkward intermediate state where xhat is canonicalized but xbar
-is not (or vice versa).  Under BN-2 + BX-2 the strict `write_id`
-check is only needed for `DUALS` (and any other genuinely
-per-scenario field), since the canonicalized fields have exactly
-one writer per node and no multi-source coherence question to
-ask.
+Per-field strict-vs-relaxed policy (the table above), implemented as
+two code paths in the multi-source reader.  No cylinder-wide iteration
+counter (it would add synchronization the async design avoids and is
+unnecessary given the per-field analysis).
 
 
 ### Impact on Existing Components
@@ -731,165 +511,141 @@ ask.
 #### `spin_the_wheel.py`
 
 - Remove the `n_proc % n_spcomms == 0` check.
-- Replace the uniform `MPI_Comm_split` with a rank assignment
-  algorithm that respects per-cylinder rank counts.
-- The `cylinder_comm` creation still uses `MPI_Comm_split` (all
-  ranks in the same cylinder get the same color).
-- The `strata_comm` is either removed (Option D) or replaced with
-  a global window communicator.
-- The `communicator_list[strata_rank]` indexing must change because
-  `strata_rank` no longer has a fixed meaning.  Each rank needs to
-  know its cylinder index directly.
+- Replace the uniform `MPI_Comm_split` with the apportionment
+  algorithm (§User Interface) that respects per-cylinder rank counts.
+- `cylinder_comm` creation still uses `MPI_Comm_split` (all ranks in
+  the same cylinder get the same color).
+- `strata_comm` is removed (Option D); the window moves to `fullcomm`.
+- Indexing that assumes a fixed `strata_rank` meaning must change;
+  each rank needs to know its cylinder index directly.
 
 #### `spbase.py`
 
 - `_calculate_scenario_ranks()` already works with any `n_proc`.
-  No change needed; each cylinder just calls it with its own rank
-  count.
+  No change needed.
 
 #### `spwindow.py`
 
-- Rename `Field.NONANT` to `Field.XBAR` and `Field.RELAXED_NONANT`
-  to `Field.RELAXED_XBAR` (as part of the BN-2 layout change).
-- Add new field-length entries for `XBAR` / `RELAXED_XBAR` sized
-  by non-leaf-node nonant count rather than `_local_nonant_length`
-  (canonical per-non-leaf-node layout).
-- `BEST_XHAT` / `RECENT_XHATS` field-length entries change
-  similarly under BX-2.
-- `FieldLengths` mostly stays the same for the remaining
-  per-rank/local-sized fields (`DUALS`, `CROSS_SCENARIO_COST`).
-- `SPWindow` must support partial `get()` calls (offset + count).
+- `SPWindow.get()` must support partial reads (offset + count).
 - The buffer layout exchange must use a communicator that spans all
-  cylinders (not just `strata_comm`).
+  cylinders (not `strata_comm`), or be computed locally from the
+  static rank-count/scenario-map data (preferred).
 - Buffer validation must account for asymmetric sizes: a receiver's
-  expected size may differ from the sender's buffer size, and that's
-  OK as long as the requested segment fits within the sender's buffer.
+  expected size may differ from the sender's, and that is fine as long
+  as each requested segment fits within the sender's buffer.
+- No field-length or layout changes: every field keeps its current
+  per-scenario / global / scalar sizing.  (Canonicalization is *not*
+  part of this design.)
 
 #### `spcommunicator.py`
 
-- `register_receive_fields()` must build overlap maps instead of
-  assuming 1-to-1 rank correspondence.
-- `get_receive_buffer()` must support multi-source assembly.
+- `register_receive_fields()` builds overlap maps instead of assuming
+  1-to-1 rank correspondence.
+- `get_receive_buffer()` supports multi-source assembly, with the
+  per-field coherence policy applied.
 - `put_send_buffer()` is unchanged (each rank writes its own data).
-- `_validate_recv_field()` must be relaxed or replaced with
-  segment-level validation (check that each requested segment fits
-  within the remote buffer, not that the total sizes match).
-- The `synchronize` parameter in `get_receive_buffer()` uses
-  `cylinder_comm.Barrier()` and `Allreduce` — this still works
-  within a cylinder but the cross-cylinder sync semantics change.
+- `_validate_recv_field()` is relaxed to per-segment validation.
+- The `synchronize` parameter's `cylinder_comm.Barrier()` / `Allreduce`
+  still work within a cylinder.
 
 #### `hub.py` and `spoke.py`
 
-- `send_nonants()`, `update_nonants()`, and similar methods
-  currently iterate over local scenarios and pack/unpack linearly.
-  The packing is unchanged (each rank packs its own data).  The
-  unpacking on the receiver side must use the overlap map to
-  correctly place data from multi-source reads.
-- Bound communication (scalars) is unaffected.
+- Packing (send side) is unchanged: each rank packs its own local
+  scenarios linearly.
+- Unpacking (receive side) uses the overlap map to place multi-source
+  data at the right local offsets.
+- For `BEST_XHAT` / `RECENT_XHATS`, the receiver reads the first-stage
+  portion via single-source (per-node) sourcing and the cost portion
+  via per-scenario assembly.
+- Bound and scalar communication is unaffected.
 
 #### `cfg_vanilla.py` and `config.py`
 
-- Add per-spoke rank ratio configuration.
-- `shared_options()` may need to carry the rank ratio information
-  so that `SPCommunicator` can compute overlap maps at init time.
+- Add per-spoke rank-ratio configuration.
+- `shared_options()` may need to carry the rank-ratio information so
+  `SPCommunicator` can compute overlap maps at init.
 
 #### `generic_cylinders.py`
 
 - After computing rank ratios, pass them to `WheelSpinner` via the
-  hub/spoke dicts.
-- Default ratio is 1.0 for all cylinders (backward compatible).
+  hub/spoke dicts.  Default ratio is 1.0 for all cylinders (backward
+  compatible).
 
 
 ### Phased Implementation Plan
 
-**Phase 0: Field canonicalization (BN-2 + BX-2 prerequisite refactor)**
-
-- Rename `Field.NONANT` → `Field.XBAR` and `Field.RELAXED_NONANT`
-  → `Field.RELAXED_XBAR` across the 7 affected files.
-- Change layout of `XBAR`, `RELAXED_XBAR`, `BEST_XHAT`, and
-  `RECENT_XHATS` from per-scenario to canonical-per-non-leaf-node.
-- Compute and persist the chosen-writer table at startup
-  (`scenario-to-rank map × scenario tree` → elected writer per
-  node per cylinder).
-- Update writers (hub for `XBAR` / `DUALS`; xhat spokes for
-  `BEST_XHAT` / `RECENT_XHATS`; relaxed-PH spoke for
-  `RELAXED_XBAR`) to write the canonical node vector(s) instead
-  of per-scenario.
-- Update readers (every consumer of these fields) with the
-  "expand from canonical to per-scenario view" step at use time.
-- Tests: existing functionality must still pass with default
-  (equal-rank) configuration.  This phase is self-contained: it
-  lands on `main` and yields immediate storage/bandwidth savings
-  even before flexible ranks ship.
+There is **no canonicalization phase** in this design.  The rename that
+the first pass bundled into "Phase 0" has already landed separately.
 
 **Phase 1: Infrastructure**
 
-- Implement the overlap map computation (given per-cylinder rank
-  counts and scenario lists, produce `OverlapSegment` lists).
+- Implement overlap-map computation (per-cylinder rank counts +
+  scenario lists → `OverlapSegment` lists).
 - Add partial-read support to `SPWindow.get()`.
-- Add rank ratio fields to spoke dicts and `WheelSpinner`.
-- Modify rank partitioning in `WheelSpinner` to support unequal
-  cylinder sizes.
-- Unit tests for overlap maps with various rank count combinations.
+- Add rank-ratio fields to spoke dicts and `WheelSpinner`, plus the
+  apportionment algorithm.
+- Modify rank partitioning in `WheelSpinner` for unequal cylinder
+  sizes.
+- Unit tests for the apportionment algorithm and for overlap maps with
+  various rank-count combinations (including the equal-rank identity
+  case).
 
 **Phase 2: Communication layer**
 
-- Replace `strata_comm`-based buffer layout exchange with
-  `fullcomm`-based exchange.
+- Replace the `strata_comm`-based layout exchange with a
+  `fullcomm`-based or locally-computed layout (Option D).
 - Implement multi-source `get_receive_buffer()` using overlap maps.
-- Relax `_validate_recv_field()` to check per-segment instead of
-  total.
-- Test with simple cases: hub with 4 ranks, Lagrangian spoke with 2
-  ranks.
+- Relax `_validate_recv_field()` to per-segment validation.
+- Test the relaxed-coherence per-scenario fields first (`NONANTS_VALS`)
+  with a simple case: hub with 4 ranks, Lagrangian spoke with 2 ranks.
 
-**Phase 3: Integration and testing**
+**Phase 3: Coherence policy and integration**
 
-- Wire up the rank ratio CLI options.
-- Auto-disable for cylinders that cannot support asymmetric ranks
-  (if any).
-- Test all spoke types with various ratios.
-- Performance benchmarks: does 8+4+2 outperform 5+5+5 for a given
+- Implement the per-field strict-vs-relaxed reader paths.
+- Add the strict `write_id` check for `DUALS`.
+- Add single-source first-stage sourcing for `BEST_XHAT` /
+  `RECENT_XHATS` in the **two-stage** case; cost portion per-scenario.
+- Settle the `cross_scen` coherence question and wire it accordingly.
+- Wire up the rank-ratio CLI options end to end.
+- Test all spoke types with various ratios at two stages.
+- Performance check: does 8+4+2 beat 5+5+5 for a representative
   problem?
 
-**Phase 4: Spoke-to-spoke communication**
+**Phase 4: Multistage and FWPH**
 
-- Extend multi-source reads for spoke-to-spoke fields (FWPH reading
-  `BEST_XHAT` from an InnerBoundSpoke with different rank count).
-- Test FWPH + xhatshuffle with unequal ranks.  Under BX-2 the FWPH
-  read of `RECENT_XHATS` becomes "one Get per (circular-buffer-slot
-  × non-leaf-node)" from each slot's elected writer, with no
-  within-slot cross-source assembly.  Expected to work cleanly, but
-  warrants targeted testing since RECENT_XHATS is the most complex
-  consumer of the canonicalized layout.
+- Per-node single-source first-stage sourcing for `BEST_XHAT` /
+  `RECENT_XHATS` in the **multistage** case.
+- FWPH reading `RECENT_XHATS` from an InnerBoundSpoke with a different
+  rank count.  This is the most complex consumer of the xhat fields and
+  warrants targeted testing.
 
 **Phase 5: APH support**
 
-- Verify that APH (asynchronous PH) works correctly with the relaxed
-  write-ID coherence model.
-- Consider adding optional strict coherence (Option 1) as a flag.
+- Verify APH (asynchronous PH) works with the relaxed-coherence model.
+- The strict-coherence fields already retry on `write_id` mismatch, so
+  they should compose with async senders; verify and add tests.
+
+
+### Possible future optimization (out of scope)
+
+The first-stage portion of `BEST_XHAT` / `RECENT_XHATS` is genuinely
+NAC-redundant (the same node value copied into every scenario's slot).
+A future optimization could store it once per non-leaf node instead of
+once per scenario, saving storage and bandwidth on those fields.  This
+is *only* valid for the Category-2 fields — never for the Category-1
+per-scenario fields — and is explicitly **not** required for flexible
+ranks.  It is recorded here so the idea is not lost, not as planned
+work.
 
 
 ### Backward Compatibility
 
 When all rank ratios are 1.0 (the default), the system must behave
-identically to the current implementation *at the algorithm level*.
-The overlap maps degenerate to single-segment identity mappings, and
-multi-source reads become single-source reads.  This should be
-verified by running the full existing test suite with the new code
-and default ratios.
-
-Note that Phase 0 (BN-2 + BX-2 canonicalization) changes the
-on-the-wire field layouts even at equal rank counts: `XBAR`,
-`RELAXED_XBAR`, `BEST_XHAT`, and `RECENT_XHATS` move from
-per-scenario buffers to canonical per-non-leaf-node buffers.  Any
-external code that touches these buffers directly (rather than
-through `SPCommunicator` send/receive APIs) would break.  We
-believe no such external code exists in tree, but downstream users
-should be flagged in release notes.
-
-
-
-
-
-
-
+identically to the current implementation.  The overlap maps degenerate
+to single-segment identity mappings, multi-source reads become
+single-source reads, and the strict/relaxed coherence checks are
+satisfied trivially (one source per field).  Because this design makes
+**no field-layout changes**, the on-the-wire format is unchanged at
+equal ranks — there is no analogue of the first pass's "Phase 0 changes
+the wire format even at equal ranks" caveat.  Verify by running the
+full existing test suite with the new code and default ratios.

--- a/mpisppy/cylinders/cross_scen_spoke.py
+++ b/mpisppy/cylinders/cross_scen_spoke.py
@@ -19,7 +19,7 @@ import pyomo.environ as pyo
 class CrossScenarioCutSpoke(Spoke):
 
     send_fields = (*Spoke.send_fields, Field.CROSS_SCENARIO_CUT)
-    receive_fields = (*Spoke.receive_fields, Field.XBAR, Field.CROSS_SCENARIO_COST)
+    receive_fields = (*Spoke.receive_fields, Field.NONANTS_VALS, Field.CROSS_SCENARIO_COST)
 
     def register_send_fields(self) -> None:
 
@@ -49,7 +49,7 @@ class CrossScenarioCutSpoke(Spoke):
     def register_receive_fields(self):
         super().register_receive_fields()
 
-        nonant_ranks = self.opt.spcomm.fields_to_ranks[Field.XBAR]
+        nonant_ranks = self.opt.spcomm.fields_to_ranks[Field.NONANTS_VALS]
         cs_cost_ranks = self.opt.spcomm.fields_to_ranks[Field.CROSS_SCENARIO_COST]
 
         assert len(nonant_ranks) == 1
@@ -57,7 +57,7 @@ class CrossScenarioCutSpoke(Spoke):
         assert nonant_ranks[0] == cs_cost_ranks[0]
         source_rank = nonant_ranks[0]
 
-        self.all_nonants = self.register_recv_field(Field.XBAR, source_rank)
+        self.all_nonants = self.register_recv_field(Field.NONANTS_VALS, source_rank)
         self.all_etas = self.register_recv_field(Field.CROSS_SCENARIO_COST, source_rank)
 
     def prep_cs_cuts(self):

--- a/mpisppy/cylinders/hub.py
+++ b/mpisppy/cylinders/hub.py
@@ -212,12 +212,12 @@ class PHPrimalHub(Hub):
     spokes like Lagrangian to a specific dual (W) buffer.
     """
 
-    send_fields = (*Hub.send_fields, Field.XBAR, )
+    send_fields = (*Hub.send_fields, Field.NONANTS_VALS, )
     receive_fields = (*Hub.receive_fields,)
 
     @property
     def nonant_field(self):
-        return Field.XBAR
+        return Field.NONANTS_VALS
 
     def setup_hub(self):
         ## Generate some warnings if nothing is giving bounds
@@ -341,7 +341,7 @@ class PHHub(PHPrimalHub):
 
 class LShapedHub(Hub):
 
-    send_fields = (*Hub.send_fields, Field.XBAR,)
+    send_fields = (*Hub.send_fields, Field.NONANTS_VALS,)
     receive_fields = (*Hub.receive_fields,)
 
     def setup_hub(self):
@@ -391,7 +391,7 @@ class LShapedHub(Hub):
         """ Gather nonants and send them to the appropriate spokes
         """
         ci = 0  ## index to self.nonant_send_buffer
-        nonant_send_buffer = self.send_buffers[Field.XBAR]
+        nonant_send_buffer = self.send_buffers[Field.NONANTS_VALS]
         for k, s in self.opt.local_scenarios.items():
             nonant_to_root_var_map = s._mpisppy_model.subproblem_to_root_vars_map
             for xvar in s._mpisppy_data.nonant_indices.values():
@@ -400,7 +400,7 @@ class LShapedHub(Hub):
                 ci += 1
         logging.debug("hub is sending X nonants={}".format(nonant_send_buffer))
 
-        self.put_send_buffer(nonant_send_buffer, Field.XBAR)
+        self.put_send_buffer(nonant_send_buffer, Field.NONANTS_VALS)
 
         return
     
@@ -408,7 +408,7 @@ class LShapedHub(Hub):
 
 class CGHub(Hub):
 
-    send_fields = (*Hub.send_fields, Field.XBAR,)
+    send_fields = (*Hub.send_fields, Field.NONANTS_VALS,)
     receive_fields = (*Hub.receive_fields,Field.RECENT_XHATS, Field.XFEAS )
 
     def register_receive_fields(self):
@@ -485,7 +485,7 @@ class CGHub(Hub):
      
     @property
     def nonant_field(self):
-        return Field.XBAR 
+        return Field.NONANTS_VALS 
     
 
 class DCGHub(CGHub):

--- a/mpisppy/cylinders/relaxed_ph_spoke.py
+++ b/mpisppy/cylinders/relaxed_ph_spoke.py
@@ -14,12 +14,12 @@ import pyomo.environ as pyo
 
 class RelaxedPHSpoke(_PHDualSpokeBase):
 
-    send_fields = (*_PHDualSpokeBase.send_fields, Field.RELAXED_XBAR, )
+    send_fields = (*_PHDualSpokeBase.send_fields, Field.RELAXED_NONANTS_VALS, )
     receive_fields = (*_PHDualSpokeBase.receive_fields, )
 
     @property
     def nonant_field(self):
-        return Field.RELAXED_XBAR
+        return Field.RELAXED_NONANTS_VALS
 
     def main(self):
         # relax the integers

--- a/mpisppy/cylinders/spoke.py
+++ b/mpisppy/cylinders/spoke.py
@@ -357,7 +357,7 @@ class _BoundNonantSpoke(_BoundNonantLenSpoke):
     """
 
     def nonant_len_type(self) -> Field:
-        return Field.XBAR
+        return Field.NONANTS_VALS
 
     @property
     def localnonants(self):
@@ -383,7 +383,7 @@ class InnerBoundNonantSpoke(_BoundNonantSpoke, InnerBoundSpoke):
     """
 
     send_fields = (*InnerBoundSpoke.send_fields, )
-    receive_fields = (*InnerBoundSpoke.receive_fields, Field.XBAR)
+    receive_fields = (*InnerBoundSpoke.receive_fields, Field.NONANTS_VALS)
 
     converger_spoke_char = 'I'
 
@@ -396,7 +396,7 @@ class OuterBoundNonantSpoke(_BoundNonantSpoke):
     """
 
     send_fields = (*_BoundNonantSpoke.send_fields, Field.OBJECTIVE_OUTER_BOUND, )
-    receive_fields = (*_BoundNonantSpoke.receive_fields, Field.XBAR)
+    receive_fields = (*_BoundNonantSpoke.receive_fields, Field.NONANTS_VALS)
 
     converger_spoke_char = 'A'  # probably Lagrangian
 

--- a/mpisppy/cylinders/spwindow.py
+++ b/mpisppy/cylinders/spwindow.py
@@ -21,9 +21,9 @@ import pyomo.environ as pyo
 
 class Field(enum.IntEnum):
     SHUTDOWN=-1000
-    XBAR=1
+    NONANTS_VALS=1
     DUALS=2
-    RELAXED_XBAR=3
+    RELAXED_NONANTS_VALS=3
     BEST_OBJECTIVE_BOUNDS=100 # Both inner and outer bounds from the hub. Layout: [OUTER INNER ID]
     OBJECTIVE_INNER_BOUND=101
     OBJECTIVE_OUTER_BOUND=102
@@ -50,9 +50,9 @@ field_length_components.total_number_recent_xhats = pyo.Param(mutable=True, init
 
 _field_lengths = {
         Field.SHUTDOWN : 1,
-        Field.XBAR : field_length_components._local_nonant_length,
+        Field.NONANTS_VALS : field_length_components._local_nonant_length,
         Field.DUALS : field_length_components._local_nonant_length,
-        Field.RELAXED_XBAR : field_length_components._local_nonant_length,
+        Field.RELAXED_NONANTS_VALS : field_length_components._local_nonant_length,
         Field.BEST_OBJECTIVE_BOUNDS : 2,
         Field.OBJECTIVE_INNER_BOUND : 1,
         Field.OBJECTIVE_OUTER_BOUND : 1,

--- a/mpisppy/debug_utils/buffer_inspect.py
+++ b/mpisppy/debug_utils/buffer_inspect.py
@@ -241,7 +241,7 @@ def _check_shutdown(buf, report: Report, ctx: InspectContext) -> None:
 
 
 def _check_nonant(buf, report: Report, ctx: InspectContext) -> None:
-    # XBAR buffers are sized to the *publisher's* sum of per-scenario
+    # NONANTS_VALS buffers are sized to the *publisher's* sum of per-scenario
     # nonant counts across that publisher's local scenarios:
     #     len(data) == nonant_count * len(publisher.local_scenarios).
     # When the publisher holds many scenarios (e.g. all 24 leaves of a
@@ -255,7 +255,7 @@ def _check_nonant(buf, report: Report, ctx: InspectContext) -> None:
     n = ctx.get_nonant_count()
     if n is not None and n > 0 and (len(data) == 0 or len(data) % n != 0):
         report.add(
-            f"XBAR data length {len(data)} is not a positive multiple "
+            f"NONANTS_VALS data length {len(data)} is not a positive multiple "
             f"of nonant_count {n}",
             severity="error",
         )
@@ -269,7 +269,7 @@ def _check_nonant(buf, report: Report, ctx: InspectContext) -> None:
         bad = np.where(data < lo)[0]
         if bad.size:
             report.add(
-                f"XBAR below lower bound at {bad.size} index(es); "
+                f"NONANTS_VALS below lower bound at {bad.size} index(es); "
                 f"first: idx {int(bad[0])} value {float(data[bad[0]])!r} "
                 f"< lo {float(lo[bad[0]])!r}"
             )
@@ -277,7 +277,7 @@ def _check_nonant(buf, report: Report, ctx: InspectContext) -> None:
         bad = np.where(data > hi)[0]
         if bad.size:
             report.add(
-                f"XBAR above upper bound at {bad.size} index(es); "
+                f"NONANTS_VALS above upper bound at {bad.size} index(es); "
                 f"first: idx {int(bad[0])} value {float(data[bad[0]])!r} "
                 f"> hi {float(hi[bad[0]])!r}"
             )
@@ -375,7 +375,7 @@ def _check_best_xhat(buf, report: Report, ctx: InspectContext) -> None:
 
 CHECKERS: dict[Field, Callable[[Any, Report, InspectContext], None]] = {
     Field.SHUTDOWN: _check_shutdown,
-    Field.XBAR: _check_nonant,
+    Field.NONANTS_VALS: _check_nonant,
     Field.NONANT_LOWER_BOUNDS: _check_lower_bounds,
     Field.NONANT_UPPER_BOUNDS: _check_upper_bounds,
     Field.OBJECTIVE_INNER_BOUND: _check_objective_scalar,

--- a/mpisppy/extensions/cross_scen_extension.py
+++ b/mpisppy/extensions/cross_scen_extension.py
@@ -150,7 +150,7 @@ class CrossScenarioExtension(Extension):
                 ## End for
             ## End for
 
-            self.opt.spcomm.put_send_buffer(all_nonants, Field.XBAR)
+            self.opt.spcomm.put_send_buffer(all_nonants, Field.NONANTS_VALS)
 
         ## End if
 
@@ -229,11 +229,11 @@ class CrossScenarioExtension(Extension):
         spcomm = self.opt.spcomm
         nscen = len(self.opt.all_scenario_names)
         local_scen_count = len(self.opt.local_scenario_names)
-        if spcomm.is_send_field_registered(Field.XBAR):
+        if spcomm.is_send_field_registered(Field.NONANTS_VALS):
             self.send_nonants = False
         else:
             self.all_nonants = spcomm.register_send_field(
-                Field.XBAR,
+                Field.NONANTS_VALS,
                 local_scen_count * self.opt.nonant_length
             )
             self.send_nonants = True

--- a/mpisppy/extensions/relaxed_ph_fixer.py
+++ b/mpisppy/extensions/relaxed_ph_fixer.py
@@ -39,20 +39,20 @@ class RelaxedPHFixer(Extension):
     def iter0_post_solver_creation(self):
         # wait for relaxed iter0:
         if self.relaxed_nonant_buf.id() == 0:
-            while not self.opt.spcomm.get_receive_buffer(self.relaxed_nonant_buf, Field.RELAXED_XBAR, self.relaxed_ph_spoke_index):
+            while not self.opt.spcomm.get_receive_buffer(self.relaxed_nonant_buf, Field.RELAXED_NONANTS_VALS, self.relaxed_ph_spoke_index):
                 continue
         self.relaxed_ph_fixing(self.relaxed_nonant_buf.value_array(), pre_iter0=True)
 
     def register_receive_fields(self):
         spcomm = self.opt.spcomm
-        relaxed_ph_ranks = spcomm.fields_to_ranks[Field.RELAXED_XBAR]
+        relaxed_ph_ranks = spcomm.fields_to_ranks[Field.RELAXED_NONANTS_VALS]
         assert len(relaxed_ph_ranks) == 1
         index = relaxed_ph_ranks[0]
 
         self.relaxed_ph_spoke_index = index
 
         self.relaxed_nonant_buf = spcomm.register_recv_field(
-            Field.RELAXED_XBAR,
+            Field.RELAXED_NONANTS_VALS,
             self.relaxed_ph_spoke_index,
         )
 
@@ -61,7 +61,7 @@ class RelaxedPHFixer(Extension):
     def miditer(self):
         self.opt.spcomm.get_receive_buffer(
             self.relaxed_nonant_buf,
-            Field.RELAXED_XBAR,
+            Field.RELAXED_NONANTS_VALS,
             self.relaxed_ph_spoke_index,
         )
         self.relaxed_ph_fixing(self.relaxed_nonant_buf.value_array(), pre_iter0=False)

--- a/mpisppy/tests/test_buffer_inspect.py
+++ b/mpisppy/tests/test_buffer_inspect.py
@@ -41,41 +41,41 @@ class TestGenericChecks(unittest.TestCase):
 
     def test_fresh_send_buffer_passes(self):
         buf = SendArray(5)
-        rep = inspect_buffer(buf, Field.XBAR,
+        rep = inspect_buffer(buf, Field.NONANTS_VALS,
                              ctx=InspectContext(nonant_count=5), send=True)
         self.assertTrue(rep.ok, msg=str(rep))
 
     def test_fresh_recv_buffer_passes(self):
         buf = RecvArray(5)
-        rep = inspect_buffer(buf, Field.XBAR,
+        rep = inspect_buffer(buf, Field.NONANTS_VALS,
                              ctx=InspectContext(nonant_count=5), send=False)
         self.assertTrue(rep.ok, msg=str(rep))
 
     def test_padding_overrun_detected(self):
         buf = RecvArray(2)
         buf._full_array[5] = 42.0   # write into padding region
-        rep = inspect_buffer(buf, Field.XBAR, send=False)
+        rep = inspect_buffer(buf, Field.NONANTS_VALS, send=False)
         self.assertFalse(rep.ok)
         self.assertTrue(any("padding region modified" in f for f in rep.findings))
 
     def test_write_id_must_be_integer_valued(self):
         buf = RecvArray(1)
         buf._array[-1] = 3.5
-        rep = inspect_buffer(buf, Field.XBAR, send=False)
+        rep = inspect_buffer(buf, Field.NONANTS_VALS, send=False)
         self.assertFalse(rep.ok)
         self.assertTrue(any("not integer-valued" in f for f in rep.findings))
 
     def test_write_id_must_be_finite(self):
         buf = RecvArray(1)
         buf._array[-1] = np.inf
-        rep = inspect_buffer(buf, Field.XBAR, send=False)
+        rep = inspect_buffer(buf, Field.NONANTS_VALS, send=False)
         self.assertFalse(rep.ok)
         self.assertTrue(any("non-finite" in f for f in rep.findings))
 
     def test_write_id_must_be_non_negative(self):
         buf = RecvArray(1)
         buf._array[-1] = -2.0
-        rep = inspect_buffer(buf, Field.XBAR, send=False)
+        rep = inspect_buffer(buf, Field.NONANTS_VALS, send=False)
         self.assertFalse(rep.ok)
         self.assertTrue(any("negative" in f for f in rep.findings))
 
@@ -84,7 +84,7 @@ class TestGenericChecks(unittest.TestCase):
         _publish(buf, [1.0, 2.0, 3.0])
         # Tamper with the trailing slot post-publish
         buf._array[-1] = 99.0
-        rep = inspect_buffer(buf, Field.XBAR, send=True)
+        rep = inspect_buffer(buf, Field.NONANTS_VALS, send=True)
         self.assertFalse(rep.ok)
         self.assertTrue(any("!= buf.id()" in f for f in rep.findings))
 
@@ -117,7 +117,7 @@ class TestGenericChecks(unittest.TestCase):
     def test_nan_in_data_after_publish_is_finding(self):
         buf = SendArray(3)
         buf._next_write_id()    # publish without setting values: data stays NaN
-        rep = inspect_buffer(buf, Field.XBAR,
+        rep = inspect_buffer(buf, Field.NONANTS_VALS,
                              ctx=InspectContext(nonant_count=3), send=True)
         self.assertFalse(rep.ok)
         self.assertTrue(any("contains NaN" in f for f in rep.findings))
@@ -128,7 +128,7 @@ class TestGenericChecks(unittest.TestCase):
         buf[1] = np.inf
         buf[2] = 3.0
         buf._next_write_id()
-        rep = inspect_buffer(buf, Field.XBAR,
+        rep = inspect_buffer(buf, Field.NONANTS_VALS,
                              ctx=InspectContext(nonant_count=3), send=True)
         self.assertFalse(rep.ok)
         self.assertTrue(any("contains inf" in f for f in rep.findings))
@@ -185,7 +185,7 @@ class TestNonantChecks(unittest.TestCase):
     def test_length_mismatch_via_explicit_count(self):
         buf = SendArray(5)
         _publish(buf, [0.0] * 5)
-        rep = inspect_buffer(buf, Field.XBAR,
+        rep = inspect_buffer(buf, Field.NONANTS_VALS,
                              ctx=InspectContext(nonant_count=7), send=True)
         self.assertFalse(rep.ok)
         self.assertTrue(any("data length 5" in f for f in rep.findings))
@@ -194,7 +194,7 @@ class TestNonantChecks(unittest.TestCase):
         buf = SendArray(5)
         _publish(buf, [0.0] * 5)
         ctx = InspectContext(spbase=_FakeSP(nonant_length=7))
-        rep = inspect_buffer(buf, Field.XBAR, ctx=ctx, send=True)
+        rep = inspect_buffer(buf, Field.NONANTS_VALS, ctx=ctx, send=True)
         self.assertFalse(rep.ok)
         self.assertTrue(any("data length 5" in f for f in rep.findings))
 
@@ -202,22 +202,22 @@ class TestNonantChecks(unittest.TestCase):
         buf = SendArray(5)
         _publish(buf, [0.0] * 5)
         ctx = InspectContext(nonant_count=5, spbase=_FakeSP(nonant_length=7))
-        rep = inspect_buffer(buf, Field.XBAR, ctx=ctx, send=True)
+        rep = inspect_buffer(buf, Field.NONANTS_VALS, ctx=ctx, send=True)
         self.assertTrue(rep.ok, msg=str(rep))
 
     def test_multi_scenario_buffer_passes(self):
-        # Publisher with K scenarios publishes a XBAR buffer of length
+        # Publisher with K scenarios publishes a NONANTS_VALS buffer of length
         # nonant_count * K. The checker must accept any positive multiple.
         buf = SendArray(24)  # e.g., 4 scenarios * 6 nonants
         _publish(buf, [0.0] * 24)
-        rep = inspect_buffer(buf, Field.XBAR,
+        rep = inspect_buffer(buf, Field.NONANTS_VALS,
                              ctx=InspectContext(nonant_count=6), send=True)
         self.assertTrue(rep.ok, msg=str(rep))
 
     def test_non_multiple_length_caught(self):
         buf = SendArray(10)  # 10 is not a multiple of 6
         _publish(buf, [0.0] * 10)
-        rep = inspect_buffer(buf, Field.XBAR,
+        rep = inspect_buffer(buf, Field.NONANTS_VALS,
                              ctx=InspectContext(nonant_count=6), send=True)
         self.assertFalse(rep.ok)
         self.assertTrue(any("not a positive multiple" in f for f in rep.findings))
@@ -227,7 +227,7 @@ class TestNonantChecks(unittest.TestCase):
         _publish(buf, [0.5, 7.0, 2.0, -1.0])
         lo = np.array([0.0, 0.0, 0.0, 0.0])
         hi = np.array([5.0, 5.0, 5.0, 5.0])
-        rep = inspect_buffer(buf, Field.XBAR,
+        rep = inspect_buffer(buf, Field.NONANTS_VALS,
                              ctx=InspectContext(nonant_count=4,
                                                 nonant_lower=lo,
                                                 nonant_upper=hi),
@@ -241,7 +241,7 @@ class TestNonantChecks(unittest.TestCase):
         buf = SendArray(3)
         lo = np.array([0.0, 0.0, 0.0])
         hi = np.array([1.0, 1.0, 1.0])
-        rep = inspect_buffer(buf, Field.XBAR,
+        rep = inspect_buffer(buf, Field.NONANTS_VALS,
                              ctx=InspectContext(nonant_count=3,
                                                 nonant_lower=lo,
                                                 nonant_upper=hi),
@@ -468,7 +468,7 @@ class TestSpokeGotKillSignalWarning(unittest.TestCase):
         self.assertTrue(fired)
 
     def test_sweep_inspects_every_buffer(self):
-        # SHUTDOWN legit + healthy XBAR recv + healthy XBAR send: no warnings.
+        # SHUTDOWN legit + healthy NONANTS_VALS recv + healthy NONANTS_VALS send: no warnings.
         # Then add a stomped OBJECTIVE_INNER_BOUND recv: exactly one warning,
         # naming that field.
         good_shutdown = RecvArray(1)
@@ -490,10 +490,10 @@ class TestSpokeGotKillSignalWarning(unittest.TestCase):
         bad_inner._full_array[3] = 7.0  # write into padding region
 
         extra_recv = {
-            (Field.XBAR, 1): good_nonant_recv,
+            (Field.NONANTS_VALS, 1): good_nonant_recv,
             (Field.OBJECTIVE_INNER_BOUND, 1): bad_inner,
         }
-        send = {Field.XBAR: good_nonant_send}
+        send = {Field.NONANTS_VALS: good_nonant_send}
         stub = _make_spoke_stub(
             good_shutdown,
             inspect_on=True,
@@ -543,11 +543,11 @@ class TestSpokeGotKillSignalWarning(unittest.TestCase):
             good_shutdown,
             inspect_on=True,
             extra_recv={
-                (Field.XBAR, 1): good_nonant_recv,
+                (Field.NONANTS_VALS, 1): good_nonant_recv,
                 (Field.OBJECTIVE_INNER_BOUND, 1): good_inner_recv,
             },
             send={
-                Field.XBAR: good_nonant_send,
+                Field.NONANTS_VALS: good_nonant_send,
                 Field.OBJECTIVE_OUTER_BOUND: good_outer_send,
             },
             nonant_length=3,


### PR DESCRIPTION
Follow-up to #723, which renamed `Field.NONANT -> XBAR`. That name was
**wrong**: the field does not carry `xbar`. This PR fixes the name and
rewrites the design doc that was built on the bad premise.

## Commit 1 — rename `XBAR -> NONANTS_VALS`

### What the field actually holds

Per-scenario **nonant Var values**. The hub packs `xvar._value` for each
scenario's `nonant_indices`, looping over `local_scenarios`
(`hub.py` `send_nonants`). Consumers rely on these being per-scenario
**distinct**:

- `slam_heuristic.py` reshapes the buffer to `(num_scen, num_vars)` and
  takes min/max **across scenarios**;
- `cross_scen_spoke.py` sums the values **across scenarios**;
- the xhat loopers (`xhatlooper`, `xhatshufflelooper`) try **each
  scenario's** first-stage solution as a candidate xhat.

`xbar` (the probability-weighted consensus) is a *separate* quantity,
stored in the `xbars` Param (`phbase.py`); it equals these values only
at convergence.

### The rename

- `Field.XBAR -> Field.NONANTS_VALS`
- `Field.RELAXED_XBAR -> Field.RELAXED_NONANTS_VALS`

Pure rename, no behavior change. Lowercase `xbar`/`xbars` (the genuine
consensus Param) are untouched.

## Commit 2 — rewrite `doc/designs/flexible_rank_assignments.md`

The first pass of that design doc assumed the field was `xbar` and
proposed collapsing it to one vector per node ("BN-2/BX-2"
canonicalization). Since that premise is false, the doc is rewritten:

- New **Field Taxonomy** section grounded in the actual write/consume
  sites.
- **Canonicalization dropped entirely.** All local-sized fields use one
  uniform mechanism (overlap maps + multi-source assembly), plus a
  per-field **coherence policy** (strict for `DUALS` and the xhat
  first-stage; relaxed for the per-scenario nonant fields; `cross_scen`
  flagged as an open item).
- Phased plan reworked with no canonicalization prerequisite; xhat
  first-stage canonicalization noted only as a possible future
  optimization.

Status remains **Draft** — intended to keep iterating (e.g. with @bknueven).

## Verification (code)

- Touched modules import cleanly
- `ruff check` clean
- `mpisppy/tests/test_buffer_inspect.py`: 42/42 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)