### PR TITLE
docs: rewrite Quick Start; audit and fix stale references across docs

### DIFF
--- a/doc/src/building_overview.rst
+++ b/doc/src/building_overview.rst
@@ -1,0 +1,21 @@
+Overview
+========
+
+If your model is written in Pyomo, you create a Python module with the
+following functions. The remaining chapters in this section describe
+each one in detail.
+
+- ``scenario_creator`` -- builds a Pyomo model for one scenario (see :ref:`scenario_creator`)
+- ``scenario_names_creator`` -- returns the list of scenario names (see :ref:`helper_functions`)
+- ``kw_creator`` -- returns keyword arguments for the scenario creator (see :ref:`helper_functions`)
+- ``inparser_adder`` -- adds problem-specific command-line arguments (see :ref:`helper_functions`)
+- ``scenario_denouement`` -- called at termination (can be ``None``; see :ref:`helper_functions`)
+
+Once you have these functions, you can use ``generic_cylinders.py``
+(see :ref:`generic_cylinders`) to solve your problem using the EF or
+the hub-and-spoke system. See the ``farmer`` directory in ``examples``
+for a complete working example (``farmer.py`` and ``farmer_generic.bash``).
+
+For models written in an algebraic modeling language other than Pyomo
+(e.g., AMPL or GAMS), see :doc:`agnostic`. For models supplied as
+SMPS-format files, see :doc:`smps`.

--- a/doc/src/code_coverage.rst
+++ b/doc/src/code_coverage.rst
@@ -46,13 +46,15 @@ arguments in each subprocess invocation. A command that would normally be:
 
 .. code-block:: text
 
-   mpiexec -np 3 python -u -m mpi4py farmer_cylinders.py --num-scens 3 ...
+   mpiexec -np 3 python -u -m mpi4py -m mpisppy.generic_cylinders \
+       --module-name farmer --num-scens 3 ...
 
 becomes:
 
 .. code-block:: text
 
-   mpiexec -np 3 python -u -m coverage run --parallel-mode --source=mpisppy -m mpi4py farmer_cylinders.py --num-scens 3 ...
+   mpiexec -np 3 python -u -m coverage run --parallel-mode --source=mpisppy \
+       -m mpi4py -m mpisppy.generic_cylinders --module-name farmer --num-scens 3 ...
 
 Because ``--parallel-mode`` is used, each MPI rank writes its own
 ``.coverage.<hostname>.<pid>`` file. After the run, ``coverage combine``

--- a/doc/src/confidence_intervals.rst
+++ b/doc/src/confidence_intervals.rst
@@ -64,8 +64,13 @@ argument.
 These functions write ``xhat`` for the root node of the scenario tree to a file and can be read using ``read_xhat``.
 When using a cylinders driver, the function ``sputils.first_stage_nonant_npy_serializer``
 can be given as the ``first_stage_solution_writer`` argument to the function
-``sputils.write_spin_the_wheel_first_stage_solution``. See the ``farmer_cylinders.py``
-and ``farmer_ef.py`` examples. The ``uc_cylinders.py`` file also shows an example.
+``sputils.write_spin_the_wheel_first_stage_solution``. See
+``examples/farmer/CI/farmer_ef.py`` for a small EF example and
+``examples/uc/uc_cylinders.py`` for a hub-and-spoke example. From
+``generic_cylinders.py`` the incumbent xhat from a hub-and-spoke run
+can be written automatically by setting
+``--incumbent-on-improvement-filename-prefix``, which produces both
+``.csv`` and ``.npy`` files each time a better inner bound is found.
 
 Evaluating a candidate solution
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/src/drivers.rst
+++ b/doc/src/drivers.rst
@@ -49,7 +49,15 @@ Extending Examples
 Many developers
 will need to add extensions. Here are few examples:
 
-* In the ``examples.farmer.archive.farmer_cylinders.py`` example, there is a block of code to add a ``--crops-mult`` argument that is passed to the scenario creator in the ``scenario_creator_kwargs`` dictionary.
+* The model file ``examples.farmer.farmer.py`` defines an
+  ``inparser_adder`` function that registers a ``--crops-multiplier``
+  option on the ``Config``, and a ``kw_creator`` function that
+  forwards that value to the scenario creator via the
+  ``scenario_creator_kwargs`` dictionary. This is the recommended
+  pattern for adding problem-specific command-line arguments when
+  driving a model through ``generic_cylinders.py``. (For comparison,
+  the older hand-wired equivalent is preserved in
+  ``examples.farmer.archive.farmer_cylinders.py``.)
 
 * In the ``hydro_cylinders.py`` example (which has three stages). The branching factors are obtained from the command line and passed to the scenario constructor via ``scenario_creator_kwargs`` and also passed to ``sputils.create_nodenames_from_BFs`` to create a node list.
 

--- a/doc/src/ef.rst
+++ b/doc/src/ef.rst
@@ -57,7 +57,7 @@ Other method: ``mpisppy.utils.sputils.create_EF``
 -------------------------------------------------
 
 The use of this function does not require the installation of ``mpi4py``. Its use
-is illustrated in ``examples.farmer.farmer_ef.py``. Here are the
+is illustrated in ``examples.farmer.CI.farmer_ef.py``. Here are the
 arguments to the function:
 
 .. autofunction:: mpisppy.utils.sputils.create_EF

--- a/doc/src/extensions.rst
+++ b/doc/src/extensions.rst
@@ -97,7 +97,7 @@ This extension provides methods for fixing nonanticipative variables (usually in
 which all scenarios have agreed for some number of iterations. There
 is an example of its use in ``examples.sizes.sizes_demo.py`` also
 in ``examples.uc.uc_ama.py``. The ``uc_ama`` example illustrates
-that when ``amgalgamator`` is used ``"id_fix_list_fct"`` needs
+that when ``amalgamator`` is used ``"id_fix_list_fct"`` needs
 to be on the ``Config`` object so the amalgamator can find it.
 
 .. note::

--- a/doc/src/extensions.rst
+++ b/doc/src/extensions.rst
@@ -38,7 +38,7 @@ Multiple Extensions
 To employ multiple PH extensions, use ``mpisppy.extensions.extension import MultiExtension``
 that allows you to give a list of extensions that will fire in order
 at each callout point. See, e.g. ``examples.sizes.sizes_demo.py`` or
-``examples.farmer.farmer_rho_demo.py`` for an
+``examples.farmer.CI.farmer_rho_demo.py`` for an
 example of use.
 
 .. note::
@@ -96,7 +96,7 @@ fixer.py
 This extension provides methods for fixing nonanticipative variables (usually integers) for
 which all scenarios have agreed for some number of iterations. There
 is an example of its use in ``examples.sizes.sizes_demo.py`` also
-in ``examples.sizes.uc_ama.py``. The ``uc_ama`` example illustrates
+in ``examples.uc.uc_ama.py``. The ``uc_ama`` example illustrates
 that when ``amgalgamator`` is used ``"id_fix_list_fct"`` needs
 to be on the ``Config`` object so the amalgamator can find it.
 
@@ -169,9 +169,11 @@ norm_rho_updater
 ^^^^^^^^^^^^^^^^
 
 This extension adjust rho dynamically. The code is in ``mpisppy.extensions.norm_rho_updater.py``
-and there is an accompanying converger in ``mpisppy.convergers.norm_rho_converger``. An
-example of use is shown in ``examples.farmer.farmer_cylinders.py``. This is
-the original Gabe H. dynamic rho.
+and there is an accompanying converger in ``mpisppy.convergers.norm_rho_converger``. From
+``generic_cylinders.py``, enable it with ``--use-norm-rho-updater``; a
+hand-wired example using the underlying classes directly is preserved in
+``examples.farmer.archive.farmer_cylinders.py``. This is the original
+Gabe H. dynamic rho.
 
 
 rho_setter
@@ -259,9 +261,10 @@ adds time and memory and is not recommended for production runs.
 
 gradient_extension
 ^^^^^^^^^^^^^^^^^^
-The gradient_extension sets gradient-based rho for PH.
-An example of its use is shown in  ``examples.farmer.farmer_rho_demo.py``
-There are options in ``cfg`` to control dynamic updates.
+The gradient_extension sets gradient-based rho for PH. From
+``generic_cylinders.py``, enable it with ``--grad-rho``; a standalone
+demo is in ``examples.farmer.CI.farmer_rho_demo.py``. There are options
+in ``cfg`` to control dynamic updates.
 
 mult_rho_updater
 ^^^^^^^^^^^^^^^^
@@ -272,7 +275,8 @@ cross-scenario cuts
 ^^^^^^^^^^^^^^^^^^^
 Two-stage models only. This extension adds cross scenario cuts as calculated
 by the cross-scenario cut spoke. See the implementation paper for details.
-An example of its use is shown in ``examples/farmer/cs_farmer.py``.
+A hand-wired example using the underlying classes is preserved in
+``examples/farmer/archive/cs_farmer.py``.
 
 
 Distributed Subproblem Presolve

--- a/doc/src/hubs.rst
+++ b/doc/src/hubs.rst
@@ -103,8 +103,11 @@ based on convergence within the hub; furthermore, convergence metrics within
 the hub can be helpful for tuning algorithms.
 
 The scenario decomposition methods (PH and APH) allow for optional
-metrics to be used as plug-ins. A pattern that can be followed is shown
-in the farmer example. The ``farmer_cylinders.py`` file has::
+metrics to be used as plug-ins. From ``generic_cylinders.py`` the
+``NormRhoConverger`` is wired in automatically when the
+``--use-norm-rho-updater`` flag is set. The underlying hand-wired
+pattern is preserved in the archived
+``examples/farmer/archive/farmer_cylinders.py``, which contains::
 
    from mpisppy.convergers.norm_rho_converger import NormRhoConverger
 

--- a/doc/src/index.rst
+++ b/doc/src/index.rst
@@ -16,6 +16,7 @@ MPI is used.
    :maxdepth: 2
    :caption: Building Your Model File
 
+   building_overview.rst
    scenario_creator.rst
    helper_functions.rst
 

--- a/doc/src/install_mpi.rst
+++ b/doc/src/install_mpi.rst
@@ -57,7 +57,7 @@ Other pip extras
 
 In addition to ``[mpi]``, mpi-sppy declares a couple of other ``pip``
 extras that can be combined with it (with commas, e.g.
-``pip install -e .[mpi,doc]``):
+``pip install -e ".[mpi,doc]"``):
 
 * ``doc`` -- installs Sphinx and the theme used to build the documentation.
 * ``scipy`` -- installs SciPy, used by a few utilities.

--- a/doc/src/install_mpi.rst
+++ b/doc/src/install_mpi.rst
@@ -47,6 +47,17 @@ At least on some US Department of Energy (e.g., at Lawrence Livermore National L
 
 export MPICH_ASYNC_PROGRESS=1
 
-Without this setting, we have observed run-times increase by a factor of between 2 and 4, due to non-blocking point-to-point calls apparently being treated as blocking. 
+Without this setting, we have observed run-times increase by a factor of between 2 and 4, due to non-blocking point-to-point calls apparently being treated as blocking.
 
-Further, without this setting and in situations with a large number of ranks (e.g., >> 10), we have observed mpi-sppy stalling once scenario instances are created. 
+Further, without this setting and in situations with a large number of ranks (e.g., >> 10), we have observed mpi-sppy stalling once scenario instances are created.
+
+
+Other pip extras
+^^^^^^^^^^^^^^^^
+
+In addition to ``[mpi]``, mpi-sppy declares a couple of other ``pip``
+extras that can be combined with it (with commas, e.g.
+``pip install -e .[mpi,doc]``):
+
+* ``doc`` -- installs Sphinx and the theme used to build the documentation.
+* ``scipy`` -- installs SciPy, used by a few utilities.

--- a/doc/src/quick_start.rst
+++ b/doc/src/quick_start.rst
@@ -409,12 +409,3 @@ for a complete working example (``farmer.py`` and ``farmer_generic.bash``).
 For models written in an algebraic modeling language other than Pyomo
 (e.g., AMPL or GAMS), see :doc:`agnostic`. For models supplied as
 SMPS-format files, see :doc:`smps`.
-
-
-Researchers Who Want to Compare with mpi-sppy
-----------------------------------------------
-
-The quickest approach is to run one of the canned examples in
-subdirectories of ``examples``. Sample commands can be found in
-``examples.runall.py``. The mpi-sppy paper in MPC provides references
-for many of the examples.

--- a/doc/src/quick_start.rst
+++ b/doc/src/quick_start.rst
@@ -389,8 +389,8 @@ Running the Farmer Example
 For more detail, see :ref:`generic_cylinders` and :ref:`Examples`.
 
 
-What You Need to Provide
--------------------------
+What You Need to Provide For Your Problem
+-----------------------------------------
 
 If your model is written in Pyomo, you create a Python module with the
 following functions:

--- a/doc/src/quick_start.rst
+++ b/doc/src/quick_start.rst
@@ -20,7 +20,7 @@ Prerequisites (all platforms)
   algorithms.
 * For decomposition algorithms (PH, APH, L-shaped, …): a working MPI
   implementation and ``mpi4py``. If you only need to solve the extensive
-  form, MPI is *not* required.
+  form directly, MPI is *not* required.
 
 
 Install from GitHub on Linux
@@ -329,9 +329,9 @@ command from the top of the cloned ``mpi-sppy`` repository.
    named 'mpisppy'``, the install did not take effect in this
    environment (most often a virtual-environment issue).
 
-2. **Your solver works.** Solve the farmer extensive form with three
-   scenarios. Substitute the solver you installed (``gurobi``,
-   ``cplex``, ``xpress``, …):
+2. **Your solver works.** Solve the farmer extensive form directly
+   with three scenarios. Substitute the solver you installed
+   (``gurobi``, ``cplex``, ``xpress``, …):
 
    .. code-block:: text
 

--- a/doc/src/quick_start.rst
+++ b/doc/src/quick_start.rst
@@ -4,17 +4,316 @@ Quick Start
 Installation
 ------------
 
-Install from source by giving this command from the mpi-sppy repo root directory:
+We strongly recommend installing mpi-sppy from its GitHub repository rather
+than from PyPI. mpi-sppy is under active development and the PyPI release
+is almost always significantly out of date; bug fixes and new features land
+on GitHub first.
 
-::
+The repository is at https://github.com/Pyomo/mpi-sppy.
 
-   pip install -e .
+Prerequisites (all platforms)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-We recommend installing from GitHub rather than pip, because
-the software is under active development and the pip version is almost
-always out of date. You can also include the extras flag ``docs`` to
-install documentation dependencies.
+* Python 3.9 or newer
+* ``git``
+* A Pyomo-compatible MIP solver (e.g., cplex, gurobi, or xpress) for most
+  algorithms. The free solver ``glpk`` works for some small examples.
+* For decomposition algorithms (PH, APH, L-shaped, …): a working MPI
+  implementation and ``mpi4py``. If you only need to solve the extensive
+  form, MPI is *not* required.
 
+The ``pip`` extras provided by mpi-sppy are:
+
+* ``mpi`` -- installs ``mpi4py`` (requires MPI headers/libraries already
+  present; see the platform-specific steps below)
+* ``doc`` -- installs Sphinx and the theme used to build these docs
+* ``scipy`` -- installs SciPy (needed by a few utilities)
+
+Combine extras with commas, e.g. ``pip install -e .[mpi,doc]``.
+
+
+Install from GitHub on Linux
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+1. Install an MPI implementation. Pick the method that matches your
+   environment:
+
+   * Debian / Ubuntu:
+
+     .. code-block:: bash
+
+        sudo apt-get update
+        sudo apt-get install -y libopenmpi-dev openmpi-bin build-essential
+
+   * Fedora / RHEL / Rocky:
+
+     .. code-block:: bash
+
+        sudo dnf install openmpi openmpi-devel
+        # then make mpicc / mpiexec visible in this shell:
+        module load mpi/openmpi-x86_64
+
+   * Conda environment (works on any Linux distro):
+
+     .. code-block:: bash
+
+        conda install -c conda-forge openmpi mpi4py
+
+     If you used the conda path, you can skip the ``[mpi]`` extra in step 3.
+
+2. Clone the repository:
+
+   .. code-block:: bash
+
+      git clone https://github.com/Pyomo/mpi-sppy.git
+      cd mpi-sppy
+
+3. Install in editable mode with the ``mpi`` extra:
+
+   .. code-block:: bash
+
+      pip install -e .[mpi]
+
+4. Install a solver of your choice (e.g. ``pip install gurobipy``; commercial
+   solvers also need a license).
+
+5. Verify the installation (see :ref:`Verify Installation` below).
+
+
+Install from GitHub on macOS
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+1. Install an MPI implementation. Two reliable paths:
+
+   * Homebrew (Intel or Apple Silicon):
+
+     .. code-block:: bash
+
+        brew install open-mpi
+
+   * Conda environment (recommended on Apple Silicon to avoid wheel/build
+     mismatches):
+
+     .. code-block:: bash
+
+        conda install -c conda-forge openmpi mpi4py
+
+     If you used the conda path, you can skip the ``[mpi]`` extra in step 3.
+
+2. Make sure command-line developer tools are present (one-time):
+
+   .. code-block:: bash
+
+      xcode-select --install
+
+3. Clone the repository:
+
+   .. code-block:: bash
+
+      git clone https://github.com/Pyomo/mpi-sppy.git
+      cd mpi-sppy
+
+4. Install in editable mode with the ``mpi`` extra:
+
+   .. code-block:: bash
+
+      pip install -e .[mpi]
+
+5. Install a solver of your choice.
+
+6. Verify the installation (see :ref:`Verify Installation` below).
+
+
+Install from GitHub on Windows
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Two installation paths are supported on Windows. Most users will have a
+substantially easier time with WSL2, because the Python+MPI ecosystem is
+developed and tested on Linux first. Native Windows with MS-MPI does work
+but breaks more often and requires more manual setup. Detailed instructions
+for both follow.
+
+Optional: notes for Visual Studio Code users
+""""""""""""""""""""""""""""""""""""""""""""
+
+**The use of VS-Code is entirely optional.** It is intended only for users
+who have already chosen to use Microsoft Visual Studio Code (VS Code) as
+their editor and want it to work smoothly with the WSL2 or MS-MPI paths
+below. You do not need VS Code to install or use mpi-sppy; any editor
+(or no editor) is fine. If you do not use VS Code, skip this subsection
+entirely and go straight to WSL2 or MS-MPI.
+
+If you *are* using VS Code, the following one-time setup pairs well with
+either installation path:
+
+1. From the Extensions panel (``Ctrl+Shift+X``), install:
+
+   * **Python** (publisher: Microsoft) -- language support, debugging,
+     interpreter selection.
+   * **Pylance** (publisher: Microsoft) -- usually installed automatically
+     with Python; provides fast type checking and autocompletion.
+   * **WSL** (publisher: Microsoft) -- only needed if you plan to use the
+     WSL2 path below. Lets VS Code open and edit files *inside* the Ubuntu
+     environment as if they were local.
+   * **Jupyter** (publisher: Microsoft) -- optional, useful if you intend
+     to use notebooks for analysis.
+
+2. After you complete the WSL2 or MS-MPI steps below and the
+   ``git clone`` step has produced an ``mpi-sppy`` folder, open it in
+   VS Code:
+
+   * **If you used WSL2:** from the Ubuntu shell, ``cd mpi-sppy`` and run
+     ``code .`` -- VS Code will launch, install its WSL server in the
+     background the first time, and open the folder. The lower-left
+     status bar should read "WSL: Ubuntu" to confirm you are editing
+     *inside* WSL, not on Windows.
+   * **If you used native MS-MPI:** open VS Code and choose
+     "File → Open Folder…", then select the cloned ``mpi-sppy`` directory.
+
+3. Select the correct Python interpreter. Open the Command Palette with
+   ``Ctrl+Shift+P``, type "Python: Select Interpreter", and press Enter.
+   Pick the interpreter from the virtual environment you created in the
+   instructions below (e.g. ``~/mpisppy-env/bin/python`` for WSL2 or
+   ``mpisppy-env\Scripts\python.exe`` for native Windows). VS Code will
+   remember this choice for the folder.
+
+4. Open an integrated terminal with ``Ctrl+` `` (Ctrl plus backtick). On
+   WSL2 this gives you the Ubuntu shell directly; on native Windows it
+   gives you PowerShell. All ``mpiexec`` and ``python`` commands shown
+   later in this document can be typed into this terminal.
+
+Continue with either WSL2 or native MS-MPI below.
+
+WSL2 (Windows Subsystem for Linux)
+""""""""""""""""""""""""""""""""""
+
+1. Install WSL2 with an Ubuntu distribution. From an *administrator*
+   PowerShell:
+
+   .. code-block:: powershell
+
+      wsl --install -d Ubuntu
+
+   Reboot if Windows asks you to, then launch the new "Ubuntu" entry from
+   the Start menu and finish the first-time user setup.
+
+2. From inside the Ubuntu shell, install Python, git, OpenMPI, and a build
+   toolchain:
+
+   .. code-block:: bash
+
+      sudo apt-get update
+      sudo apt-get install -y python3 python3-pip python3-venv git \
+          libopenmpi-dev openmpi-bin build-essential
+
+3. (Recommended) Create and activate a Python virtual environment so
+   mpi-sppy and its dependencies do not interfere with the system Python:
+
+   .. code-block:: bash
+
+      python3 -m venv ~/mpisppy-env
+      source ~/mpisppy-env/bin/activate
+
+4. Clone the repository and install:
+
+   .. code-block:: bash
+
+      git clone https://github.com/Pyomo/mpi-sppy.git
+      cd mpi-sppy
+      pip install -e .[mpi]
+
+5. Install your solver inside the WSL environment (e.g.
+   ``pip install gurobipy``). Commercial solver licenses generally work
+   cross-platform.
+
+6. Verify the installation (see :ref:`Verify Installation` below). All
+   ``mpiexec``/``python`` commands should be run from the Ubuntu shell, not
+   from PowerShell.
+
+Native Windows with MS-MPI
+""""""""""""""""""""""""""
+
+This path uses Microsoft MPI (MS-MPI), the standard MPI implementation on
+Windows.
+
+1. Install Python 3.9 or newer from https://www.python.org/downloads/ or
+   via Miniconda. If using the python.org installer, check
+   "Add python.exe to PATH" during install.
+
+2. Install Git for Windows from https://git-scm.com/download/win. This
+   provides ``git`` and a "Git Bash" shell (you can use either PowerShell
+   or Git Bash for the steps below).
+
+3. Install Microsoft MPI. You need *both* downloads from the Microsoft MPI
+   downloads page
+   (https://learn.microsoft.com/en-us/message-passing-interface/microsoft-mpi):
+
+   * ``msmpisetup.exe`` -- the MPI runtime (provides ``mpiexec.exe``)
+   * ``msmpisdk.msi`` -- the MPI SDK (headers/libs needed to build
+     ``mpi4py``)
+
+   After installing both, open a *new* PowerShell window and confirm that
+   ``mpiexec`` is on PATH:
+
+   .. code-block:: powershell
+
+      mpiexec -help
+
+4. (Recommended) Create and activate a virtual environment:
+
+   .. code-block:: powershell
+
+      py -m venv mpisppy-env
+      mpisppy-env\Scripts\Activate.ps1
+
+5. Install ``mpi4py``. The simplest path is conda-forge:
+
+   .. code-block:: powershell
+
+      conda install -c conda-forge mpi4py
+
+   If you prefer pip, you must also have the Microsoft C++ Build Tools and
+   the MS-MPI SDK installed; then:
+
+   .. code-block:: powershell
+
+      pip install mpi4py
+
+6. Clone the repository and install mpi-sppy. Note that in PowerShell the
+   square brackets in ``[mpi]`` must be quoted:
+
+   .. code-block:: powershell
+
+      git clone https://github.com/Pyomo/mpi-sppy.git
+      cd mpi-sppy
+      pip install -e ".[mpi]"
+
+7. Install your solver. The Python bindings for gurobi and cplex are
+   available natively on Windows.
+
+8. Verify the installation (see :ref:`Verify Installation` below). On
+   native Windows, use MS-MPI's ``mpiexec`` form, for example:
+
+   .. code-block:: powershell
+
+      mpiexec -n 3 python -m mpi4py mpisppy\generic_cylinders.py ...
+
+
+Install from PyPI (not recommended)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A released version of mpi-sppy is also published on PyPI:
+
+.. code-block:: bash
+
+   pip install mpi-sppy[mpi]
+
+This release typically lags the GitHub ``main`` branch by months; bug
+fixes and new features may not yet be available. We recommend the GitHub
+install above for any active research use.
+
+
+.. _Verify Installation:
 
 Verify Installation
 -------------------

--- a/doc/src/quick_start.rst
+++ b/doc/src/quick_start.rst
@@ -16,20 +16,11 @@ Prerequisites (all platforms)
 
 * Python 3.9 or newer
 * ``git``
-* A Pyomo-compatible MIP solver (e.g., cplex, gurobi, or xpress) for most
-  algorithms. The free solver ``glpk`` works for some small examples.
+* A Pyomo-compatible solver (e.g., cplex, gurobi, or xpress) for most
+  algorithms.
 * For decomposition algorithms (PH, APH, L-shaped, …): a working MPI
   implementation and ``mpi4py``. If you only need to solve the extensive
   form, MPI is *not* required.
-
-The ``pip`` extras provided by mpi-sppy are:
-
-* ``mpi`` -- installs ``mpi4py`` (requires MPI headers/libraries already
-  present; see the platform-specific steps below)
-* ``doc`` -- installs Sphinx and the theme used to build these docs
-* ``scipy`` -- installs SciPy (needed by a few utilities)
-
-Combine extras with commas, e.g. ``pip install -e .[mpi,doc]``.
 
 
 Install from GitHub on Linux
@@ -318,34 +309,62 @@ install above for any active research use.
 Verify Installation
 -------------------
 
-Verify that mpi-sppy and a solver are installed by running:
+The following three checks confirm that mpi-sppy, your solver, and (if
+you installed it) MPI are all working. The commands below are
+shell-neutral: they work in bash, zsh, the WSL2 Ubuntu shell, and
+Windows PowerShell. On native Windows, if ``python`` is not on PATH but
+the Python launcher is, substitute ``py`` for ``python``. Run each
+command from the top of the cloned ``mpi-sppy`` repository.
 
-.. code-block:: bash
+1. **mpi-sppy is importable and the CLI works.** This confirms the
+   editable install succeeded and Python can import the package.
 
-   cd examples/farmer
-   python -m mpisppy.generic_cylinders --module-name farmer --help
+   .. code-block:: text
 
+      cd examples/farmer
+      python -m mpisppy.generic_cylinders --module-name farmer --help
 
-If you intend to use decomposition (PH, APH, etc.), you also need a
-working installation of MPI and ``mpi4py``; see :ref:`Install mpi4py`.
-If you only need to solve the extensive form directly, MPI is not required.
+   You should see a long help message listing all available
+   command-line options. If you see ``ModuleNotFoundError: No module
+   named 'mpisppy'``, the install did not take effect in this
+   environment (most often a virtual-environment issue).
 
+2. **Your solver works.** Solve the farmer extensive form with three
+   scenarios. Substitute the solver you installed (``gurobi``,
+   ``cplex``, ``xpress``, …):
 
-What You Need to Provide
--------------------------
+   .. code-block:: text
 
-To use mpi-sppy, you create a Python module with the following functions:
+      python -m mpisppy.generic_cylinders --module-name farmer \
+          --num-scens 3 --EF --EF-solver-name gurobi
 
-- ``scenario_creator`` -- builds a Pyomo model for one scenario (see :ref:`scenario_creator`)
-- ``scenario_names_creator`` -- returns the list of scenario names (see :ref:`helper_functions`)
-- ``kw_creator`` -- returns keyword arguments for the scenario creator (see :ref:`helper_functions`)
-- ``inparser_adder`` -- adds problem-specific command-line arguments (see :ref:`helper_functions`)
-- ``scenario_denouement`` -- called at termination (can be ``None``; see :ref:`helper_functions`)
+   You should see the solver print progress and the script print an
+   optimal objective value. This check does *not* use MPI.
 
-Once you have these functions, you can use ``generic_cylinders.py``
-(see :ref:`generic_cylinders`) to solve your problem using the EF or
-the hub-and-spoke system. See the ``farmer`` directory in ``examples``
-for a complete working example (``farmer.py`` and ``farmer_generic.bash``).
+3. **MPI works** (only if you installed MPI and ``mpi4py``). From the
+   repository root, run the bundled one-sided MPI test:
+
+   .. code-block:: text
+
+      mpiexec -n 2 python -m mpi4py mpi_one_sided_test.py
+
+   If you see no error messages, your MPI installation should be
+   suitable. Then confirm the full hub-and-spoke flow with a short PH
+   run on farmer:
+
+   .. code-block:: text
+
+      mpiexec -n 3 python -m mpi4py -m mpisppy.generic_cylinders \
+          --module-name farmer --num-scens 3 \
+          --solver-name gurobi --max-iterations 5 \
+          --default-rho 1 --lagrangian --xhatshuffle
+
+   You should see iteration output and the run should terminate
+   normally.
+
+If you only intend to solve the extensive form directly, you can skip
+step 3 -- MPI is not required for ``--EF``. For additional MPI install
+guidance and HPC-specific tips, see :ref:`Install mpi4py`.
 
 
 Running the Farmer Example
@@ -368,6 +387,28 @@ Running the Farmer Example
        --default-rho 1 --lagrangian --xhatshuffle --rel-gap 0.01
 
 For more detail, see :ref:`generic_cylinders` and :ref:`Examples`.
+
+
+What You Need to Provide
+-------------------------
+
+If your model is written in Pyomo, you create a Python module with the
+following functions:
+
+- ``scenario_creator`` -- builds a Pyomo model for one scenario (see :ref:`scenario_creator`)
+- ``scenario_names_creator`` -- returns the list of scenario names (see :ref:`helper_functions`)
+- ``kw_creator`` -- returns keyword arguments for the scenario creator (see :ref:`helper_functions`)
+- ``inparser_adder`` -- adds problem-specific command-line arguments (see :ref:`helper_functions`)
+- ``scenario_denouement`` -- called at termination (can be ``None``; see :ref:`helper_functions`)
+
+Once you have these functions, you can use ``generic_cylinders.py``
+(see :ref:`generic_cylinders`) to solve your problem using the EF or
+the hub-and-spoke system. See the ``farmer`` directory in ``examples``
+for a complete working example (``farmer.py`` and ``farmer_generic.bash``).
+
+For models written in an algebraic modeling language other than Pyomo
+(e.g., AMPL or GAMS), see :doc:`agnostic`. For models supplied as
+SMPS-format files, see :doc:`smps`.
 
 
 Researchers Who Want to Compare with mpi-sppy

--- a/doc/src/quick_start.rst
+++ b/doc/src/quick_start.rst
@@ -59,11 +59,12 @@ Install from GitHub on Linux
       git clone https://github.com/Pyomo/mpi-sppy.git
       cd mpi-sppy
 
-3. Install in editable mode with the ``mpi`` extra:
+3. Install in editable mode with the ``mpi`` extra (quote ``".[mpi]"`` so
+   shells that glob brackets, such as zsh, do not mangle it):
 
    .. code-block:: bash
 
-      pip install -e .[mpi]
+      pip install -e ".[mpi]"
 
 4. Install a solver of your choice (e.g. ``pip install gurobipy``; commercial
    solvers also need a license).
@@ -104,11 +105,13 @@ Install from GitHub on macOS
       git clone https://github.com/Pyomo/mpi-sppy.git
       cd mpi-sppy
 
-4. Install in editable mode with the ``mpi`` extra:
+4. Install in editable mode with the ``mpi`` extra (quote ``".[mpi]"`` so
+   shells that glob brackets, such as zsh -- the macOS default -- do not
+   mangle it):
 
    .. code-block:: bash
 
-      pip install -e .[mpi]
+      pip install -e ".[mpi]"
 
 5. Install a solver of your choice.
 
@@ -211,7 +214,7 @@ WSL2 (Windows Subsystem for Linux)
 
       git clone https://github.com/Pyomo/mpi-sppy.git
       cd mpi-sppy
-      pip install -e .[mpi]
+      pip install -e ".[mpi]"
 
 5. Install your solver inside the WSL environment (e.g.
    ``pip install gurobipy``). Commercial solver licenses generally work
@@ -250,27 +253,31 @@ Windows.
 
       mpiexec -help
 
-4. (Recommended) Create and activate a virtual environment:
+4. (Recommended) Create and activate an isolated environment and install
+   ``mpi4py`` into it. Pick **one** of the following paths; do not mix
+   them, because ``conda install`` puts packages in the active conda
+   environment rather than a ``venv``.
 
-   .. code-block:: powershell
+   * **conda-forge (simplest).** Installs a prebuilt ``mpi4py``, so you do
+     not need the MS-MPI SDK or a C++ compiler:
 
-      py -m venv mpisppy-env
-      mpisppy-env\Scripts\Activate.ps1
+     .. code-block:: powershell
 
-5. Install ``mpi4py``. The simplest path is conda-forge:
+        conda create -n mpisppy-env python=3.12
+        conda activate mpisppy-env
+        conda install -c conda-forge mpi4py
 
-   .. code-block:: powershell
+   * **venv + pip.** Use this only if you have the Microsoft C++ Build
+     Tools and the MS-MPI SDK installed, since pip builds ``mpi4py`` from
+     source:
 
-      conda install -c conda-forge mpi4py
+     .. code-block:: powershell
 
-   If you prefer pip, you must also have the Microsoft C++ Build Tools and
-   the MS-MPI SDK installed; then:
+        py -m venv mpisppy-env
+        mpisppy-env\Scripts\Activate.ps1
+        pip install mpi4py
 
-   .. code-block:: powershell
-
-      pip install mpi4py
-
-6. Clone the repository and install mpi-sppy. Note that in PowerShell the
+5. Clone the repository and install mpi-sppy. Note that in PowerShell the
    square brackets in ``[mpi]`` must be quoted:
 
    .. code-block:: powershell
@@ -279,10 +286,10 @@ Windows.
       cd mpi-sppy
       pip install -e ".[mpi]"
 
-7. Install your solver. The Python bindings for gurobi and cplex are
+6. Install your solver. The Python bindings for gurobi and cplex are
    available natively on Windows.
 
-8. Verify the installation (see :ref:`Verify Installation` below). On
+7. Verify the installation (see :ref:`Verify Installation` below). On
    native Windows, use MS-MPI's ``mpiexec`` form, for example:
 
    .. code-block:: powershell
@@ -313,8 +320,9 @@ The following three checks confirm that mpi-sppy, your solver, and (if
 you installed it) MPI are all working. The commands below are
 shell-neutral: they work in bash, zsh, the WSL2 Ubuntu shell, and
 Windows PowerShell. On native Windows, if ``python`` is not on PATH but
-the Python launcher is, substitute ``py`` for ``python``. Run each
-command from the top of the cloned ``mpi-sppy`` repository.
+the Python launcher is, substitute ``py`` for ``python``. Start from the
+top of the cloned ``mpi-sppy`` repository; step 1 changes into
+``examples/farmer`` and the remaining commands are run from there.
 
 1. **mpi-sppy is importable and the CLI works.** This confirms the
    editable install succeeded and Python can import the package.
@@ -335,18 +343,18 @@ command from the top of the cloned ``mpi-sppy`` repository.
 
    .. code-block:: text
 
-      python -m mpisppy.generic_cylinders --module-name farmer \
-          --num-scens 3 --EF --EF-solver-name gurobi
+      python -m mpisppy.generic_cylinders --module-name farmer --num-scens 3 --EF --EF-solver-name gurobi
 
    You should see the solver print progress and the script print an
    optimal objective value. This check does *not* use MPI.
 
-3. **MPI works** (only if you installed MPI and ``mpi4py``). From the
-   repository root, run the bundled one-sided MPI test:
+3. **MPI works** (only if you installed MPI and ``mpi4py``). Still in
+   ``examples/farmer``, run the bundled one-sided MPI test (its path is
+   given relative to ``examples/farmer``):
 
    .. code-block:: text
 
-      mpiexec -n 2 python -m mpi4py mpi_one_sided_test.py
+      mpiexec -n 2 python -m mpi4py ../../mpi_one_sided_test.py
 
    If you see no error messages, your MPI installation should be
    suitable. Then confirm the full hub-and-spoke flow with a short PH
@@ -354,10 +362,7 @@ command from the top of the cloned ``mpi-sppy`` repository.
 
    .. code-block:: text
 
-      mpiexec -n 3 python -m mpi4py -m mpisppy.generic_cylinders \
-          --module-name farmer --num-scens 3 \
-          --solver-name gurobi --max-iterations 5 \
-          --default-rho 1 --lagrangian --xhatshuffle
+      mpiexec -n 3 python -m mpi4py -m mpisppy.generic_cylinders --module-name farmer --num-scens 3 --solver-name gurobi --max-iterations 5 --default-rho 1 --lagrangian --xhatshuffle
 
    You should see iteration output and the run should terminate
    normally.

--- a/doc/src/secretmenu.rst
+++ b/doc/src/secretmenu.rst
@@ -12,15 +12,18 @@ If the `linearize_proximal_terms` option is specified (see :ref:`linearize_proxi
 then the option 'initial_proximal_cut_count' controls
 the initial number of cuts (default 2).
 
-E.g. if you wanted to specify four cuts
-in ``examples.farmer.farmer_cylinders`` where the
-hub definition dictionary is called ``hub_dict`` you would add
+E.g. if you wanted to specify four cuts in a hand-wired driver such as
+``examples.farmer.archive.farmer_cylinders`` (where the hub definition
+dictionary is called ``hub_dict``) you would add
 
 .. code-block:: python
-                
+
    hub_dict["opt_kwargs"]["PHoptions"]["initial_proximal_cut_count"] = 4
 
-before passing ``hub_dict`` to ``spin_the_wheel``.
+before passing ``hub_dict`` to ``spin_the_wheel``. When running through
+``generic_cylinders.py`` instead, this option is not currently exposed
+as a CLI flag and must be set by modifying the configured ``hub_dict``
+in code.
 
 
 subgradient_while_waiting

--- a/doc/src/seqsamp.rst
+++ b/doc/src/seqsamp.rst
@@ -5,7 +5,7 @@ Sequential sampling
 
 Given a confidence interval, one can try to find a candidate solution
 ``xhat_one`` such that its optimality gap has this confidence interval.
-The class ``SeqSampling`` in ``mpisppy.confiden_intervals.seqsampling.py`` implements three procedures described in 
+The class ``SeqSampling`` in ``mpisppy.confidence_intervals.seqsampling.py`` implements three procedures described in
 [bm2011]_ and [bpl2012]_. It takes as an input a method to generate
 candidate solutions and options, and its ``run`` method returns a ``xhat_one`` and a confidence interval on its optimality gap.
 


### PR DESCRIPTION
Documentation-only PR. Two related threads:

**1. Quick Start rewrite (commits 51303d40 ... a0db2d8a)**

The previous Installation section led with `pip install -e .` and only
mentioned GitHub afterward. Since the PyPI release lags `main`
substantially, the rewrite leads with the GitHub clone path and demotes
PyPI to a brief "not recommended" note at the end.

- New Prerequisites block (Python, git, solver, MPI-if-decomposing).
- Per-platform install: **Linux** (apt / dnf / conda for MPI),
  **macOS** (Homebrew or conda-forge; Apple Silicon note;
  xcode-select), **Windows** with two full paths --
  **WSL2** (recommended; `wsl --install`, apt prereqs, venv, clone,
  install) and **native MS-MPI** (both MS-MPI installers, PowerShell
  venv, conda-forge `mpi4py` with pip fallback, PowerShell bracket
  quoting for `".[mpi]"`, Windows-style `mpiexec` example).
- Optional "use of VS-Code" subsection at the top of the Windows path,
  explicitly flagged as skippable; covers extensions, opening the
  cloned folder (WSL2 `code .` vs native File -> Open Folder),
  interpreter selection, integrated terminal.
- **Verify Installation** rewritten as three numbered shell-neutral
  steps: (1) CLI/import via `--help` with a `ModuleNotFoundError`
  failure-mode hint; (2) solver check via `--EF --EF-solver-name`
  on farmer with three scenarios; (3) MPI check inlining
  `mpi_one_sided_test.py` + a small PH run.
  This path is exercised in CI by the dedicated `nompi4py` job in
  `.github/workflows/test_pr_and_main.yml` (step 1 + 2 only).
- **Reordering**: "What You Need to Provide For Your Problem" moved
  to after "Running the Farmer Example" so the reader sees a working
  invocation before being asked to think about writing their own
  module. Opens with "If your model is written in Pyomo, ...";
  closes with pointers to `:doc:\`agnostic\`` (AMPL/GAMS) and
  `:doc:\`smps\`` (SMPS-format input). The section heading is now
  "What You Need to Provide **For Your Problem**" to make it explicit
  whose problem the listed functions describe.
- "Researchers Who Want to Compare" section dropped.
- Pip-extras catalog (`mpi`, `doc`, `scipy`) moved out of Quick Start
  and into a new "Other pip extras" subsection at the end of
  `install_mpi.rst`.
- Other small fixes: `glpk` dropped from prereqs (can't solve PH
  subproblems with the standard quadratic prox without linearizing);
  drop "MIP" from the solver bullet; pre-existing `docs` -> `doc`
  extras typo fixed; "extensive form" consistently followed by
  "directly" wherever it appears in this chapter.

**2. New "Building Your Model File" Overview page (a0db2d8a)**

`doc/src/building_overview.rst` is added as the first entry under the
toctree's "Building Your Model File" caption (before
`scenario_creator.rst` and `helper_functions.rst`). It restates the
Quick Start "What You Need to Provide For Your Problem" content so
readers who land in this section by browsing the toc see the same
orientation without having to scroll back to Quick Start.

**3. Audit and fix of stale file references (24e1b39b)**

An audit of `doc/src/*.rst` surfaced a cluster of stale example-file
references that pre-dated two changes: (a) the consolidation of
hand-wired farmer driver scripts (`farmer_cylinders.py`, `cs_farmer.py`)
into `examples/farmer/archive/` in favor of `generic_cylinders.py`
driving `farmer.py`; (b) the move of farmer demo/CI scripts
(`farmer_ef.py`, `farmer_rho_demo.py`) into `examples/farmer/CI/`.

Path / typo fixes:
- `seqsamp.rst`: `mpisppy.confiden_intervals` -> `confidence_intervals`.
- `ef.rst`: `farmer_ef.py` moved to `examples/farmer/CI/`.
- `extensions.rst`: `farmer_rho_demo.py` moved to `examples/farmer/CI/`.
- `extensions.rst`: `uc_ama.py` lives under `examples/uc/`, not `sizes/`.

Re-pointed at `generic_cylinders.py` for the archived hand-wired
drivers, keeping the archived files mentioned as the underlying
pattern where the section is genuinely about the underlying class:

- `extensions.rst` (norm_rho_updater): enable via
  `--use-norm-rho-updater`; archived hand-wired example kept as fallback.
- `extensions.rst` (gradient_extension): enable via `--grad-rho`; demo
  at `examples/farmer/CI/farmer_rho_demo.py`.
- `extensions.rst` (cross-scenario cuts): no CLI exposure in
  `generic_cylinders`, so just fix the path to `archive/cs_farmer.py`.
- `hubs.rst` (NormRhoConverger pattern): note that `generic_cylinders`
  wires it automatically with `--use-norm-rho-updater`; keep the
  hand-wired import snippet pointing at its current archived location.
- `confidence_intervals.rst`: drop archived `farmer_cylinders.py`;
  keep `CI/farmer_ef.py` and `uc/uc_cylinders.py`; add pointer to
  `--incumbent-on-improvement-filename-prefix` (verified in
  `mpisppy/utils/config.py:311`) for automatic xhat writing.
- `secretmenu.rst` (initial_proximal_cut_count): clarify that the
  example driver is now under `archive/` and that the option is not
  exposed via CLI in `generic_cylinders`, so it must be set in code.
- `code_coverage.rst`: replace both `farmer_cylinders.py` `mpiexec`
  examples with the modern
  `mpiexec ... -m mpi4py -m mpisppy.generic_cylinders --module-name farmer` form.
- `drivers.rst` (`--crops-mult` example): re-point at `farmer.py`'s
  actual `inparser_adder` / `kw_creator` functions (the recommended
  pattern for problem-specific CLI args under `generic_cylinders`);
  keep the archived hand-wired equivalent as a parenthetical
  comparison.

**Build verification**

Sphinx build clean throughout. Only the pre-existing unrelated
warnings remain: `viewcode_import` config value, `FieldArray` docstring
indentation in `mpisppy/cylinders/spcommunicator.py`, `uc_cleanup.rst`
not in any visible toctree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)