### PR TITLE
flex-ranks phase 3b: CLI --<spoke>-rank-ratio flags

### DIFF
--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -1140,7 +1140,8 @@ jobs:
             mpisppy/tests/test_overlap_map.py \
             mpisppy/tests/test_spwindow_partial_get.py \
             mpisppy/tests/test_flexible_rank_ratios.py \
-            mpisppy/tests/test_flex_coherence_policy.py
+            mpisppy/tests/test_flex_coherence_policy.py \
+            mpisppy/tests/test_flexible_rank_cli.py
 
       - name: Upload coverage data
         if: always()

--- a/mpisppy/cylinders/spcommunicator.py
+++ b/mpisppy/cylinders/spcommunicator.py
@@ -676,11 +676,18 @@ class SPCommunicator:
         if field in (Field.NONANTS_VALS, Field.RELAXED_NONANTS_VALS, Field.DUALS):
             k = self.opt.nonant_length
             return [k] * len(self.opt.all_scenario_names)
+        # Reached at startup (window creation), not mid-solve: this cylinder is
+        # in a flexible-rank run and reads a per-scenario field whose
+        # multi-source assembly across unequal rank counts is not implemented
+        # yet. Fail here with an actionable message rather than mis-assembling.
         raise NotImplementedError(
-            f"multi-source assembly of {field} under unequal rank counts is "
-            f"not implemented in the communication-layer cut; only the "
-            f"per-scenario nonant fields (NONANTS_VALS, RELAXED_NONANTS_VALS, "
-            f"DUALS) are supported so far."
+            f"Flexible (unequal) rank assignments: {self.__class__.__name__} "
+            f"reads {field.name}, whose multi-source assembly across cylinders "
+            f"with different rank counts is not supported yet (only "
+            f"{Field.NONANTS_VALS.name}, {Field.RELAXED_NONANTS_VALS.name}, and "
+            f"{Field.DUALS.name} are). Run the cylinders that exchange "
+            f"{field.name} at equal rank counts (rank_ratio == 1.0), or wait "
+            f"for the phase that adds {field.name} support."
         )
 
     def _validate_segment(self, field: Field, remote_global_rank: int, seg) -> None:

--- a/mpisppy/generic/spokes.py
+++ b/mpisppy/generic/spokes.py
@@ -55,6 +55,7 @@ def build_spoke_list(cfg, beans, scenario_creator_kwargs,
         if (cfg.lagrangian_starting_mipgap is not None
                 or cfg.lagrangian_mipgaps_json is not None):
             vanilla.add_gapper(lagrangian_spoke, cfg, "lagrangian")
+        lagrangian_spoke["rank_ratio"] = cfg.lagrangian_rank_ratio
 
     # dual ph spoke
     if cfg.ph_dual:
@@ -140,6 +141,7 @@ def build_spoke_list(cfg, beans, scenario_creator_kwargs,
         if cfg.get("stage2_ef_solver_name") is not None:
             xhatshuffle_spoke["opt_kwargs"]["options"]["stage2_ef_solver_name"] = cfg["stage2_ef_solver_name"]
             xhatshuffle_spoke["opt_kwargs"]["options"]["branching_factors"] = cfg["branching_factors"]
+        xhatshuffle_spoke["rank_ratio"] = cfg.xhatshuffle_rank_ratio
 
     if cfg.xhatxbar:
         xhatxbar_spoke = vanilla.xhatxbar_spoke(*beans,
@@ -148,6 +150,7 @@ def build_spoke_list(cfg, beans, scenario_creator_kwargs,
                                                    all_nodenames=all_nodenames,
                                                    average_scenario_creator=average_scenario_creator,
                                                    feasible_xhat_creator=feasible_xhat_creator)
+        xhatxbar_spoke["rank_ratio"] = cfg.xhatxbar_rank_ratio
 
     # reduced cost fixer options setup
     if cfg.reduced_costs:

--- a/mpisppy/tests/test_flexible_rank_cli.py
+++ b/mpisppy/tests/test_flexible_rank_cli.py
@@ -1,0 +1,101 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+"""The flexible-rank CLI flags (--<spoke>-rank-ratio) are declared with their
+spokes and flow through build_spoke_list onto each spoke dict's rank_ratio key,
+which WheelSpinner reads. Serial; no MPI."""
+
+import unittest
+
+from mpisppy.utils import config
+import mpisppy.tests.examples.farmer as farmer
+from mpisppy.generic.spokes import build_spoke_list
+
+
+def _full_cfg():
+    # Declare the same arg set the generic driver does (the subset that
+    # build_spoke_list reads), so every cfg flag it touches exists.
+    cfg = config.Config()
+    cfg.num_scens_required()
+    cfg.popular_args()
+    cfg.two_sided_args()
+    cfg.ph_args()
+    cfg.fwph_args()
+    cfg.lagrangian_args()
+    cfg.gapper_args("lagrangian")
+    cfg.ph_dual_args()
+    cfg.relaxed_ph_args()
+    cfg.ph_xfeas_spoke_args()
+    cfg.subgradient_args()
+    cfg.subgradient_bounder_args()
+    cfg.xhatshuffle_args()
+    cfg.xhatxbar_args()
+    cfg.reduced_costs_args()
+    cfg.sep_rho_args()
+    cfg.coeff_rho_args()
+    cfg.sensi_rho_args()
+    cfg.gradient_args()
+    cfg.gapper_args()
+    return cfg
+
+
+class TestFlexibleRankCLI(unittest.TestCase):
+
+    def test_rank_ratio_args_default_to_one(self):
+        cfg = _full_cfg()
+        self.assertEqual(cfg.lagrangian_rank_ratio, 1.0)
+        self.assertEqual(cfg.xhatshuffle_rank_ratio, 1.0)
+        self.assertEqual(cfg.xhatxbar_rank_ratio, 1.0)
+
+    def test_build_spoke_list_injects_rank_ratio(self):
+        cfg = _full_cfg()
+        cfg.num_scens = 6
+        cfg.lagrangian = True
+        cfg.lagrangian_rank_ratio = 0.5
+        cfg.xhatshuffle = True
+        cfg.xhatshuffle_rank_ratio = 0.25
+        cfg.xhatxbar = True
+        cfg.xhatxbar_rank_ratio = 2.0
+
+        scenario_creator = farmer.scenario_creator
+        scenario_denouement = farmer.scenario_denouement
+        all_scenario_names = farmer.scenario_names_creator(cfg.num_scens)
+        scenario_creator_kwargs = farmer.kw_creator(cfg)
+        beans = (cfg, scenario_creator, scenario_denouement, all_scenario_names)
+
+        spokes = build_spoke_list(
+            cfg, beans, scenario_creator_kwargs,
+            rho_setter=None, all_nodenames=None,
+        )
+
+        # exactly the three enabled spokes, each carrying its requested ratio
+        ratios = sorted(d["rank_ratio"] for d in spokes)
+        self.assertEqual(ratios, sorted([0.5, 0.25, 2.0]))
+        # and every spoke dict got an explicit rank_ratio
+        self.assertTrue(all("rank_ratio" in d for d in spokes))
+
+    def test_default_run_leaves_ratios_at_one(self):
+        # With no ratios set, enabled spokes default to 1.0 (equal-rank path).
+        cfg = _full_cfg()
+        cfg.num_scens = 6
+        cfg.xhatshuffle = True
+        scenario_creator = farmer.scenario_creator
+        scenario_denouement = farmer.scenario_denouement
+        all_scenario_names = farmer.scenario_names_creator(cfg.num_scens)
+        scenario_creator_kwargs = farmer.kw_creator(cfg)
+        beans = (cfg, scenario_creator, scenario_denouement, all_scenario_names)
+
+        spokes = build_spoke_list(
+            cfg, beans, scenario_creator_kwargs,
+            rho_setter=None, all_nodenames=None,
+        )
+        self.assertEqual([d["rank_ratio"] for d in spokes], [1.0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mpisppy/utils/config.py
+++ b/mpisppy/utils/config.py
@@ -745,6 +745,13 @@ class Config(pyofig.ConfigDict):
                               domain=bool,
                               default=False)
 
+        self.add_to_config('lagrangian_rank_ratio',
+                              description="MPI ranks for the lagrangian spoke "
+                                          "relative to the hub (flexible rank "
+                                          "assignments; default 1.0 = equal)",
+                              domain=float,
+                              default=1.0)
+
         self.add_solver_specs("lagrangian")
         self.add_mipgap_specs("lagrangian")
 
@@ -971,6 +978,13 @@ class Config(pyofig.ConfigDict):
                            domain=bool,
                            default=False)
 
+        self.add_to_config('xhatshuffle_rank_ratio',
+                           description="MPI ranks for the xhatshuffle spoke "
+                                       "relative to the hub (flexible rank "
+                                       "assignments; default 1.0 = equal)",
+                           domain=float,
+                           default=1.0)
+
         self.add_to_config('add_reversed_shuffle',
                            description="using also the reversed shuffling (multistage only, default True)",
                            domain=bool,
@@ -1069,6 +1083,13 @@ class Config(pyofig.ConfigDict):
                               description="have an xhatxbar spoke",
                               domain=bool,
                               default=False)
+
+        self.add_to_config('xhatxbar_rank_ratio',
+                              description="MPI ranks for the xhatxbar spoke "
+                                          "relative to the hub (flexible rank "
+                                          "assignments; default 1.0 = equal)",
+                              domain=float,
+                              default=1.0)
 
         self.add_to_config('xhatxbar_try_jensens_first',
                            description="before entering the xhatxbar main loop, solve "

--- a/run_coverage.bash
+++ b/run_coverage.bash
@@ -143,6 +143,9 @@ run_phase "test_flexible_rank_ratios (serial)" \
 run_phase "test_flex_coherence_policy (serial)" \
     coverage run --rcfile=.coveragerc -m pytest mpisppy/tests/test_flex_coherence_policy.py -v
 
+run_phase "test_flexible_rank_cli (serial)" \
+    coverage run --rcfile=.coveragerc -m pytest mpisppy/tests/test_flexible_rank_cli.py -v
+
 run_phase "test_xhat_from_file (serial)" \
     coverage run --rcfile=.coveragerc -m pytest mpisppy/tests/test_xhat_from_file.py -v
 


### PR DESCRIPTION
> **📚 Stacked PRs — flexible rank assignments**
> Reviewed and merged bottom-up; each PR targets the one below it.
>
> 1. **Pyomo/mpi-sppy#725 — Phase 1: infrastructure** — ✅ merged
> 2. **Pyomo/mpi-sppy#731 — Phase 2: communication layer** — ✅ merged
> 3. **Pyomo/mpi-sppy#736 — Phase 3a: per-field coherence (DUALS strict)** — ✅ merged
> 4. **Phase 3b: CLI rank-ratio flags** ← _this PR_ (targets `main`)
> 5. **DLWoodruff/mpi-sppy-1#15 — Phase 4a: two-stage xhat fields** (targets `flex-ranks-phase3b-cli`)
> 6. **DLWoodruff/mpi-sppy-1#16 — Phase 4b: multistage per-node xhat sourcing** (targets `flex-ranks-phase4a-xhat-2stage`)
> 7. **DLWoodruff/mpi-sppy-1#17 — Phase 5: APH (asynchronous sender) verification** (targets `flex-ranks-phase4b-multistage`)
>
> _Later phases will be appended here as they open._

---

Makes flexible ranks usable from the `generic_cylinders` command line, for the
spokes verified to work under unequal ranks.

## What's here

- **CLI flags** (`config.py`): `--lagrangian-rank-ratio` (DUALS, strict),
  `--xhatshuffle-rank-ratio` and `--xhatxbar-rank-ratio` (NONANTS_VALS,
  relaxed), each a float defaulting to `1.0` (equal), declared with its spoke.
  Spokes whose crossed fields aren't flex-supported yet (fwph, ph_xfeas, …)
  intentionally get **no** flag.
- **Injection** (`generic/spokes.py`): `build_spoke_list` sets each spoke
  dict's `rank_ratio` from its cfg value (what `WheelSpinner` reads).
- **Guard / defense in depth** (`spcommunicator.py`): the
  `_items_per_scen_for_field` error now names the spoke and is actionable, e.g.
  *"FWPHHub reads RECENT_XHATS, whose multi-source assembly … is not supported
  yet … run at rank_ratio == 1.0, or wait for the phase that adds RECENT_XHATS
  support."* It fires at **window creation** (startup), before solving, for any
  unsupported per-scenario field reached via any path (CLI, callback, or a
  hand-built dict) — so the not-yet-exposed spokes are protected too.

## Tests

- **`test_flexible_rank_cli.py`** (serial): ratio args default to 1.0;
  `build_spoke_list` injects the requested ratios; a default run stays at 1.0.

Wired into `run_coverage.bash` + the CI serial suite. `test_config.py` (85)
unaffected by the new args.

## Out of scope

- **cross_scen** multi-source — non-functional + untested upstream
  (Pyomo/mpi-sppy#728, sizing Pyomo/mpi-sppy#727); excluded from the flex stack.
- **BEST_XHAT / RECENT_XHATS** first-stage sourcing, **multistage**, and
  **FWPH** — Phase 4. Flags for those spokes arrive when their fields land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
