### PR TITLE
flex-ranks phase 2: communication layer (unequal-rank fullcomm window + multi-source reader)

### DIFF
--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -971,6 +971,13 @@ jobs:
           cd mpisppy/tests
           mpiexec -np 2 coverage run $COV_ARGS -m mpi4py test_with_cylinders.py
 
+      - name: run flexible (unequal) rank tests
+        timeout-minutes: 10
+        run: |
+          cd mpisppy/tests
+          mpiexec -np 6 coverage run $COV_ARGS -m mpi4py test_spwindow_multisource.py
+          mpiexec -np 6 coverage run $COV_ARGS -m mpi4py test_flexible_rank_cylinders.py
+
       - name: Upload coverage data
         if: always()
         uses: actions/upload-artifact@v4

--- a/doc/designs/flexible_rank_assignments.md
+++ b/doc/designs/flexible_rank_assignments.md
@@ -373,8 +373,10 @@ window creation.  Cons:
   Because total rank counts in the thousands are a real operating
   regime here, the O(N) startup allgather and its O(N)-per-rank layout
   storage must be replaced by the two-level (or local-compute) scheme
-  **before flexible ranks are advertised as production-supported**.
-  That replacement is its own focused change — it touches only how
+  **before flexible ranks is documented or recommended for production
+  use** (it can land on `main` before then, since it is inert until a
+  non-default ratio).  That replacement is its own focused change — it
+  touches only how
   `strata_buffer_layouts` is populated at startup, not the multi-source
   reader — so it is tracked as a release-gate item rather than folded
   into the feature phases, letting it be reviewed and scale-tested on
@@ -770,19 +772,20 @@ are subtle.  If isolation is ever genuinely wanted, prefer a branch in
 the upstream repository over a separate fork -- same isolation, far less
 CI and merge friction.)
 
-**Gate reliance on the feature with an MPI CI matrix.**  There is no
-default to flip, but before the `fullcomm` path is advertised as
-supported, exercise it on at least two MPI implementations (e.g. OpenMPI
-and MPICH) and more than one mpi4py / MPI version, since that path is
-where the RMA-portability risk lives.
+**Prerequisites before the feature is recommended for production use.**
+There is no default to flip, but before the `fullcomm` path is
+documented or recommended for production use, exercise it on at least
+two MPI implementations (e.g. OpenMPI and MPICH) and more than one
+mpi4py / MPI version, since that path is where the RMA-portability risk
+lives.
 
-The same advertisement gate carries the **scalable layout exchange**:
-the interim `fullcomm.allgather` (see the Option D layout-exchange note)
-must be replaced by the two-level or local-compute scheme before the
-feature is advertised as production-supported, because total rank counts
-in the thousands are a real operating regime here.  Tracked as a
-release-gate item so it lands before scale use without gating the
-feature phases on it.
+The same "finish before recommending it" list carries the **scalable
+layout exchange**: the interim `fullcomm.allgather` (see the Option D
+layout-exchange note) must be replaced by the two-level or local-compute
+scheme before the feature is documented or recommended for production
+use, because total rank counts in the thousands are a real operating
+regime here.  Both are prerequisites for recommending the feature, not
+for landing the intervening phases on `main`.
 
 
 ### Possible future optimization (out of scope)

--- a/doc/designs/flexible_rank_assignments.md
+++ b/doc/designs/flexible_rank_assignments.md
@@ -363,6 +363,23 @@ window creation.  Cons:
   over one anchor rank per cylinder — rather than a single
   `fullcomm.allgather`, which scales worse at N=thousands.
 
+  *What the communication-layer cut actually ships, and the release
+  gate.*  The first cut uses a single `fullcomm.allgather` for the
+  unequal-rank layout exchange.  This is deliberate but interim: it is
+  effectively zero new code (the existing `SPWindow` exchange run on
+  `fullcomm` instead of `strata_comm`), it is a one-time *startup* cost
+  on a cold path — not the RMA hot path — and at development/test scale
+  (a handful of ranks) it is free.  It is **not** the end state.
+  Because total rank counts in the thousands are a real operating
+  regime here, the O(N) startup allgather and its O(N)-per-rank layout
+  storage must be replaced by the two-level (or local-compute) scheme
+  **before flexible ranks are advertised as production-supported**.
+  That replacement is its own focused change — it touches only how
+  `strata_buffer_layouts` is populated at startup, not the multi-source
+  reader — so it is tracked as a release-gate item rather than folded
+  into the feature phases, letting it be reviewed and scale-tested on
+  its own.  See §Gate reliance on the feature with an MPI CI matrix.
+
   *Lock granularity.*  `MPI_Win_lock(rank=target, ...)` is per-
   target-rank in the MPI spec, not per-window — a writer's exclusive
   lock on its own buffer does not block readers fetching from a
@@ -632,9 +649,12 @@ the first pass bundled into "Phase 0" has already landed separately.
 **Phase 2: Communication layer** (additive; reached only when a ratio
 differs from 1.0)
 
-- Add a `fullcomm`-based or locally-computed layout exchange for the
-  unequal-rank path (Option D's addressing), *alongside* the existing
+- Add the `fullcomm.allgather` layout exchange for the unequal-rank
+  path (Option D's addressing), *alongside* the existing
   `strata_comm`-based exchange, which the equal-rank path keeps using.
+  This is the interim exchange; the scalable replacement is a release
+  gate, not a feature phase (see the Option D layout-exchange note and
+  §Gate reliance on the feature with an MPI CI matrix).
 - Implement multi-source `get_receive_buffer()` using overlap maps, as
   a path taken only under non-default ratios; the single-source reader
   is unchanged for the equal-rank case.
@@ -755,6 +775,14 @@ default to flip, but before the `fullcomm` path is advertised as
 supported, exercise it on at least two MPI implementations (e.g. OpenMPI
 and MPICH) and more than one mpi4py / MPI version, since that path is
 where the RMA-portability risk lives.
+
+The same advertisement gate carries the **scalable layout exchange**:
+the interim `fullcomm.allgather` (see the Option D layout-exchange note)
+must be replaced by the two-level or local-compute scheme before the
+feature is advertised as production-supported, because total rank counts
+in the thousands are a real operating regime here.  Tracked as a
+release-gate item so it lands before scale use without gating the
+feature phases on it.
 
 
 ### Possible future optimization (out of scope)

--- a/mpisppy/cylinders/spcommunicator.py
+++ b/mpisppy/cylinders/spcommunicator.py
@@ -536,6 +536,42 @@ class SPCommunicator:
         self.window.put(buf.window_array(), field)
         return
 
+    def _write_ids_agree(self, new_id: int, synchronize: bool) -> bool:
+        """Cross-rank write_id agreement on ``cylinder_comm`` (shared by every
+        reader: the equal-rank path and both unequal-rank helpers).
+
+        Consumers that run collectives on freshly-received data (Eobjective
+        Allreduce, ROOT bcast, ...) must enter them in lockstep, so every reader
+        rank has to agree on whether a read is "new". A synchronous writer
+        stamps all of its ranks at one write_id, so when ids agree every rank
+        computes the same answer; a transient mixed-id read (the writer Put
+        between two readers' Gets) fails here and is rejected, to be retried,
+        rather than accepted out of lockstep.
+
+        Returns True if not synchronizing, or if all ranks read the same id.
+        """
+        if not synchronize:
+            return True
+        local_val = np.array((new_id,), 'i')
+        sum_ids = np.zeros(1, 'i')
+        self.cylinder_comm.Allreduce((local_val, MPI.INT),
+                                     (sum_ids, MPI.INT),
+                                     op=MPI.SUM)
+        return new_id * self.cylinder_comm.size == sum_ids[0]
+
+    def _mark_new(self, buf: RecvArray, new_id: int) -> bool:
+        """Commit an accepted read: stamp ``new_id`` into the buffer's id slot
+        and mark it new. The data itself must already be in ``buf`` (placed by
+        the caller's single Get, or by overlap-map assembly for a multi-source
+        read). Writing the id slot before ``_pull_id`` lets the multi-source
+        path -- whose assembly fills only the data region -- reuse the same
+        commit as the single-source/equal-rank paths.
+        """
+        buf._is_new = True
+        buf._array[-1] = new_id
+        buf._pull_id()
+        return True
+
     def get_receive_buffer(self,
                            buf: RecvArray,
                            field: Field,
@@ -576,23 +612,15 @@ class SPCommunicator:
 
         new_id = int(buf.array()[-1])  # logical view
 
-        if synchronize:
-            local_val = np.array((new_id,), 'i')
-            sum_ids = np.zeros(1, 'i')
-            self.cylinder_comm.Allreduce((local_val, MPI.INT),
-                                         (sum_ids, MPI.INT),
-                                         op=MPI.SUM)
-            if new_id * self.cylinder_comm.size != sum_ids[0]:
-                buf._is_new = False
-                return False
-
-        if new_id > last_id:
-            buf._is_new = True
-            buf._pull_id()
-            return True
-        else:
+        if not self._write_ids_agree(new_id, synchronize):
             buf._is_new = False
             return False
+
+        if new_id > last_id:
+            # data is already in buf from the Get above
+            return self._mark_new(buf, new_id)
+        buf._is_new = False
+        return False
 
     # ------------------------------------------------------------------
     # Unequal-rank (Option D) helpers. These are reached only when
@@ -632,6 +660,12 @@ class SPCommunicator:
             )
         _, logical_len, _ = layout[field]
         remote_data_len = logical_len - 1  # exclude the trailing write_id slot
+        # The segment occupies the half-open remote range
+        # [remote_offset, remote_offset + count); the guard is an overrun
+        # check on its exclusive end, so '>' (ending exactly at remote_data_len
+        # is legal) and remote_offset belongs in the LHS (a segment may start
+        # mid-buffer). A reader needing only a subset of a source's scenarios
+        # legitimately ends before remote_data_len, so this is not '!='.
         if seg.remote_offset + seg.count > remote_data_len:
             raise RuntimeError(
                 f"{self.__class__.__name__}: overlap segment for {field} reads "
@@ -670,19 +704,12 @@ class SPCommunicator:
         last_id = buf.id()
         self.window.get(buf.window_array(), window_rank, field)
         new_id = int(buf.array()[-1])
-        if synchronize:
-            local_val = np.array((new_id,), 'i')
-            sum_ids = np.zeros(1, 'i')
-            self.cylinder_comm.Allreduce((local_val, MPI.INT),
-                                         (sum_ids, MPI.INT),
-                                         op=MPI.SUM)
-            if new_id * self.cylinder_comm.size != sum_ids[0]:
-                buf._is_new = False
-                return False
+        if not self._write_ids_agree(new_id, synchronize):
+            buf._is_new = False
+            return False
         if new_id > last_id:
-            buf._is_new = True
-            buf._pull_id()
-            return True
+            # data is already in buf from the Get above
+            return self._mark_new(buf, new_id)
         buf._is_new = False
         return False
 
@@ -690,19 +717,13 @@ class SPCommunicator:
         """Assemble a per-scenario field from several of a peer cylinder's
         global ranks using the precomputed overlap map.
 
-        Coherence note. Consumers that read a per-scenario field across a
-        cylinder (e.g. xhatshufflelooper_bounder) require every reader rank to
-        agree on whether the data is "new", because the collectives they run on
-        the new data (Eobjective Allreduce, ROOT bcast, ...) must be entered in
-        lockstep on cylinder_comm. So this mirrors the equal-rank reader's
-        cross-rank write_id agreement rather than accepting each source
-        independently: this rank's id is the coherent floor over its sources
-        (a synchronous hub writes all its ranks at one id, so every reader
-        computes the same value and they proceed together); a transient
-        mixed-id read fails the agreement check and is retried, never accepted
-        out of lockstep. (Per-source relaxed acceptance, which would need
-        consumer cooperation, and strict per-field policies such as DUALS are
-        later phases.)
+        Coherence note. This rank's id is the coherent floor (min) over its
+        sources rather than per-source independent acceptance: a synchronous
+        hub writes all its ranks at one id, so every reader computes the same
+        value and then clears the shared _write_ids_agree check together; a
+        transient mixed-id read floors low, fails agreement, and is retried.
+        (Per-source relaxed acceptance, which would need consumer cooperation,
+        and strict per-field policies such as DUALS are later phases.)
         """
         if synchronize:
             self.cylinder_comm.Barrier()
@@ -728,26 +749,19 @@ class SPCommunicator:
         if new_id is None:
             new_id = 0
 
-        if synchronize:
-            local_val = np.array((new_id,), 'i')
-            sum_ids = np.zeros(1, 'i')
-            self.cylinder_comm.Allreduce((local_val, MPI.INT),
-                                         (sum_ids, MPI.INT),
-                                         op=MPI.SUM)
-            if new_id * self.cylinder_comm.size != sum_ids[0]:
-                buf._is_new = False
-                return False
+        if not self._write_ids_agree(new_id, synchronize):
+            buf._is_new = False
+            return False
 
         if new_id > last_id:
+            # assemble the accepted data into buf, then commit via the shared
+            # _mark_new (which stamps the id slot the assembly does not touch)
             data_view = buf.value_array()
             for seg in self.overlap_maps[(field, peer_cylinder)]:
                 snapshot = source_snapshots[seg.remote_rank]
                 data_view[seg.local_offset : seg.local_offset + seg.count] = \
                     snapshot[seg.remote_offset : seg.remote_offset + seg.count]
-            buf._is_new = True
-            buf._id = new_id
-            buf._array[-1] = new_id
-            return True
+            return self._mark_new(buf, new_id)
         buf._is_new = False
         return False
 

--- a/mpisppy/cylinders/spcommunicator.py
+++ b/mpisppy/cylinders/spcommunicator.py
@@ -27,8 +27,30 @@ from math import inf
 
 from mpisppy import MPI, global_toc
 from mpisppy.cylinders.spwindow import Field, FieldLengths, SPWindow, padded_len_n_doubles
+from mpisppy.cylinders.overlap_map import compute_overlap_segments
+from mpisppy.utils.rank_apportionment import (
+    apportion_ranks,
+    cylinder_bases,
+    rank_to_cylinder,
+)
 
 logger = logging.getLogger(__name__)
+
+# Fields whose buffer length is the same on every rank (global-sized) or a
+# fixed-size record (scalar): Categories 3 and 4 in the design doc. Under
+# unequal rank counts these are read single-source from the publishing
+# cylinder's base rank -- there is nothing to assemble. Every other field is
+# local-sized / per-scenario (Categories 1 and 2) and is read via the
+# overlap-map multi-source path.
+_GLOBAL_OR_SCALAR_FIELDS = frozenset((
+    Field.SHUTDOWN,
+    Field.OBJECTIVE_INNER_BOUND,
+    Field.OBJECTIVE_OUTER_BOUND,
+    Field.BEST_OBJECTIVE_BOUNDS,
+    Field.NONANT_LOWER_BOUNDS,
+    Field.NONANT_UPPER_BOUNDS,
+    Field.EXPECTED_REDUCED_COST,
+))
 
 def communicator_array(data_length: int):
     """
@@ -222,11 +244,30 @@ class SPCommunicator:
         self.strata_comm = strata_comm
         self.cylinder_comm = cylinder_comm
         self.communicators = communicators
-        assert len(communicators) == strata_comm.Get_size()
         self.global_rank = fullcomm.Get_rank()
-        self.strata_rank = strata_comm.Get_rank()
         self.cylinder_rank = cylinder_comm.Get_rank()
-        self.n_spokes = strata_comm.Get_size() - 1
+
+        # Flexible rank assignments (Option D in the design doc): when
+        # strata_comm is None the cylinders have unequal rank counts, so the
+        # strata grouping is undefined and the window lives on fullcomm with
+        # peers addressed by global rank via overlap maps. The cylinder index
+        # plays the role strata_rank does on the equal path -- it indexes
+        # `communicators` and marks the hub as 0 -- so we set strata_rank to it
+        # for the code paths shared with the equal-rank case.
+        self._flex_ranks = strata_comm is None
+        if self._flex_ranks:
+            rank_ratios = [d.get("rank_ratio", 1.0) for d in communicators]
+            self.rank_counts = apportion_ranks(rank_ratios, fullcomm.Get_size())
+            self._cylinder_bases = cylinder_bases(self.rank_counts)
+            self.cylinder_index, _ = rank_to_cylinder(self.global_rank, self.rank_counts)
+            self.strata_rank = self.cylinder_index
+            self.n_spokes = len(communicators) - 1
+        else:
+            assert len(communicators) == strata_comm.Get_size()
+            self.strata_rank = strata_comm.Get_rank()
+            self.cylinder_index = self.strata_rank
+            self.n_spokes = strata_comm.Get_size() - 1
+
         self.opt = spbase_object
         self.inst_time = time.time() # For diagnostics
         if options is None:
@@ -239,6 +280,11 @@ class SPCommunicator:
         self.send_buffers = {}
         # key: Field, value: list of (strata_rank, SPComm, buffer) with that Field
         self.receive_field_spcomms = {}
+
+        # Overlap-map state for the unequal-rank path; empty on the equal path.
+        # Keyed by (field, peer_cylinder_index).
+        self.overlap_maps = {}            # -> list[OverlapSegment] (global ranks)
+        self._overlap_source_ranks = {}   # -> sorted distinct source global ranks
 
         # setup FieldLengths which calculates
         # the length of each buffer type based
@@ -290,6 +336,25 @@ class SPCommunicator:
         self.fields_to_ranks = {}
         self.ranks_to_fields = {}
 
+        if self._flex_ranks:
+            # On the unequal-rank path the window spans fullcomm, so
+            # strata_buffer_layouts is indexed by global rank. Map fields to
+            # peer *cylinder* indices instead (so downstream `origin` values
+            # stay cylinder indices, as on the equal path): every rank in a
+            # cylinder registers the same send fields, so the base rank's
+            # layout names exactly the fields that cylinder publishes.
+            for peer in range(len(self.rank_counts)):
+                if peer == self.cylinder_index:
+                    continue
+                base_layout = self.window.strata_buffer_layouts[self._cylinder_bases[peer]]
+                self.ranks_to_fields[peer] = []
+                for field in base_layout.keys():
+                    if field == Field.WHOLE:
+                        continue
+                    self.fields_to_ranks.setdefault(field, []).append(peer)
+                    self.ranks_to_fields[peer].append(field)
+            return
+
         for rank, buffer_layout in enumerate(self.window.strata_buffer_layouts):
             if rank == self.strata_rank:
                 continue
@@ -337,7 +402,13 @@ class SPCommunicator:
             assert expected_logical_len == my_fa.logical_len()
             assert expected_padded_len == my_fa.padded_len()
         else:
-            self._validate_recv_field(field, origin, length)
+            # On the equal-rank path the remote buffer for `origin` has the
+            # same local sizing as ours, so we can validate it directly. On the
+            # unequal-rank path `origin` is a peer cylinder spanning several
+            # global ranks of differing sizes, so validation is per-segment
+            # (in _build_overlap_map) instead.
+            if not self._flex_ranks:
+                self._validate_recv_field(field, origin, length)
             my_fa = RecvArray(length)
             self.receive_buffers[key] = my_fa
         ## End if
@@ -393,7 +464,11 @@ class SPCommunicator:
         self.register_send_fields()
 
         window_spec = self._build_window_spec()
-        self.window = SPWindow(window_spec, self.strata_comm)
+        # Equal-rank: window on strata_comm (rank i of every cylinder),
+        # addressed by strata_rank. Unequal-rank: window on fullcomm,
+        # addressed by global rank via overlap maps (strata_comm is None).
+        window_comm = self.fullcomm if self._flex_ranks else self.strata_comm
+        self.window = SPWindow(window_spec, window_comm)
 
         self._create_field_rank_mappings()
         self.register_receive_fields()
@@ -410,6 +485,8 @@ class SPCommunicator:
         self.receive_buffers = {}
         self.send_buffers = {}
         self.receive_field_spcomms = {}
+        self.overlap_maps = {}
+        self._overlap_source_ranks = {}
 
         self.window.free()
 
@@ -424,6 +501,10 @@ class SPCommunicator:
 
     def register_receive_fields(self) -> None:
         # print(f"{self.__class__.__name__}: {self.receive_fields=}")
+        if self._flex_ranks:
+            # local global scenario indices held by this rank (its slice in
+            # its own cylinder's partition); used to build overlap maps
+            self._local_scen_idxs = list(self.opt._rank_slices[self.cylinder_rank])
         for field in self.receive_fields:
             # NOTE: If this list is empty after this method, it is up
             #       to the caller to raise an error. Sometimes optional
@@ -437,6 +518,12 @@ class SPCommunicator:
                 if field != Field.WHOLE and field in self.ranks_to_fields[strata_rank]:
                     buff = self.register_recv_field(field, strata_rank)
                     self.receive_field_spcomms[field].append((strata_rank, cls, buff))
+                    # On the unequal-rank path, a per-scenario (local-sized)
+                    # field is assembled from several remote buffers; precompute
+                    # its overlap map now. Global/scalar fields are read
+                    # single-source and need no map.
+                    if self._flex_ranks and field not in _GLOBAL_OR_SCALAR_FIELDS:
+                        self._build_overlap_map(field, strata_rank)
 
     def put_send_buffer(self, buf: SendArray, field: Field):
         """ Put the specified values into the specified locally-owned buffer
@@ -471,6 +558,15 @@ class SPCommunicator:
             is_new (bool): Indicates whether the "gotten" values are new,
                 based on the write_id.
         """
+        if self._flex_ranks:
+            # Unequal-rank path: `origin` is a peer cylinder index. A
+            # per-scenario field is assembled from several of that cylinder's
+            # global ranks via its overlap map; a global/scalar field is read
+            # single-source from the cylinder's base rank.
+            if (field, origin) in self.overlap_maps:
+                return self._flex_get_multi_source(buf, field, origin, synchronize)
+            return self._flex_get_single_source(buf, field, origin, synchronize)
+
         if synchronize:
             self.cylinder_comm.Barrier()
 
@@ -497,6 +593,163 @@ class SPCommunicator:
         else:
             buf._is_new = False
             return False
+
+    # ------------------------------------------------------------------
+    # Unequal-rank (Option D) helpers. These are reached only when
+    # self._flex_ranks is True; the equal-rank path above never calls them.
+    # ------------------------------------------------------------------
+
+    def _items_per_scen_for_field(self, field: Field):
+        """Number of field items each scenario contributes, indexed by global
+        scenario index, for a per-scenario field (used to build overlap maps).
+
+        For the nonant-valued fields this is the per-scenario nonant count,
+        which is uniform across scenarios in a two-stage problem
+        (``opt.nonant_length``). Other per-scenario fields (e.g. the xhat
+        circular buffers) have layouts whose multi-source assembly is deferred
+        to later phases; building an overlap map for them raises here rather
+        than silently mis-assembling.
+        """
+        if field in (Field.NONANTS_VALS, Field.RELAXED_NONANTS_VALS, Field.DUALS):
+            k = self.opt.nonant_length
+            return [k] * len(self.opt.all_scenario_names)
+        raise NotImplementedError(
+            f"multi-source assembly of {field} under unequal rank counts is "
+            f"not implemented in the communication-layer cut; only the "
+            f"per-scenario nonant fields (NONANTS_VALS, RELAXED_NONANTS_VALS, "
+            f"DUALS) are supported so far."
+        )
+
+    def _validate_segment(self, field: Field, remote_global_rank: int, seg) -> None:
+        """Check that one overlap segment fits within the remote buffer it
+        will be read from (the per-segment analogue of _validate_recv_field)."""
+        layout = self.window.strata_buffer_layouts[remote_global_rank]
+        if field not in layout:
+            raise RuntimeError(
+                f"{self.__class__.__name__} on cylinder {self.cylinder_index} "
+                f"expected {field} on global rank {remote_global_rank} but it "
+                f"is not published there."
+            )
+        _, logical_len, _ = layout[field]
+        remote_data_len = logical_len - 1  # exclude the trailing write_id slot
+        if seg.remote_offset + seg.count > remote_data_len:
+            raise RuntimeError(
+                f"{self.__class__.__name__}: overlap segment for {field} reads "
+                f"items [{seg.remote_offset}, {seg.remote_offset + seg.count}) "
+                f"from global rank {remote_global_rank} whose {field} data "
+                f"length is only {remote_data_len}."
+            )
+
+    def _build_overlap_map(self, field: Field, peer_cylinder: int) -> None:
+        """Precompute, for a per-scenario field and a peer cylinder, the list
+        of remote segments (in global-rank terms) that assemble this rank's
+        local buffer, validating each against the remote layout."""
+        base = self._cylinder_bases[peer_cylinder]
+        rc_peer = self.rank_counts[peer_cylinder]
+        # peer cylinder's scenario partition for its own rank count
+        _, peer_slices, _ = self.opt._scenario_tree.scen_names_to_ranks(rc_peer)
+        items_per_scen = self._items_per_scen_for_field(field)
+        segments = compute_overlap_segments(
+            self._local_scen_idxs, peer_slices, items_per_scen
+        )
+        for seg in segments:
+            seg.remote_rank = base + seg.remote_rank  # peer-local -> global
+            self._validate_segment(field, seg.remote_rank, seg)
+        self.overlap_maps[(field, peer_cylinder)] = segments
+        self._overlap_source_ranks[(field, peer_cylinder)] = \
+            sorted({seg.remote_rank for seg in segments})
+
+    def _flex_get_single_source(self, buf, field, peer_cylinder, synchronize):
+        """Read a global/scalar field single-source from a peer cylinder's base
+        rank. Every rank of the cylinder holds the identical value, so reading
+        the base rank is sufficient and keeps the cross-cylinder write_id
+        agreement check (every local rank reads the same remote rank)."""
+        window_rank = self._cylinder_bases[peer_cylinder]
+        if synchronize:
+            self.cylinder_comm.Barrier()
+        last_id = buf.id()
+        self.window.get(buf.window_array(), window_rank, field)
+        new_id = int(buf.array()[-1])
+        if synchronize:
+            local_val = np.array((new_id,), 'i')
+            sum_ids = np.zeros(1, 'i')
+            self.cylinder_comm.Allreduce((local_val, MPI.INT),
+                                         (sum_ids, MPI.INT),
+                                         op=MPI.SUM)
+            if new_id * self.cylinder_comm.size != sum_ids[0]:
+                buf._is_new = False
+                return False
+        if new_id > last_id:
+            buf._is_new = True
+            buf._pull_id()
+            return True
+        buf._is_new = False
+        return False
+
+    def _flex_get_multi_source(self, buf, field, peer_cylinder, synchronize):
+        """Assemble a per-scenario field from several of a peer cylinder's
+        global ranks using the precomputed overlap map.
+
+        Coherence note. Consumers that read a per-scenario field across a
+        cylinder (e.g. xhatshufflelooper_bounder) require every reader rank to
+        agree on whether the data is "new", because the collectives they run on
+        the new data (Eobjective Allreduce, ROOT bcast, ...) must be entered in
+        lockstep on cylinder_comm. So this mirrors the equal-rank reader's
+        cross-rank write_id agreement rather than accepting each source
+        independently: this rank's id is the coherent floor over its sources
+        (a synchronous hub writes all its ranks at one id, so every reader
+        computes the same value and they proceed together); a transient
+        mixed-id read fails the agreement check and is retried, never accepted
+        out of lockstep. (Per-source relaxed acceptance, which would need
+        consumer cooperation, and strict per-field policies such as DUALS are
+        later phases.)
+        """
+        if synchronize:
+            self.cylinder_comm.Barrier()
+        last_id = buf.id()
+
+        # Read each source's whole field once -- data and trailing write_id
+        # from a single atomic snapshot, exactly as the equal-rank reader does.
+        # Reading the data segment and the id in separate Gets would race the
+        # writer: the hub could Put a source between the two reads, yielding
+        # pre-write NaN data paired with a fresh id, which the gate below would
+        # then accept. One whole-field Get per source closes that window. We
+        # also defer writing into buf until the read is accepted, so a rejected
+        # (mixed-id) read never leaves stale data behind.
+        source_snapshots = {}
+        new_id = None
+        for r in self._overlap_source_ranks[(field, peer_cylinder)]:
+            _, logical_len, padded_len = self.window.strata_buffer_layouts[r][field]
+            snapshot = np.empty(padded_len, dtype="d")
+            self.window.get(snapshot, r, field)
+            source_snapshots[r] = snapshot
+            rid = int(snapshot[logical_len - 1])
+            new_id = rid if new_id is None else min(new_id, rid)
+        if new_id is None:
+            new_id = 0
+
+        if synchronize:
+            local_val = np.array((new_id,), 'i')
+            sum_ids = np.zeros(1, 'i')
+            self.cylinder_comm.Allreduce((local_val, MPI.INT),
+                                         (sum_ids, MPI.INT),
+                                         op=MPI.SUM)
+            if new_id * self.cylinder_comm.size != sum_ids[0]:
+                buf._is_new = False
+                return False
+
+        if new_id > last_id:
+            data_view = buf.value_array()
+            for seg in self.overlap_maps[(field, peer_cylinder)]:
+                snapshot = source_snapshots[seg.remote_rank]
+                data_view[seg.local_offset : seg.local_offset + seg.count] = \
+                    snapshot[seg.remote_offset : seg.remote_offset + seg.count]
+            buf._is_new = True
+            buf._id = new_id
+            buf._array[-1] = new_id
+            return True
+        buf._is_new = False
+        return False
 
     def receive_nonant_bounds(self):
         """ receive the bounds on the nonanticipative variables based on

--- a/mpisppy/spin_the_wheel.py
+++ b/mpisppy/spin_the_wheel.py
@@ -12,7 +12,7 @@ from mpisppy import haveMPI, global_toc, MPI
 
 from mpisppy.utils import nice_join
 from mpisppy.utils.sputils import first_stage_nonant_writer, scenario_tree_solution_writer
-from mpisppy.utils.rank_apportionment import apportion_ranks
+from mpisppy.utils.rank_apportionment import apportion_ranks, rank_to_cylinder
 
 class WheelSpinner:
 
@@ -104,31 +104,40 @@ class WheelSpinner:
 
         # Create the necessary communicators
         fullcomm = comm_world
+        global_rank = fullcomm.Get_rank()
 
         # Flexible rank assignments: each cylinder may request a rank ratio
-        # relative to the hub (default 1.0) via a "rank_ratio" dict key. The
-        # uniform case (all ratios 1.0) is handled exactly as before. A
-        # non-uniform request is apportioned (largest-remainder, floor of one)
-        # and reported, but building the communicators for unequal per-cylinder
-        # counts is not yet wired into the communicator/window layer.
+        # relative to the hub (default 1.0) via a "rank_ratio" dict key.
+        #
+        # Equal-rank path (all ratios 1.0, today's only case): build
+        # strata_comm and cylinder_comm with the uniform split, exactly as
+        # before.
+        #
+        # Unequal-rank path (any ratio != 1.0): apportion the rank pool into
+        # contiguous global-rank blocks, one per cylinder (largest-remainder,
+        # floor of one). The strata grouping ("rank i of every cylinder") is
+        # undefined when cylinders differ in size, so strata_comm is NOT
+        # created; strata_comm is passed as None and the communicator layer
+        # puts its window on fullcomm and addresses peers by global rank via
+        # overlap maps (Option D in doc/designs/flexible_rank_assignments.md).
+        # The cylinder index plays strata_rank's role (it selects the
+        # spcomm dict and marks the hub as 0).
         rank_ratios = [d.get("rank_ratio", 1.0) for d in communicator_list]
         if any(r != 1.0 for r in rank_ratios):
             rank_counts = apportion_ranks(rank_ratios, fullcomm.Get_size())
             global_toc(
-                f"Requested per-cylinder rank ratios {rank_ratios} -> "
-                f"rank counts {rank_counts}",
-                fullcomm.Get_rank() == 0,
+                f"Flexible rank assignment: ratios {rank_ratios} -> "
+                f"per-cylinder rank counts {rank_counts}",
+                global_rank == 0,
             )
-            raise NotImplementedError(
-                "Per-cylinder rank counts (flexible rank assignments) are not "
-                f"yet wired into the communicator layer; computed allocation "
-                f"{rank_counts}. Run with all rank_ratio == 1.0 for now."
-            )
-
-        strata_comm, cylinder_comm = _make_comms(n_spcomms, fullcomm=fullcomm)
-        strata_rank = strata_comm.Get_rank()
-        cylinder_rank = cylinder_comm.Get_rank()
-        global_rank = fullcomm.Get_rank()
+            strata_comm = None
+            cylinder_index, cylinder_rank = rank_to_cylinder(global_rank, rank_counts)
+            cylinder_comm = fullcomm.Split(key=global_rank, color=cylinder_index)
+            strata_rank = cylinder_index
+        else:
+            strata_comm, cylinder_comm = _make_comms(n_spcomms, fullcomm=fullcomm)
+            strata_rank = strata_comm.Get_rank()
+            cylinder_rank = cylinder_comm.Get_rank()
 
         spcomm_dict = communicator_list[strata_rank]
 

--- a/mpisppy/tests/test_flexible_rank_cylinders.py
+++ b/mpisppy/tests/test_flexible_rank_cylinders.py
@@ -1,0 +1,139 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+"""End-to-end integration test for the unequal-rank communication layer.
+
+Runs farmer with a PH hub and an xhatshuffle spoke at *unequal* rank counts.
+This is the clean Phase-2 case: of the local-sized per-scenario fields, only
+NONANTS_VALS crosses cylinders (hub -> spoke, multi-source assembly). The PH
+hub receives only scalar bounds back from the xhatshuffle spoke, so no DUALS
+(strict coherence) or xhat circular-buffer assembly is involved -- those are
+later phases.
+
+The xhatshuffle spoke reaches a good incumbent only if it reconstructs the
+hub's per-scenario nonant values correctly through the multi-source overlap
+assembly; a misrouted or torn read would feed it garbage candidates. We pin
+correctness two ways, both using fullcomm windows (so neither depends on the
+shared-memory-on-a-split-subcommunicator path, which some MPI builds reject):
+
+  * 4+2 vs 2+4: the same problem solved with the hub larger than the spoke and
+    vice versa. These exercise opposite asymmetry directions -- a spoke rank
+    stitching several hub buffers, and a spoke rank reading a sub-range of one
+    -- yet must reach the same inner bound. (No magic constant.)
+  * both must reach the extensive-form optimum (ground truth) within a loose
+    tolerance.
+
+mpiexec -np 6 python -m mpi4py -m pytest mpisppy/tests/test_flexible_rank_cylinders.py
+"""
+
+import unittest
+
+from mpi4py import MPI
+
+from mpisppy.utils import config
+import mpisppy.utils.cfg_vanilla as vanilla
+import mpisppy.tests.examples.farmer as farmer
+from mpisppy.spin_the_wheel import WheelSpinner
+from mpisppy.tests.utils import get_solver
+
+comm = MPI.COMM_WORLD
+
+solver_available, solver_name, persistent_available, persistent_solver_name = get_solver()
+
+# Extensive-form optimum for farmer with NUM_SCENS=10 (a deterministic LP
+# optimum, solver-independent). Regenerate with mpisppy.opt.ef.ExtensiveForm on
+# one rank if the farmer example ever changes.
+EF_OPT = -122146.70
+
+
+def _build_dicts(num_scens, max_iterations, hub_ratio, spoke_ratio):
+    # Fresh cfg/dicts per run: WheelSpinner.run mutates the dicts (key
+    # renaming) and may only run once, so each run needs its own.
+    cfg = config.Config()
+    cfg.num_scens_required()
+    cfg.popular_args()
+    cfg.two_sided_args()
+    cfg.ph_args()
+    cfg.xhatshuffle_args()
+    cfg.solver_name = solver_name
+    cfg.num_scens = num_scens
+    cfg.default_rho = 1.0
+    cfg.max_iterations = max_iterations
+    cfg.rel_gap = 1e-6
+
+    scenario_creator = farmer.scenario_creator
+    scenario_denouement = farmer.scenario_denouement
+    all_scenario_names = farmer.scenario_names_creator(num_scens)
+    scenario_creator_kwargs = farmer.kw_creator(cfg)
+    beans = (cfg, scenario_creator, scenario_denouement, all_scenario_names)
+
+    hub_dict = vanilla.ph_hub(*beans, scenario_creator_kwargs=scenario_creator_kwargs)
+    hub_dict["rank_ratio"] = hub_ratio
+
+    xhatshuffle_spoke = vanilla.xhatshuffle_spoke(
+        *beans, scenario_creator_kwargs=scenario_creator_kwargs
+    )
+    xhatshuffle_spoke["rank_ratio"] = spoke_ratio
+
+    return hub_dict, [xhatshuffle_spoke]
+
+
+def _run(num_scens, max_iterations, hub_ratio, spoke_ratio):
+    hub_dict, spoke_list = _build_dicts(
+        num_scens, max_iterations, hub_ratio, spoke_ratio
+    )
+    wheel = WheelSpinner(hub_dict, spoke_list)
+    wheel.spin()
+    # Bounds are populated on the hub ranks (strata_rank 0); broadcast the
+    # lead hub rank's values so all ranks can assert in lockstep.
+    if wheel.global_rank == 0:
+        payload = (wheel.BestInnerBound, wheel.BestOuterBound)
+    else:
+        payload = None
+    return comm.bcast(payload, root=0)
+
+
+@unittest.skipUnless(comm.size == 6, "needs exactly 6 MPI ranks")
+@unittest.skipUnless(solver_available, "no solver is available")
+class TestFlexibleRankCylinders(unittest.TestCase):
+
+    NUM_SCENS = 10
+    MAX_ITERS = 50
+
+    def test_unequal_rank_both_directions_agree_and_are_optimal(self):
+        # 4-rank hub, 2-rank spoke: each spoke rank stitches NONANTS_VALS from
+        # several hub buffers (multi-segment assembly).
+        ib_42, ob_42 = _run(self.NUM_SCENS, self.MAX_ITERS, 1.0, 0.5)
+        # 2-rank hub, 4-rank spoke: each spoke rank reads a sub-range of one
+        # hub buffer (the other asymmetry direction).
+        ib_24, ob_24 = _run(self.NUM_SCENS, self.MAX_ITERS, 1.0, 2.0)
+
+        # Finite incumbents (a torn/garbage read would give inf or error out).
+        self.assertTrue(abs(ib_42) < float("inf"))
+        self.assertTrue(abs(ib_24) < float("inf"))
+
+        # Both asymmetry directions reach the same inner bound.
+        self.assertLess(
+            abs(ib_42 - ib_24), 1e-3 * abs(ib_42),
+            msg=f"4+2 inner bound {ib_42} disagrees with 2+4 {ib_24}",
+        )
+
+        # ...and that bound is the extensive-form optimum (within 1%).
+        for ib in (ib_42, ib_24):
+            self.assertLess(
+                abs(ib - EF_OPT), 1e-2 * abs(EF_OPT),
+                msg=f"inner bound {ib} is not near the EF optimum {EF_OPT}",
+            )
+
+        # Valid bracketing for the (minimizing) farmer objective.
+        self.assertLessEqual(ob_42, ib_42 + 1e-6)
+        self.assertLessEqual(ob_24, ib_24 + 1e-6)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mpisppy/tests/test_flexible_rank_ratios.py
+++ b/mpisppy/tests/test_flexible_rank_ratios.py
@@ -71,9 +71,10 @@ class TestFlexibleRankBranch(unittest.TestCase):
         hub = _min_dict("hub", rank_ratio=1.0)
         spoke = _min_dict("spoke", rank_ratio=0.5)
         ws = WheelSpinner(hub, [spoke])
-        with self.assertRaises(Exception) as ctx:
+        # Reaching communicator construction (past the removed gate) fails on
+        # the stub's missing Split with AttributeError, not NotImplementedError.
+        with self.assertRaises(AttributeError):
             ws.run(comm_world=_StubComm(size=4))
-        self.assertNotIsInstance(ctx.exception, NotImplementedError)
 
     def test_uniform_ratios_use_equal_path(self):
         # All ratios 1.0 -> equal path; reaches _make_comms and fails on the
@@ -82,9 +83,11 @@ class TestFlexibleRankBranch(unittest.TestCase):
         hub = _min_dict("hub", rank_ratio=1.0)
         spoke = _min_dict("spoke", rank_ratio=1.0)
         ws = WheelSpinner(hub, [spoke])
-        with self.assertRaises(Exception) as ctx:
+        # Equal path reaches _make_comms and fails on the stub's missing Split
+        # with AttributeError; reaching it confirms the unequal branch was not
+        # taken and nothing raised NotImplementedError.
+        with self.assertRaises(AttributeError):
             ws.run(comm_world=_StubComm(size=2))
-        self.assertNotIsInstance(ctx.exception, NotImplementedError)
 
 
 if __name__ == "__main__":

--- a/mpisppy/tests/test_flexible_rank_ratios.py
+++ b/mpisppy/tests/test_flexible_rank_ratios.py
@@ -6,13 +6,23 @@
 # All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
 # full copyright and license information.
 ###############################################################################
-"""WheelSpinner reads per-cylinder rank_ratio dict keys and, when any is
-non-default, apportions and reports the allocation then raises (the live
-unequal-rank communicator path is not yet wired in). The uniform default
-path is exercised by the cylinder test suite, not here.
+"""WheelSpinner's flexible-rank branch (the equal-vs-unequal decision in
+``run``), exercised without MPI via a stub comm.
 
-WheelSpinner raises before any communicator is built, so a stub comm with
-just Get_size/Get_rank is enough to reach that point without MPI."""
+Phase 1 walled the unequal path off behind a NotImplementedError; the
+communication-layer cut removes that wall and builds per-cylinder
+communicators instead. These tests pin the surviving startup behavior that
+needs no MPI:
+
+  * an infeasible request (more cylinders than ranks) still errors early,
+    from apportion_ranks, before any communicator is built; and
+  * a feasible non-uniform request is no longer rejected -- it proceeds past
+    the (now removed) gate into communicator construction, where the bare
+    stub (which has no Split) fails with something *other* than
+    NotImplementedError.
+
+The full unequal path is exercised end to end by the mpiexec integration
+test; here we only need Get_size/Get_rank to drive the branch decision."""
 
 import unittest
 
@@ -20,7 +30,8 @@ from mpisppy.spin_the_wheel import WheelSpinner
 
 
 class _StubComm:
-    """Minimal comm: WheelSpinner only needs size and rank before it raises."""
+    """Minimal comm: the branch decision only needs size and rank. It has no
+    Split, so reaching communicator construction surfaces as AttributeError."""
     def __init__(self, size, rank=0):
         self._size = size
         self._rank = rank
@@ -33,25 +44,19 @@ class _StubComm:
 
 
 def _min_dict(role, **extra):
-    # Dicts only need the keys WheelSpinner validates before it raises;
+    # Dicts only need the keys WheelSpinner validates before the branch;
     # the classes are never instantiated on this path.
     d = {f"{role}_class": object, "opt_class": object}
     d.update(extra)
     return d
 
 
-class TestFlexibleRankRatios(unittest.TestCase):
-
-    def test_nonuniform_ratio_raises_not_implemented(self):
-        hub = _min_dict("hub", rank_ratio=1.0)
-        spoke = _min_dict("spoke", rank_ratio=0.5)
-        ws = WheelSpinner(hub, [spoke])
-        with self.assertRaises(NotImplementedError):
-            ws.run(comm_world=_StubComm(size=4))
+class TestFlexibleRankBranch(unittest.TestCase):
 
     def test_nonuniform_with_too_few_ranks_raises_value_error(self):
-        # When even the floor-of-one is infeasible, apportion_ranks raises
-        # ValueError first, before the unequal-rank NotImplementedError.
+        # Two 0.5-ratio spokes + a hub is three cylinders; with only two ranks
+        # the floor-of-one is infeasible, so apportion_ranks raises ValueError
+        # before any communicator construction is attempted.
         hub = _min_dict("hub", rank_ratio=1.0)
         spoke_a = _min_dict("spoke", rank_ratio=0.5)
         spoke_b = _min_dict("spoke", rank_ratio=0.5)
@@ -59,10 +64,21 @@ class TestFlexibleRankRatios(unittest.TestCase):
         with self.assertRaises(ValueError):
             ws.run(comm_world=_StubComm(size=2))
 
-    def test_explicit_uniform_ratios_proceed(self):
-        # All ratios 1.0 -> no unequal-rank raise; the next step (_make_comms)
-        # is reached and fails on the stub (no Split). Reaching that point at
-        # all proves WheelSpinner did not raise NotImplementedError.
+    def test_nonuniform_no_longer_raises_not_implemented(self):
+        # A feasible non-uniform request used to raise NotImplementedError.
+        # Now it proceeds to build communicators; on the bare stub (no Split)
+        # that surfaces as some other exception -- proving the gate is gone.
+        hub = _min_dict("hub", rank_ratio=1.0)
+        spoke = _min_dict("spoke", rank_ratio=0.5)
+        ws = WheelSpinner(hub, [spoke])
+        with self.assertRaises(Exception) as ctx:
+            ws.run(comm_world=_StubComm(size=4))
+        self.assertNotIsInstance(ctx.exception, NotImplementedError)
+
+    def test_uniform_ratios_use_equal_path(self):
+        # All ratios 1.0 -> equal path; reaches _make_comms and fails on the
+        # stub (no Split). Reaching that point at all confirms the unequal
+        # branch was not taken and nothing raised NotImplementedError.
         hub = _min_dict("hub", rank_ratio=1.0)
         spoke = _min_dict("spoke", rank_ratio=1.0)
         ws = WheelSpinner(hub, [spoke])

--- a/mpisppy/tests/test_rank_apportionment.py
+++ b/mpisppy/tests/test_rank_apportionment.py
@@ -6,11 +6,16 @@
 # All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
 # full copyright and license information.
 ###############################################################################
-"""Unit tests for mpisppy.utils.rank_apportionment.apportion_ranks."""
+"""Unit tests for mpisppy.utils.rank_apportionment: apportion_ranks plus the
+contiguous-block layout helpers cylinder_bases and rank_to_cylinder."""
 
 import unittest
 
-from mpisppy.utils.rank_apportionment import apportion_ranks
+from mpisppy.utils.rank_apportionment import (
+    apportion_ranks,
+    cylinder_bases,
+    rank_to_cylinder,
+)
 
 
 class TestApportionRanks(unittest.TestCase):
@@ -104,6 +109,49 @@ class TestApportionRanks(unittest.TestCase):
         a = apportion_ranks([1.0, 0.5, 0.25], 14)
         b = apportion_ranks([0.25, 0.5, 1.0], 14)
         self.assertEqual(a, list(reversed(b)))
+
+
+class TestContiguousBlockLayout(unittest.TestCase):
+    """cylinder_bases / rank_to_cylinder define the contiguous global-rank
+    block layout used by the unequal-rank path."""
+
+    def test_bases_doc_example(self):
+        # 8 / 4 / 2 -> blocks start at 0, 8, 12.
+        self.assertEqual(cylinder_bases([8, 4, 2]), [0, 8, 12])
+
+    def test_bases_single_cylinder(self):
+        self.assertEqual(cylinder_bases([5]), [0])
+
+    def test_rank_to_cylinder_doc_example(self):
+        counts = [8, 4, 2]
+        # hub block 0..7
+        self.assertEqual(rank_to_cylinder(0, counts), (0, 0))
+        self.assertEqual(rank_to_cylinder(7, counts), (0, 7))
+        # lagrangian block 8..11
+        self.assertEqual(rank_to_cylinder(8, counts), (1, 0))
+        self.assertEqual(rank_to_cylinder(11, counts), (1, 3))
+        # xhat block 12..13
+        self.assertEqual(rank_to_cylinder(12, counts), (2, 0))
+        self.assertEqual(rank_to_cylinder(13, counts), (2, 1))
+
+    def test_rank_to_cylinder_covers_every_rank(self):
+        # Every global rank maps to exactly one (cylinder, local rank), and
+        # the local ranks within a cylinder are 0..count-1 in order.
+        counts = [3, 1, 2, 4]
+        bases = cylinder_bases(counts)
+        seen = {c: [] for c in range(len(counts))}
+        for gr in range(sum(counts)):
+            cyl, local = rank_to_cylinder(gr, counts)
+            self.assertEqual(gr, bases[cyl] + local)
+            seen[cyl].append(local)
+        for cyl, count in enumerate(counts):
+            self.assertEqual(seen[cyl], list(range(count)))
+
+    def test_rank_to_cylinder_out_of_range_raises(self):
+        with self.assertRaises(ValueError):
+            rank_to_cylinder(14, [8, 4, 2])
+        with self.assertRaises(ValueError):
+            rank_to_cylinder(-1, [8, 4, 2])
 
 
 if __name__ == "__main__":

--- a/mpisppy/tests/test_spwindow_multisource.py
+++ b/mpisppy/tests/test_spwindow_multisource.py
@@ -1,0 +1,133 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+"""Low-level multi-source RMA assembly test for the unequal-rank path.
+
+This exercises the dangerous part of the communication-layer cut -- real
+passive-target one-sided RMA reads assembled from several remote ranks via
+an overlap map -- in isolation from the hub/spoke stack. It builds an
+``SPWindow`` directly on ``COMM_WORLD``, has a "writer" cylinder publish
+known per-scenario values, and has a smaller "reader" cylinder reconstruct
+its own scenarios' values with ``compute_overlap_segments`` + partial
+``SPWindow.get`` reads. A reader rank whose scenarios straddle a writer-rank
+boundary must stitch the result from two writer buffers; that is the case the
+plain single-source reader cannot handle and the multi-source path must.
+
+Run with: ``mpiexec -np 6 python -m mpi4py -m pytest <thisfile>`` (or via the
+straight_tests / coverage harness, which launches mpiexec for it).
+"""
+
+import unittest
+
+import numpy as np
+
+from mpisppy import MPI
+from mpisppy.cylinders.spwindow import Field, SPWindow, padded_len_n_doubles
+from mpisppy.cylinders.overlap_map import compute_overlap_segments
+
+fullcomm = MPI.COMM_WORLD
+global_rank = fullcomm.Get_rank()
+global_size = fullcomm.Get_size()
+
+
+def _contiguous_slices(n_scen, n_proc):
+    """Contiguous per-rank scenario partition, matching the formula used by
+    sputils._ScenTree.scen_names_to_ranks (rank -> list of global scen idxs)."""
+    avg = n_scen / n_proc
+    return [list(range(int(i * avg), int((i + 1) * avg))) for i in range(n_proc)]
+
+
+def _scen_value(scen, item):
+    """A distinct, recognizable value for (global scenario, item) so a
+    misrouted read is caught rather than silently plausible."""
+    return 1000.0 * scen + item
+
+
+@unittest.skipUnless(global_size == 6, "needs exactly 6 MPI ranks (4 writers + 2 readers)")
+class TestMultiSourceAssembly(unittest.TestCase):
+    """Ranks 0-3 are a 4-rank writer cylinder; ranks 4-5 a 2-rank reader
+    cylinder. Both cover the same N_SCEN scenarios, split differently, so a
+    reader rank reads from several writer ranks."""
+
+    N_SCEN = 10
+    WRITER_RANKS = 4   # global ranks 0..3
+    READER_RANKS = 2   # global ranks 4..5
+
+    def _run_one(self, items_per_scen_k):
+        writer_slices = _contiguous_slices(self.N_SCEN, self.WRITER_RANKS)
+        reader_slices = _contiguous_slices(self.N_SCEN, self.READER_RANKS)
+        k = items_per_scen_k
+
+        is_writer = global_rank < self.WRITER_RANKS
+
+        # Every rank builds the (collective) window. Writers publish a
+        # NONANTS_VALS-like field sized to their local scenarios; readers
+        # publish nothing and only read.
+        if is_writer:
+            my_scen = writer_slices[global_rank]
+            data_len = k * len(my_scen)
+            logical_len = data_len  # data only; no id slot needed for this test
+            padded = padded_len_n_doubles(logical_len)
+            my_fields = {Field.NONANTS_VALS: (logical_len, padded)}
+        else:
+            my_fields = {}
+
+        win = SPWindow(my_fields, fullcomm)
+
+        if is_writer:
+            padded = win.buffer_layout[Field.NONANTS_VALS][2]
+            buf = np.full(padded, np.nan, dtype="d")
+            for i, scen in enumerate(my_scen):
+                for j in range(k):
+                    buf[i * k + j] = _scen_value(scen, j)
+            win.put(buf, Field.NONANTS_VALS)
+
+        # Ensure all writer puts are visible before any reader get.
+        fullcomm.Barrier()
+
+        if not is_writer:
+            reader_local = global_rank - self.WRITER_RANKS
+            my_scen = reader_slices[reader_local]
+            segments = compute_overlap_segments(
+                my_scen, writer_slices, [k] * self.N_SCEN
+            )
+            # writer cylinder's global-rank base is 0
+            local_buf = np.full(k * len(my_scen), np.nan, dtype="d")
+            for seg in segments:
+                dest = local_buf[seg.local_offset : seg.local_offset + seg.count]
+                win.get(dest, seg.remote_rank, Field.NONANTS_VALS,
+                        item_offset=seg.remote_offset, item_count=seg.count)
+
+            expected = np.array(
+                [_scen_value(scen, j) for scen in my_scen for j in range(k)],
+                dtype="d",
+            )
+            np.testing.assert_array_equal(
+                local_buf, expected,
+                err_msg=f"{global_rank=} {k=} {my_scen=} {segments=}",
+            )
+            # A straddling reader rank must have used more than one segment.
+            if reader_local == 0:
+                self.assertGreater(
+                    len(segments), 1,
+                    "reader rank 0 spans a writer-rank boundary; expected a "
+                    "multi-segment assembly",
+                )
+
+        fullcomm.Barrier()
+        win.free()
+
+    def test_assembly_one_item_per_scenario(self):
+        self._run_one(items_per_scen_k=1)
+
+    def test_assembly_multi_item_per_scenario(self):
+        self._run_one(items_per_scen_k=3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mpisppy/tests/test_spwindow_multisource.py
+++ b/mpisppy/tests/test_spwindow_multisource.py
@@ -71,7 +71,11 @@ class TestMultiSourceAssembly(unittest.TestCase):
         if is_writer:
             my_scen = writer_slices[global_rank]
             data_len = k * len(my_scen)
-            logical_len = data_len  # data only; no id slot needed for this test
+            # Mirror the production layout: every field reserves a trailing
+            # write_id slot. The overlap segments below address only the data
+            # region [0, data_len), so this also guards that assembly never
+            # reads into the id slot.
+            logical_len = data_len + 1
             padded = padded_len_n_doubles(logical_len)
             my_fields = {Field.NONANTS_VALS: (logical_len, padded)}
         else:

--- a/mpisppy/utils/rank_apportionment.py
+++ b/mpisppy/utils/rank_apportionment.py
@@ -82,3 +82,50 @@ def apportion_ranks(ratios, n_proc):
         counts[zeros[0]] += 1
 
     return counts
+
+
+def cylinder_bases(rank_counts):
+    """First global rank of each cylinder's contiguous block.
+
+    The unequal-rank path lays cylinders out as contiguous global-rank
+    blocks in declaration order: cylinder ``i`` owns global ranks
+    ``[bases[i], bases[i] + rank_counts[i])``.
+
+    Args:
+        rank_counts: per-cylinder rank counts (e.g. from ``apportion_ranks``).
+
+    Returns:
+        list[int]: ``bases[i]`` is the lowest global rank in cylinder ``i``.
+    """
+    bases = []
+    base = 0
+    for rc in rank_counts:
+        bases.append(base)
+        base += rc
+    return bases
+
+
+def rank_to_cylinder(global_rank, rank_counts):
+    """Locate a global rank within the contiguous-block cylinder layout.
+
+    Args:
+        global_rank: a rank in ``[0, sum(rank_counts))``.
+        rank_counts: per-cylinder rank counts (e.g. from ``apportion_ranks``).
+
+    Returns:
+        tuple[int, int]: ``(cylinder_index, rank_within_cylinder)``, where
+        ``rank_within_cylinder`` is this rank's position in its cylinder's
+        ``cylinder_comm`` (i.e. its ``cylinder_rank``).
+
+    Raises:
+        ValueError: if ``global_rank`` is outside the apportioned range.
+    """
+    base = 0
+    for cyl, rc in enumerate(rank_counts):
+        if base <= global_rank < base + rc:
+            return cyl, global_rank - base
+        base += rc
+    raise ValueError(
+        f"rank_to_cylinder: global_rank {global_rank} is outside the "
+        f"apportioned range [0, {base}) for rank_counts {list(rank_counts)}"
+    )

--- a/run_coverage.bash
+++ b/run_coverage.bash
@@ -174,6 +174,14 @@ run_phase "test_dualcg_main (serial)" \
 run_phase "test_dualcg_with_cylinders (mpiexec -np 2)" \
     mpiexec -np 2 coverage run --rcfile="$PROJ_DIR/.coveragerc" -m mpi4py mpisppy/tests/test_dualcg_with_cylinders.py
 
+# Flexible (unequal) rank assignments: both need 6 ranks (4-rank + 2-rank
+# cylinders); -oversubscribe so they run on hosts with fewer than 6 cores.
+run_phase "test_spwindow_multisource (mpiexec -np 6)" \
+    mpiexec -np 6 -oversubscribe coverage run --rcfile="$PROJ_DIR/.coveragerc" -m mpi4py mpisppy/tests/test_spwindow_multisource.py
+
+run_phase "test_flexible_rank_cylinders (mpiexec -np 6)" \
+    mpiexec -np 6 -oversubscribe coverage run --rcfile="$PROJ_DIR/.coveragerc" -m mpi4py mpisppy/tests/test_flexible_rank_cylinders.py
+
 # ---------- Tests that spawn mpiexec internally ----------
 
 PYARGS="-m coverage run --parallel-mode --rcfile=$PROJ_DIR/.coveragerc --data-file=$PROJ_DIR/.coverage"

--- a/run_coverage.bash
+++ b/run_coverage.bash
@@ -53,6 +53,13 @@ has_module() {
     python -c "import $1" 2>/dev/null
 }
 
+# -oversubscribe is OpenMPI-only (MPICH rejects it). Some flexible-rank tests
+# need more ranks than the host has cores, so add the flag only under OpenMPI.
+OVERSUBSCRIBE=""
+if mpiexec --version 2>&1 | grep -qiE "open[ -]?mpi|open ?rte"; then
+    OVERSUBSCRIBE="-oversubscribe"
+fi
+
 # ---------- Serial pytest / unittest tests ----------
 
 run_phase "test_ef_ph (serial)" \
@@ -175,12 +182,13 @@ run_phase "test_dualcg_with_cylinders (mpiexec -np 2)" \
     mpiexec -np 2 coverage run --rcfile="$PROJ_DIR/.coveragerc" -m mpi4py mpisppy/tests/test_dualcg_with_cylinders.py
 
 # Flexible (unequal) rank assignments: both need 6 ranks (4-rank + 2-rank
-# cylinders); -oversubscribe so they run on hosts with fewer than 6 cores.
+# cylinders); $OVERSUBSCRIBE (set above, OpenMPI only) lets them run on hosts
+# with fewer than 6 cores.
 run_phase "test_spwindow_multisource (mpiexec -np 6)" \
-    mpiexec -np 6 -oversubscribe coverage run --rcfile="$PROJ_DIR/.coveragerc" -m mpi4py mpisppy/tests/test_spwindow_multisource.py
+    mpiexec -np 6 $OVERSUBSCRIBE coverage run --rcfile="$PROJ_DIR/.coveragerc" -m mpi4py mpisppy/tests/test_spwindow_multisource.py
 
 run_phase "test_flexible_rank_cylinders (mpiexec -np 6)" \
-    mpiexec -np 6 -oversubscribe coverage run --rcfile="$PROJ_DIR/.coveragerc" -m mpi4py mpisppy/tests/test_flexible_rank_cylinders.py
+    mpiexec -np 6 $OVERSUBSCRIBE coverage run --rcfile="$PROJ_DIR/.coveragerc" -m mpi4py mpisppy/tests/test_flexible_rank_cylinders.py
 
 # ---------- Tests that spawn mpiexec internally ----------
 


### PR DESCRIPTION
> **📚 Stacked PRs — flexible rank assignments**
> Reviewed and merged bottom-up; each PR targets the one below it.
>
> 1. **Pyomo/mpi-sppy#725 — Phase 1: infrastructure** — ✅ merged
> 2. **Phase 2: communication layer** ← _this PR_ (targets `main`)
> 3. **DLWoodruff/mpi-sppy-1#13 — Phase 3a: per-field coherence (DUALS strict)** (targets `flex-ranks-phase2-communication`)
> 4. **DLWoodruff/mpi-sppy-1#14 — Phase 3b: CLI rank-ratio flags** (targets `flex-ranks-phase3-coherence`)
> 5. **DLWoodruff/mpi-sppy-1#15 — Phase 4a: two-stage xhat fields** (targets `flex-ranks-phase3b-cli`)
>
> 6. **DLWoodruff/mpi-sppy-1#16 — Phase 4b: multistage per-node xhat sourcing** (targets `flex-ranks-phase4a-xhat-2stage`)
> 7. **DLWoodruff/mpi-sppy-1#17 — Phase 5: APH (asynchronous sender) verification** (targets `flex-ranks-phase4b-multistage`)
>
> _Later phases will be appended here as they open._

---

Second phase of the flexible-rank design (`doc/designs/flexible_rank_assignments.md`).
Adds the communication layer that actually runs cylinders at unequal rank
counts. **Gated-additive: the equal-rank path is unchanged** — all of this is
reached only when a cylinder's `rank_ratio` differs from 1.0.

## What's here

- **`spin_the_wheel.py`** — on a non-uniform rank-ratio request, apportion the
  rank pool into contiguous global-rank blocks, build `cylinder_comm` only
  (no `strata_comm`, which is undefined when cylinders differ in size), and
  pass `strata_comm=None`. The phase-1 `NotImplementedError` gate is removed.
- **`rank_apportionment.py`** — `cylinder_bases` / `rank_to_cylinder` for the
  contiguous-block layout.
- **`SPCommunicator`** — when `strata_comm is None`: window on `fullcomm`,
  peers addressed by global rank. `get_receive_buffer` gains a flex dispatch —
  single-source (from a peer cylinder's base rank) for global/scalar fields,
  multi-source overlap-map assembly for per-scenario fields.
- **Layout exchange** is `fullcomm.allgather` (interim; the scalable
  two-level/local-compute replacement is a pre-advertisement release gate,
  tracked in Pyomo/mpi-sppy#726).

## Coherence — two RMA bugs found while testing (this is the flaky corner the design flags)

- **Lockstep:** consumers like `xhatshufflelooper` require every reader rank to
  agree on "is_new" so the collectives they run on new data stay matched on
  `cylinder_comm`. The multi-source reader mirrors the equal-rank cross-rank
  `write_id` agreement rather than accepting each source independently.
- **Atomicity:** each source's whole field is read in **one** `Get` (data +
  trailing `write_id` from a single snapshot), committed into the buffer only
  after the agreement check passes. Reading data and id in separate `Get`s
  raced the writer (pre-write NaN data paired with a fresh id, accepted as new).

## Tests (np=6, both on `fullcomm` windows; `-oversubscribe`)

- **`test_spwindow_multisource.py`** — builds an `SPWindow` directly on
  `COMM_WORLD` and asserts exact multi-source assembly from several remote
  ranks (incl. a reader rank straddling a writer boundary). Isolates the RMA
  primitive from the hub/spoke stack.
- **`test_flexible_rank_cylinders.py`** — farmer PH hub + xhatshuffle spoke at
  **4+2 and 2+4**. The only local-sized field crossing cylinders is
  `NONANTS_VALS`; both asymmetry directions must agree and reach the
  extensive-form optimum.

Both wired into `run_coverage.bash` and the `test-cylinders` CI job. Equal-rank
regression (`test_with_cylinders` np=2) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
