### PR TITLE
fix(cg): broadcast best_solution_obj_val so a multi-rank CG hub doesn't deadlock (#729)

### DIFF
--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -1018,6 +1018,12 @@ jobs:
           cd mpisppy/tests
           mpiexec -np 2 coverage run $COV_ARGS -m mpi4py test_cg_with_cylinders.py
 
+      - name: run multi-rank CG hub test
+        timeout-minutes: 10
+        run: |
+          cd mpisppy/tests
+          mpiexec -np 4 coverage run $COV_ARGS -m mpi4py test_cg_multirank_hub.py
+
       - name: run DCG serial tests
         timeout-minutes: 10
         run: |

--- a/mpisppy/cgbase.py
+++ b/mpisppy/cgbase.py
@@ -683,10 +683,15 @@ class CGBase(mpisppy.spopt.SPOpt):
                     print("Iteration time: %6.2f" % (time.time() - iteration_start_time))
                     print("Elapsed time:   %6.2f" % (time.perf_counter() - self.start_time))
 
-            # Broadcast updated bound and convergence metric
+            # Broadcast updated bounds and convergence metric so that
+            # is_converged() (which feeds determine_termination via the inner
+            # bound) reaches the same verdict on every hub rank. Without
+            # broadcasting best_solution_obj_val, only rank 0's gap updates and
+            # ranks can disagree on termination, deadlocking a multi-rank hub.
             self.best_bound_obj_val = self.mpicomm.bcast(self.best_bound_obj_val, root=0)
+            self.best_solution_obj_val = self.mpicomm.bcast(self.best_solution_obj_val, root=0)
             self.conv = self.mpicomm.bcast(self.conv, root=0)
-            
+
             if self.spcomm and self.spcomm.is_converged():
                 global_toc("Cylinder convergence", self.cylinder_rank == 0)
                 break

--- a/mpisppy/opt/dualcg.py
+++ b/mpisppy/opt/dualcg.py
@@ -267,7 +267,10 @@ class DCG(mpisppy.cgbase.CGBase):
                     print("Iteration time: %6.2f" % (time.time() - iteration_start_time))
                     print("Elapsed time:   %6.2f" % (time.perf_counter() - self.start_time))
                 
+            # Broadcast both bounds and the convergence metric so is_converged()
+            # reaches the same verdict on every hub rank (see CGBase.iterk_loop).
             self.best_bound_obj_val = self.mpicomm.bcast(self.best_bound_obj_val, root=0)
+            self.best_solution_obj_val = self.mpicomm.bcast(self.best_solution_obj_val, root=0)
             self.conv = self.mpicomm.bcast(self.conv, root=0)
             if self.spcomm and self.spcomm.is_converged():
                 global_toc("Cylinder convergence", self.cylinder_rank == 0)

--- a/mpisppy/tests/test_cg_multirank_hub.py
+++ b/mpisppy/tests/test_cg_multirank_hub.py
@@ -1,0 +1,95 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+"""
+Exercise a CG hub that spans more than one MPI rank.
+
+    mpiexec -np 4 python -m mpi4py test_cg_multirank_hub.py
+
+With one hub plus one spoke at np=4, WheelSpinner gives each cylinder two
+ranks, so the CG hub's cylinder_comm has rank 0 and rank 1. This is the first
+configuration to put more than one rank under a CG hub, and it covers the
+convergence-path shutdown that used to deadlock when per-iteration results
+(in particular best_solution_obj_val) were computed on rank 0 but not
+broadcast across the hub (issue #729): the hub ranks would then disagree on
+the termination verdict, with one rank breaking out of the iteration loop
+while another blocked forever at the next master-problem broadcast.
+"""
+
+import unittest
+from mpisppy.utils import config
+
+import mpisppy.utils.cfg_vanilla as vanilla
+import mpisppy.tests.examples.farmer as farmer
+from mpisppy.spin_the_wheel import WheelSpinner
+from mpisppy.tests.utils import get_solver
+
+__version__ = 0.1
+
+from mpi4py import MPI
+comm = MPI.COMM_WORLD
+assert comm.size == 4, "These tests need four ranks (two-rank CG hub)"
+
+# CG needs a non-persistent master solver; the persistent interface raises
+# "Please use set_instance ..." on the CG master.
+solver_available, solver_name, persistent_available, persistent_solver_name = \
+    get_solver(persistent_OK=False)
+
+
+def _create_cfg():
+    cfg = config.Config()
+    cfg.num_scens_required()
+    cfg.popular_args()
+    cfg.ph_args()
+    cfg.two_sided_args()
+    cfg.cg_args()
+    cfg.solver_name = solver_name
+    return cfg
+
+
+class Test_cg_multirank_hub(unittest.TestCase):
+    """ A CG hub spanning two ranks must reach convergence without deadlocking. """
+
+    def _create_stuff(self, iters=10):
+        self.cfg.num_scens = 6
+        self.cfg.max_iterations = iters
+        self.cfg.rel_gap = 0.005
+        scenario_creator = farmer.scenario_creator
+        scenario_denouement = farmer.scenario_denouement
+        all_scenario_names = farmer.scenario_names_creator(self.cfg.num_scens)
+        scenario_creator_kwargs = farmer.kw_creator(self.cfg)
+        beans = (self.cfg, scenario_creator, scenario_denouement, all_scenario_names)
+        hub_dict = vanilla.cg_hub(*beans, scenario_creator_kwargs=scenario_creator_kwargs)
+        return scenario_creator_kwargs, beans, hub_dict
+
+    def setUp(self):
+        self.cfg = _create_cfg()
+
+    @unittest.skipIf(not solver_available, "no solver is available")
+    def test_two_rank_hub_converges(self):
+        self.cfg.default_rho = 1
+        self.cfg.xhatshuffle_args()
+        scenario_creator_kwargs, beans, hub_dict = self._create_stuff()
+
+        list_of_spoke_dict = list()
+        xhatshuffle_spoke = vanilla.xhatshuffle_spoke(
+            *beans, scenario_creator_kwargs=scenario_creator_kwargs)
+        list_of_spoke_dict.append(xhatshuffle_spoke)
+
+        wheel = WheelSpinner(hub_dict, list_of_spoke_dict)
+        # If the hub ranks disagree on termination (issue #729) this hangs.
+        wheel.spin()
+
+        if wheel.strata_rank == 0:  # a CG hub rank
+            cg_object = wheel.spcomm.opt
+            self.assertIsNotNone(cg_object)
+            self.assertIsNotNone(cg_object.conv)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/run_coverage.bash
+++ b/run_coverage.bash
@@ -175,6 +175,11 @@ run_phase "test_cg_main (serial)" \
 run_phase "test_cg_with_cylinders (mpiexec -np 2)" \
     mpiexec -np 2 coverage run --rcfile="$PROJ_DIR/.coveragerc" -m mpi4py mpisppy/tests/test_cg_with_cylinders.py
 
+# A CG hub spanning two ranks (one hub + one spoke at np=4) covers the
+# convergence-path broadcast that used to deadlock a multi-rank hub (#729).
+run_phase "test_cg_multirank_hub (mpiexec -np 4)" \
+    mpiexec -np 4 $OVERSUBSCRIBE coverage run --rcfile="$PROJ_DIR/.coveragerc" -m mpi4py mpisppy/tests/test_cg_multirank_hub.py
+
 run_phase "test_dualcg_main (serial)" \
     coverage run --rcfile=.coveragerc mpisppy/tests/test_dualcg_main.py
 


### PR DESCRIPTION
Fixes #729.

### Problem

A `CGHub` run deadlocks during convergence-path shutdown whenever the CG hub cylinder has more than one MPI rank. It hangs after printing the inter-cylinder-gap termination message.

In `CGBase.iterk_loop`, the per-iteration `best_bound_obj_val` and `conv` are broadcast across the hub's `cylinder_comm`, but `best_solution_obj_val` (set on rank 0 in the LP branch, `cgbase.py:665`) is **not**. `CGHub.is_converged()` derives `BestInnerBound` — and thus the gap that `determine_termination` checks — from `best_solution_obj_val`. So with >1 hub rank, rank 0 saw the updated gap and `break`-ed out of the iteration loop while the other ranks kept `None`, did not terminate, and blocked forever at the next master-problem broadcast (`cgbase.py:638`).

This was latent because CG is otherwise only exercised at one rank per cylinder (the `np=2` suites). It surfaces as soon as the CG hub spans more than one rank.

### Fix

Broadcast `best_solution_obj_val` across the hub's `cylinder_comm` alongside `best_bound_obj_val` and `conv`, so `is_converged()` is coherent across all hub ranks. The same defensive broadcast is added to `DCG.iterk_loop` to keep the two loops parallel (DCG does not set `best_solution_obj_val` today, so it is coherently `None` there, but this guards against a future LP branch reintroducing the divergence).

### Test

Adds `mpisppy/tests/test_cg_multirank_hub.py`: an `np=4` run that gives the CG hub two ranks (equal-rank 2+2: CG hub + xhatshuffle spoke). It converges to the EF optimum with the fix and **deadlocks without it** (verified by reverting the broadcast — the run times out). This needs no flexible-rank infrastructure; it reproduces the bug on the plain equal-rank path.

Wired into `run_coverage.bash` and `.github/workflows/test_pr_and_main.yml` (`mpiexec -np 4`).

### Note on #730

#730 (the unequal-rank XFEAS end-to-end test + `--ph-xfeas-spoke-rank-ratio`) is a separate follow-up. It is gated not only on this fix but also on the XFEAS multi-source assembly (flex-ranks phase 4a) and the CLI rank-ratio flags (phase 3b), which are not yet on `main` — on `main`, `_items_per_scen_for_field` raises `NotImplementedError` for `XFEAS`. So #730 stays open pending those phases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)