### PR TITLE
flex-ranks phase 3a: per-field coherence policy (DUALS strict)

### DIFF
--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -977,6 +977,7 @@ jobs:
           cd mpisppy/tests
           mpiexec -np 6 coverage run $COV_ARGS -m mpi4py test_spwindow_multisource.py
           mpiexec -np 6 coverage run $COV_ARGS -m mpi4py test_flexible_rank_cylinders.py
+          mpiexec -np 6 coverage run $COV_ARGS -m mpi4py test_flexible_rank_duals.py
 
       - name: Upload coverage data
         if: always()
@@ -1138,7 +1139,8 @@ jobs:
             mpisppy/tests/test_rank_apportionment.py \
             mpisppy/tests/test_overlap_map.py \
             mpisppy/tests/test_spwindow_partial_get.py \
-            mpisppy/tests/test_flexible_rank_ratios.py
+            mpisppy/tests/test_flexible_rank_ratios.py \
+            mpisppy/tests/test_flex_coherence_policy.py
 
       - name: Upload coverage data
         if: always()

--- a/mpisppy/cylinders/spcommunicator.py
+++ b/mpisppy/cylinders/spcommunicator.py
@@ -52,6 +52,41 @@ _GLOBAL_OR_SCALAR_FIELDS = frozenset((
     Field.EXPECTED_REDUCED_COST,
 ))
 
+# Per-scenario fields that require *strict* coherence when assembled across
+# ranks: every contributing source must be at the same write_id, or the read
+# is rejected and retried. DUALS carries the PH multipliers W_s, whose
+# normalization sum_s p_s W_s = 0 holds only within a single iteration --
+# stitching W from mixed iterations yields an invalid Lagrangian bound. Every
+# other per-scenario field uses *relaxed* coherence (the assembled value may
+# mix iterations; its consumers re-evaluate, so it is always honest).
+_STRICT_COHERENCE_FIELDS = frozenset((
+    Field.DUALS,
+))
+
+
+def reduce_source_write_ids(source_ids, strict: bool) -> int:
+    """Reduce the per-source write_ids of a multi-source read to the single id
+    this rank will compare against its last-accepted id.
+
+    Args:
+        source_ids: write_ids read from each contributing remote rank.
+        strict: if True, the sources must agree on one id (strict coherence);
+            a disagreement returns the sentinel ``-1`` so the read is rejected
+            (it is < any real id, and it breaks the cross-reader agreement
+            check, so every reader rejects together). If False (relaxed), the
+            floor over sources is taken -- a mixed-iteration assembly is
+            accepted, which is fine for fields whose consumers re-evaluate.
+
+    Returns:
+        int: the accepted write_id, or ``-1`` to reject (strict mismatch),
+        or ``0`` when there are no sources.
+    """
+    if not source_ids:
+        return 0
+    if strict:
+        return source_ids[0] if len(set(source_ids)) == 1 else -1
+    return min(source_ids)
+
 def communicator_array(data_length: int):
     """
     Allocate an MPI memory region with a padded length (multiple of 8 doubles = 64B),
@@ -717,13 +752,21 @@ class SPCommunicator:
         """Assemble a per-scenario field from several of a peer cylinder's
         global ranks using the precomputed overlap map.
 
-        Coherence note. This rank's id is the coherent floor (min) over its
-        sources rather than per-source independent acceptance: a synchronous
-        hub writes all its ranks at one id, so every reader computes the same
-        value and then clears the shared _write_ids_agree check together; a
-        transient mixed-id read floors low, fails agreement, and is retried.
-        (Per-source relaxed acceptance, which would need consumer cooperation,
-        and strict per-field policies such as DUALS are later phases.)
+        Coherence note. The per-source write_ids are reduced to this rank's
+        `new_id` by a per-field coherence policy (reduce_source_write_ids):
+
+          * relaxed (default): `new_id` is the floor (min) over sources -- the
+            assembled value may mix iterations, which is fine for fields whose
+            consumers re-evaluate (NONANTS_VALS, ...);
+          * strict (`_STRICT_COHERENCE_FIELDS`, e.g. DUALS): all sources must
+            share one id, else `new_id` is a sentinel (-1) that rejects the
+            read -- a mixed-iteration assembly would be invalid.
+
+        `new_id` then feeds the shared _write_ids_agree check, so the strict
+        rejection is collective-safe: the sentinel (below any real id) simply
+        breaks agreement and every reader rejects together (no early return, no
+        deadlock). With a synchronous hub all sources share an id, so strict
+        reads pass normally and a transient mixed-id read is retried.
         """
         if synchronize:
             self.cylinder_comm.Barrier()
@@ -738,16 +781,17 @@ class SPCommunicator:
         # also defer writing into buf until the read is accepted, so a rejected
         # (mixed-id) read never leaves stale data behind.
         source_snapshots = {}
-        new_id = None
+        source_ids = []
         for r in self._overlap_source_ranks[(field, peer_cylinder)]:
             _, logical_len, padded_len = self.window.strata_buffer_layouts[r][field]
             snapshot = np.empty(padded_len, dtype="d")
             self.window.get(snapshot, r, field)
             source_snapshots[r] = snapshot
-            rid = int(snapshot[logical_len - 1])
-            new_id = rid if new_id is None else min(new_id, rid)
-        if new_id is None:
-            new_id = 0
+            source_ids.append(int(snapshot[logical_len - 1]))
+
+        new_id = reduce_source_write_ids(
+            source_ids, strict=field in _STRICT_COHERENCE_FIELDS
+        )
 
         if not self._write_ids_agree(new_id, synchronize):
             buf._is_new = False

--- a/mpisppy/tests/test_flex_coherence_policy.py
+++ b/mpisppy/tests/test_flex_coherence_policy.py
@@ -1,0 +1,56 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+"""Unit tests for the per-field coherence policy used by the unequal-rank
+multi-source reader (spcommunicator.reduce_source_write_ids).
+
+The MPI integration tests run against a synchronous PH hub, where all sources
+of a field always carry the same write_id -- so strict and relaxed behave
+identically there and cannot distinguish the policies. These tests pin the
+policy logic directly: strict rejects a mixed-iteration read, relaxed accepts
+the floor."""
+
+import unittest
+
+from mpisppy.cylinders.spcommunicator import reduce_source_write_ids
+
+
+class TestReduceSourceWriteIds(unittest.TestCase):
+
+    def test_relaxed_takes_floor(self):
+        # Relaxed: the assembled value may mix iterations; report the floor so
+        # "new" is detected only once every source has advanced past it.
+        self.assertEqual(reduce_source_write_ids([5, 5, 5], strict=False), 5)
+        self.assertEqual(reduce_source_write_ids([7, 5, 6], strict=False), 5)
+        self.assertEqual(reduce_source_write_ids([3], strict=False), 3)
+
+    def test_strict_accepts_only_when_all_agree(self):
+        # Strict: a single shared id is accepted as-is.
+        self.assertEqual(reduce_source_write_ids([5, 5, 5], strict=True), 5)
+        self.assertEqual(reduce_source_write_ids([9], strict=True), 9)
+
+    def test_strict_rejects_mixed_with_sentinel(self):
+        # Strict: any disagreement -> sentinel -1 (reject). -1 is below any
+        # real write_id, so `new_id > last_id` is false, and it breaks the
+        # cross-reader sum-equality check so every reader rejects together.
+        self.assertEqual(reduce_source_write_ids([5, 4], strict=True), -1)
+        self.assertEqual(reduce_source_write_ids([7, 5, 6], strict=True), -1)
+        self.assertEqual(reduce_source_write_ids([1, 1, 2], strict=True), -1)
+
+    def test_empty_sources_is_zero(self):
+        self.assertEqual(reduce_source_write_ids([], strict=True), 0)
+        self.assertEqual(reduce_source_write_ids([], strict=False), 0)
+
+    def test_sentinel_is_below_any_initial_id(self):
+        # The reject sentinel must be < the initial buffer id (0) so a rejected
+        # strict read is never reported new.
+        self.assertLess(reduce_source_write_ids([2, 3], strict=True), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mpisppy/tests/test_flexible_rank_duals.py
+++ b/mpisppy/tests/test_flexible_rank_duals.py
@@ -1,0 +1,120 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+"""Unequal-rank integration test for the *strict*-coherence path (DUALS).
+
+Runs farmer with a PH hub and a Lagrangian spoke at unequal rank counts. The
+Lagrangian spoke receives DUALS (the PH multipliers W_s) from the hub, which
+crosses cylinders and is assembled multi-source. DUALS uses strict coherence:
+the dual normalization sum_s p_s W_s = 0 holds only within a single PH
+iteration, so a W stitched from mixed iterations would yield an *invalid*
+Lagrangian bound (one that need not lower-bound the optimum).
+
+Correctness is pinned two ways, both on fullcomm windows (environment-safe):
+  * 4+2 vs 2+4 must produce the same Lagrangian outer bound -- the hub's W
+    trajectory is a global reduction independent of the rank split, so the
+    reassembled W (and the bound it yields) must match across both splits; and
+  * the bound must be a valid lower bound on the extensive-form optimum.
+
+A mixed-iteration (non-strict) assembly would break the second property and/or
+make the two splits disagree.
+
+mpiexec -np 6 python -m mpi4py -m pytest mpisppy/tests/test_flexible_rank_duals.py
+"""
+
+import unittest
+
+from mpi4py import MPI
+
+from mpisppy.utils import config
+import mpisppy.utils.cfg_vanilla as vanilla
+import mpisppy.tests.examples.farmer as farmer
+from mpisppy.spin_the_wheel import WheelSpinner
+from mpisppy.tests.utils import get_solver
+
+comm = MPI.COMM_WORLD
+
+solver_available, solver_name, persistent_available, persistent_solver_name = get_solver()
+
+# Extensive-form optimum for farmer NUM_SCENS=10 (see test_flexible_rank_cylinders).
+EF_OPT = -122146.70
+
+
+def _build_dicts(num_scens, max_iterations, hub_ratio, spoke_ratio):
+    cfg = config.Config()
+    cfg.num_scens_required()
+    cfg.popular_args()
+    cfg.two_sided_args()
+    cfg.ph_args()
+    cfg.lagrangian_args()
+    cfg.solver_name = solver_name
+    cfg.num_scens = num_scens
+    cfg.default_rho = 1.0
+    cfg.max_iterations = max_iterations
+    cfg.rel_gap = 1e-6
+
+    scenario_creator = farmer.scenario_creator
+    scenario_denouement = farmer.scenario_denouement
+    all_scenario_names = farmer.scenario_names_creator(num_scens)
+    scenario_creator_kwargs = farmer.kw_creator(cfg)
+    beans = (cfg, scenario_creator, scenario_denouement, all_scenario_names)
+
+    hub_dict = vanilla.ph_hub(*beans, scenario_creator_kwargs=scenario_creator_kwargs)
+    hub_dict["rank_ratio"] = hub_ratio
+
+    lagrangian_spoke = vanilla.lagrangian_spoke(
+        *beans, scenario_creator_kwargs=scenario_creator_kwargs
+    )
+    lagrangian_spoke["rank_ratio"] = spoke_ratio
+
+    return hub_dict, [lagrangian_spoke]
+
+
+def _run(num_scens, max_iterations, hub_ratio, spoke_ratio):
+    hub_dict, spoke_list = _build_dicts(
+        num_scens, max_iterations, hub_ratio, spoke_ratio
+    )
+    wheel = WheelSpinner(hub_dict, spoke_list)
+    wheel.spin()
+    if wheel.global_rank == 0:
+        payload = wheel.BestOuterBound
+    else:
+        payload = None
+    return comm.bcast(payload, root=0)
+
+
+@unittest.skipUnless(comm.size == 6, "needs exactly 6 MPI ranks")
+@unittest.skipUnless(solver_available, "no solver is available")
+class TestFlexibleRankDuals(unittest.TestCase):
+
+    NUM_SCENS = 10
+    MAX_ITERS = 50
+
+    def test_strict_duals_both_directions_agree_and_bound_valid(self):
+        ob_42 = _run(self.NUM_SCENS, self.MAX_ITERS, 1.0, 0.5)  # 4-rank hub, 2-rank spoke
+        ob_24 = _run(self.NUM_SCENS, self.MAX_ITERS, 1.0, 2.0)  # 2-rank hub, 4-rank spoke
+
+        # Finite bound (a broken read would give inf or error out).
+        self.assertTrue(abs(ob_42) < float("inf"))
+        self.assertTrue(abs(ob_24) < float("inf"))
+
+        # The hub's W trajectory is rank-split-independent, so the reassembled
+        # W -- and the Lagrangian bound it yields -- must match across splits.
+        self.assertLess(
+            abs(ob_42 - ob_24), 1e-3 * abs(ob_42),
+            msg=f"4+2 Lagrangian bound {ob_42} disagrees with 2+4 {ob_24}",
+        )
+
+        # A *valid* Lagrangian bound lower-bounds the (minimizing) optimum.
+        # A mixed-iteration W could violate this.
+        self.assertLessEqual(ob_42, EF_OPT + 1e-4 * abs(EF_OPT))
+        self.assertLessEqual(ob_24, EF_OPT + 1e-4 * abs(EF_OPT))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/run_coverage.bash
+++ b/run_coverage.bash
@@ -140,6 +140,9 @@ run_phase "test_spwindow_partial_get (serial)" \
 run_phase "test_flexible_rank_ratios (serial)" \
     coverage run --rcfile=.coveragerc -m pytest mpisppy/tests/test_flexible_rank_ratios.py -v
 
+run_phase "test_flex_coherence_policy (serial)" \
+    coverage run --rcfile=.coveragerc -m pytest mpisppy/tests/test_flex_coherence_policy.py -v
+
 run_phase "test_xhat_from_file (serial)" \
     coverage run --rcfile=.coveragerc -m pytest mpisppy/tests/test_xhat_from_file.py -v
 
@@ -189,6 +192,9 @@ run_phase "test_spwindow_multisource (mpiexec -np 6)" \
 
 run_phase "test_flexible_rank_cylinders (mpiexec -np 6)" \
     mpiexec -np 6 $OVERSUBSCRIBE coverage run --rcfile="$PROJ_DIR/.coveragerc" -m mpi4py mpisppy/tests/test_flexible_rank_cylinders.py
+
+run_phase "test_flexible_rank_duals (mpiexec -np 6)" \
+    mpiexec -np 6 $OVERSUBSCRIBE coverage run --rcfile="$PROJ_DIR/.coveragerc" -m mpi4py mpisppy/tests/test_flexible_rank_duals.py
 
 # ---------- Tests that spawn mpiexec internally ----------
 


### PR DESCRIPTION
> **📚 Stacked PRs — flexible rank assignments**
> Reviewed and merged bottom-up; each PR targets the one below it.
>
> 1. **Pyomo/mpi-sppy#725 — Phase 1: infrastructure** — ✅ merged
> 2. **Pyomo/mpi-sppy#731 — Phase 2: communication layer** — ✅ merged
> 3. **Phase 3a: per-field coherence (DUALS strict)** ← _this PR_ (targets `main`)
> 4. **DLWoodruff/mpi-sppy-1#14 — Phase 3b: CLI rank-ratio flags** (targets `flex-ranks-phase3-coherence`)
> 5. **DLWoodruff/mpi-sppy-1#15 — Phase 4a: two-stage xhat fields** (targets `flex-ranks-phase3b-cli`)
>
> 6. **DLWoodruff/mpi-sppy-1#16 — Phase 4b: multistage per-node xhat sourcing** (targets `flex-ranks-phase4a-xhat-2stage`)
> 7. **DLWoodruff/mpi-sppy-1#17 — Phase 5: APH (asynchronous sender) verification** (targets `flex-ranks-phase4b-multistage`)
>
> _Later phases will be appended here as they open._

---

First slice of Phase 3 (`doc/designs/flexible_rank_assignments.md`): give the
unequal-rank multi-source reader a **per-field coherence policy**, so fields
that need a single coherent iteration (DUALS) are not stitched from mixed
iterations. Equal-rank path unchanged; this is reached only at non-default
rank ratios.

## What's here

- **`reduce_source_write_ids(source_ids, strict)`** reduces a multi-source
  read's per-source write_ids:
  - *relaxed* (default): floor over sources — the assembled value may mix
    iterations, fine for fields whose consumers re-evaluate (`NONANTS_VALS`);
  - *strict* (`_STRICT_COHERENCE_FIELDS = {DUALS}`): all sources must share one
    id, else sentinel `-1` rejects the read. `Σ pₛWₛ = 0` holds only within a
    PH iteration, so a `W` stitched across iterations is an invalid Lagrangian
    bound.
- **Collective-safe strict rejection:** the sentinel (`-1`, below any real id)
  breaks the cross-reader `Allreduce`-equality check (`_write_ids_agree`), so
  every reader rejects together — no early return before the collective, no
  deadlock.

This rebases cleanly onto the merged Phase 2: `reduce_source_write_ids` feeds
its `new_id` into the shared `_write_ids_agree` / `_mark_new` helpers that
Phase 2 introduced.

## Tests

- **`test_flex_coherence_policy.py`** (serial) pins the strict/relaxed
  reduction directly — a synchronous hub never produces mixed-id sources, so
  the MPI test alone can't distinguish the policies.
- **`test_flexible_rank_duals.py`** (np=6) — farmer PH hub + Lagrangian spoke
  at **4+2 and 2+4**; DUALS crosses cylinders (strict). Both directions agree
  and the Lagrangian bound validly lower-bounds the EF optimum.

Wired into `run_coverage.bash` + the `test-cylinders` CI job. Equal-rank
regression (`test_with_cylinders` np=2) unaffected.

## Not here (separate follow-on PRs)

- **cross_scen multi-source** — `CrossScenarioCutSpoke` has a custom
  `register_receive_fields`, an `nscen`-per-scenario `CROSS_SCENARIO_COST`
  layout, and a pre-existing `FieldLengths` inconsistency (`local²` vs
  `nscen·local`) to untangle. Too complex/risky to bundle with the coherence
  framework.
- **CLI `--<spoke>-rank-ratio` flags** end to end.

BEST_XHAT/RECENT_XHATS first-stage sourcing remains deferred to Phase 4 (next
to its FWPH consumer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
