### PR TITLE
fix(xhatbase): use branching_factors[0] for stage2 node count

### DIFF
--- a/mpisppy/extensions/xhatbase.py
+++ b/mpisppy/extensions/xhatbase.py
@@ -144,8 +144,9 @@ class XhatBase(mpisppy.extensions.extension.Extension):
                 print("root comm size={}".format(self.comms["ROOT"].size))
                 raise
             # now form the EF for the appropriate number of second-stage scenario tree nodes
-            # Use the branching factors to figure out how many second-stage nodes.
-            stage2cnt = branching_factors[1]
+            # The count of second-stage tree nodes is branching_factors[0] (children of ROOT);
+            # branching_factors[1] is the per-second-stage-node branching, not the count.
+            stage2cnt = branching_factors[0]
             rankcnt = self.n_proc
             # The next assert is important.
             assert stage2cnt % rankcnt== 0, "for stage2ef, ranks must be a multiple of stage2 nodes"            

--- a/mpisppy/tests/examples/hydro/hydro.py
+++ b/mpisppy/tests/examples/hydro/hydro.py
@@ -192,7 +192,13 @@ def MakeNodesforScen(model, BFs, scennum):
         Args:
             BFs (list of int): branching factors
     """
-    ndn = "ROOT_"+str((scennum-1) // BFs[0]) # scennum is one-based
+    # Divide by the product of the branching factors that come after the node;
+    # for a 3-stage tree that's BFs[1]. This must agree with
+    # sputils.create_nodenames_from_branching_factors, which builds BFs[0]
+    # second-stage nodes (ROOT_0 .. ROOT_{BFs[0]-1}). Using BFs[0] as the
+    # divisor here happens to give the same answer when BFs[0]==BFs[1] but
+    # disagrees with the canonical convention for asymmetric trees.
+    ndn = "ROOT_"+str((scennum-1) // BFs[1]) # scennum is one-based
     retval = [scenario_tree.ScenarioNode("ROOT",
                                          1.0,
                                          1,

--- a/mpisppy/tests/test_with_cylinders.py
+++ b/mpisppy/tests/test_with_cylinders.py
@@ -211,6 +211,44 @@ class Test_hydro_with_cylinders(unittest.TestCase):
             self.assertTrue(wheel.BestInnerBound is not None)
             self.assertTrue(wheel.BestOuterBound is not None)
 
+    @unittest.skipIf(not solver_available,
+                     "no solver is available")
+    def test_xhatshuffle_stage2ef_asymmetric_bf(self):
+        """Regression test: asymmetric branching factors must use bf[0] as the
+        second-stage node count, not bf[1].
+
+        With branching_factors=[2,3] and 2 ranks, the count of second-stage
+        nodes is 2 (=bf[0]); the buggy code used bf[1]=3 and tripped the
+        `stage2cnt % rankcnt == 0` assertion (3 % 2 != 0)."""
+        branching_factors = [2, 3]
+        num_scens = branching_factors[0] * branching_factors[1]
+        all_scenario_names = [f"Scen{i+1}" for i in range(num_scens)]
+        all_nodenames = sputils.create_nodenames_from_branching_factors(
+            branching_factors)
+        self.cfg.branching_factors = branching_factors
+
+        scenario_creator_kwargs = {"branching_factors": branching_factors}
+        beans = (self.cfg, hydro.scenario_creator,
+                 hydro.scenario_denouement, all_scenario_names)
+
+        hub_dict = vanilla.ph_hub(*beans,
+                                  scenario_creator_kwargs=scenario_creator_kwargs,
+                                  all_nodenames=all_nodenames)
+
+        xhatshuffle_spoke = vanilla.xhatshuffle_spoke(
+            *beans,
+            scenario_creator_kwargs=scenario_creator_kwargs,
+            all_nodenames=all_nodenames)
+        xhatshuffle_spoke["opt_kwargs"]["options"]["stage2_ef_solver_name"] = solver_name
+        xhatshuffle_spoke["opt_kwargs"]["options"]["branching_factors"] = branching_factors
+
+        wheel = WheelSpinner(hub_dict, [xhatshuffle_spoke])
+        wheel.spin()
+
+        if wheel.global_rank == 0:
+            self.assertTrue(wheel.BestInnerBound is not None)
+            self.assertTrue(wheel.BestOuterBound is not None)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

- Fix off-by-one in `XhatBase._try_one` (stage2ef path): the count of second-stage scenario tree nodes is `branching_factors[0]` (children of ROOT), not `branching_factors[1]`. `branching_factors[1]` is the per-second-stage-node branching, which is unrelated.
- Companion fix in the test copy of hydro (`mpisppy/tests/examples/hydro/hydro.py`) — `MakeNodesforScen` used `BFs[0]` as the divisor where the canonical `examples/hydro/hydro.py` and `sputils.create_nodenames_from_branching_factors` use `BFs[1]`. Both bugs were invisible under the only existing test (`branching_factors=[2,2]`, where both indices coincide).
- Add `test_xhatshuffle_stage2ef_asymmetric_bf` (`branching_factors=[2,3]`, 2 ranks). It fails on the pre-fix code (RuntimeError at the `local_2ndns` count check) and passes after.

## Test plan

- [x] Pre-fix: new test fails as described
- [x] Post-fix: new test + existing `test_xhatshuffle_stage2ef` (BF=[2,2]) both pass under `mpiexec -np 2 python -m mpi4py -m unittest mpisppy.tests.test_with_cylinders.Test_hydro_with_cylinders`
- [x] `Test_hydro` in `test_ef_ph.py` (BF=[3,3]) still green — no regression for symmetric callers
- [x] Full `test_with_cylinders.py` green (6 tests) under `mpiexec -np 2`
- [x] `ruff check .` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)