### PR TITLE
generic: let --module-name appear in any CLI position

### DIFF
--- a/mpisppy/generic/parsing.py
+++ b/mpisppy/generic/parsing.py
@@ -26,7 +26,10 @@ _IMPLICIT_MODULES = {
 }
 
 def model_fname():
-    """Extract the module name from the first CLI argument (--module-name).
+    """Extract the module name from the CLI arguments (--module-name).
+
+    ``--module-name`` may appear in any position on the command line, in
+    either the ``--module-name foo`` or ``--module-name=foo`` form.
 
     As an exception, ``--smps-dir`` and ``--mps-files-directory`` may be
     used instead of ``--module-name``; the appropriate module is inferred
@@ -34,46 +37,49 @@ def model_fname():
     implicit-module flags is an error.
     """
     def _bad_news():
-        raise RuntimeError("Unable to parse module name from first argument"
+        raise RuntimeError("Unable to parse module name from the command line"
                            " (for module foo.py, we want, e.g.\n"
                            "--module-name foo\n"
                            "or\n"
                            "--module-name=foo\n"
                            "Alternatively, use --smps-dir or"
-                           " --mps-files-directory as the first argument.")
-    def _len_check(needed_length):
-        if len(sys.argv) <= needed_length:
-            _bad_news()
-        else:
-            return True
+                           " --mps-files-directory.")
 
-    _len_check(1)
+    args = sys.argv[1:]
 
-    # Check for implicit module flags (--smps-dir, --mps-files-directory)
-    first_arg = sys.argv[1]
-    # Handle both --flag value and --flag=value forms
-    first_flag = first_arg.split("=")[0]
+    # Scan the whole command line for an explicit --module-name (any position).
+    module_name = None
+    for i, arg in enumerate(args):
+        if arg == "--module-name":
+            if i + 1 >= len(args):
+                _bad_news()
+            module_name = args[i + 1]
+            break
+        if arg.startswith("--module-name="):
+            module_name = arg.split("=", 1)[1]
+            if not module_name:
+                _bad_news()
+            break
 
-    if first_flag in _IMPLICIT_MODULES:
-        # Error if --module-name also appears on the command line
-        for arg in sys.argv[2:]:
-            if arg.startswith("--module-name"):
-                raise RuntimeError(
-                    f"Cannot use both {first_flag} and --module-name."
-                    f" {first_flag} implies --module-name"
-                    f" {_IMPLICIT_MODULES[first_flag]}")
-        return _IMPLICIT_MODULES[first_flag]
+    # Scan for an implicit-module flag (--smps-dir, --mps-files-directory).
+    # Handle both --flag value and --flag=value forms.
+    implicit_flag = None
+    for arg in args:
+        if arg.split("=")[0] in _IMPLICIT_MODULES:
+            implicit_flag = arg.split("=")[0]
+            break
 
-    if not first_arg.startswith("--module-name"):
+    if implicit_flag is not None:
+        if module_name is not None:
+            raise RuntimeError(
+                f"Cannot use both {implicit_flag} and --module-name."
+                f" {implicit_flag} implies --module-name"
+                f" {_IMPLICIT_MODULES[implicit_flag]}")
+        return _IMPLICIT_MODULES[implicit_flag]
+
+    if module_name is None:
         _bad_news()
-    if first_arg == "--module-name":
-        _len_check(2)
-        return sys.argv[2]
-    else:
-        parts = first_arg.split("=")
-        if len(parts) != 2:
-            _bad_news()
-        return parts[1]
+    return module_name
 
 
 def load_module(model_fname):

--- a/mpisppy/tests/test_pre_pickle_pipeline.py
+++ b/mpisppy/tests/test_pre_pickle_pipeline.py
@@ -28,6 +28,7 @@ from mpisppy.spbase import SPBase
 from mpisppy.utils import config
 from mpisppy.utils import sputils
 from mpisppy.generic.scenario_io import _run_pre_pickle_pipeline
+from mpisppy.generic.parsing import model_fname
 
 import mpisppy.MPI as mpi
 
@@ -591,6 +592,70 @@ class TestADMMBundlePipeline(unittest.TestCase):
                     break
             self.assertTrue(any_value,
                             f"{bname} has no nonant values after iter0")
+
+
+class TestModelFname(unittest.TestCase):
+    """model_fname() must find --module-name in any position, and still
+    honor the implicit-module flags (--smps-dir, --mps-files-directory)."""
+
+    def setUp(self):
+        self._saved_argv = sys.argv
+
+    def tearDown(self):
+        sys.argv = self._saved_argv
+
+    def _fname(self, argv):
+        sys.argv = ["prog"] + argv
+        return model_fname()
+
+    def test_module_name_first_space_form(self):
+        self.assertEqual(self._fname(["--module-name", "farmer"]), "farmer")
+
+    def test_module_name_first_equals_form(self):
+        self.assertEqual(self._fname(["--module-name=farmer"]), "farmer")
+
+    def test_module_name_not_first_space_form(self):
+        self.assertEqual(
+            self._fname(["--solver-name", "gurobi", "--module-name", "farmer"]),
+            "farmer")
+
+    def test_module_name_not_first_equals_form(self):
+        self.assertEqual(
+            self._fname(["--num-scens", "3", "--module-name=farmer"]),
+            "farmer")
+
+    def test_implicit_smps_dir_first(self):
+        self.assertEqual(self._fname(["--smps-dir", "mydir"]),
+                         "mpisppy.problem_io.smps_module")
+
+    def test_implicit_mps_dir_not_first_equals_form(self):
+        self.assertEqual(
+            self._fname(["--num-scens", "3", "--mps-files-directory=mydir"]),
+            "mpisppy.problem_io.mps_module")
+
+    def test_implicit_and_module_name_conflict(self):
+        with self.assertRaises(RuntimeError):
+            self._fname(["--smps-dir", "d", "--module-name", "farmer"])
+
+    def test_implicit_and_module_name_conflict_reversed(self):
+        with self.assertRaises(RuntimeError):
+            self._fname(["--module-name", "farmer", "--smps-dir", "d"])
+
+    def test_missing_module_name_raises(self):
+        with self.assertRaises(RuntimeError):
+            self._fname(["--num-scens", "3"])
+
+    def test_no_args_raises(self):
+        with self.assertRaises(RuntimeError):
+            self._fname([])
+
+    def test_dangling_module_name_raises(self):
+        with self.assertRaises(RuntimeError):
+            self._fname(["--module-name"])
+
+    def test_empty_module_name_value_raises(self):
+        with self.assertRaises(RuntimeError):
+            self._fname(["--module-name="])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up requested in the #739 review thread: make `--module-name` work in any position on the command line.

## Problem

`model_fname()` in `mpisppy/generic/parsing.py` read only `sys.argv[1]`, forcing `--module-name` (or the implicit `--smps-dir` / `--mps-files-directory` flags) to be the **first** argument.

## Fix

Scan the whole argument vector for `--module-name` instead, in both the `--module-name foo` and `--module-name=foo` forms, so it works in any position. The implicit-module flags and the module-name/implicit conflict check are likewise now position-independent.

## Tests

Adds `TestModelFname` to `mpisppy/tests/test_pre_pickle_pipeline.py` (an existing, already-CI-wired file) covering positions, both flag forms, implicit modules, the conflict error, and the missing/dangling/empty-value error paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)