### PR TITLE
grad_rho: compute xbar at iter0 before setting rho

### DIFF
--- a/mpisppy/extensions/grad_rho.py
+++ b/mpisppy/extensions/grad_rho.py
@@ -338,6 +338,15 @@ class GradRho(mpisppy.extensions.dyn_rho_base.Dyn_Rho_extension_base):
 
     def post_iter0(self):
         global_toc("Using grad-rho rho setter")
+        # PHBase.Iter0 runs the iter0 solve loop before this hook but does not
+        # compute xbar (Compute_Xbar is first called in iterk_loop, i.e. at
+        # iteration 1). Until then the xbars Param sits at its attach_xbars
+        # init value of 0.0, which would make the rho denominator abs(x - xbar)
+        # collapse to abs(x) -- distance from zero rather than from the iter0
+        # consensus mean. Compute xbar from the iter0 solutions here so both
+        # the convergence caches (update_caches) and the rho denominator use
+        # the real mean.
+        self.opt.Compute_Xbar()
         self.update_caches()
         self._get_grad_exprs()
         self.compute_and_update_rho()

--- a/mpisppy/tests/test_gradient_rho.py
+++ b/mpisppy/tests/test_gradient_rho.py
@@ -14,6 +14,7 @@ version matter a lot, so we often just do smoke tests.
 """
 
 import unittest
+import numpy as np
 from mpisppy.utils import config
 
 import mpisppy.utils.cfg_vanilla as vanilla
@@ -25,6 +26,21 @@ from mpisppy.extensions.grad_rho import GradRho
 __version__ = 0.3
 
 solver_available,solver_name, persistent_available, persistent_solver_name= get_solver()
+
+
+class _NanXhatBuf:
+    """Stand-in for the BEST_XHAT receive buffer that ``post_iter0`` reads via
+    ``_eval_grad_exprs``. An all-NaN array keeps the gradient evaluation on the
+    current (iter0) Var values regardless of the ``eval_at_xhat`` setting, so
+    the test exercises ``post_iter0`` without needing a live xhat spoke."""
+
+    def __init__(self, ph):
+        n = max(len(s._mpisppy_data.nonant_indices)
+                for s in ph.local_scenarios.values())
+        self._arr = np.full(n, np.nan)
+
+    def value_array(self):
+        return self._arr
 
 def _create_cfg():
     cfg = config.Config()
@@ -71,6 +87,57 @@ class Test_gradient_farmer(unittest.TestCase):
 
     def test_grad_rho_init(self):
         self.grad_object = GradRho(self.ph_object)
+
+    @staticmethod
+    def _reference_xbar(ph):
+        """The probability-weighted mean of the current nonant values per
+        (node, i) -- the quantity ``_Compute_Xbar`` produces (serial run: all
+        scenarios are local, so the global mean is just the local sum)."""
+        acc = {}
+        for s in ph.local_scenarios.values():
+            for node in s._mpisppy_node_list:
+                ndn = node.name
+                prob = s._mpisppy_data.prob_coeff[ndn]
+                for i, v in enumerate(node.nonant_vardata_list):
+                    acc[(ndn, i)] = acc.get((ndn, i), 0.0) + prob * v._value
+        return acc
+
+    def test_post_iter0_uses_iter0_xbar_not_zero(self):
+        # Regression test: grad_rho must compute xbar from the iter0 solutions
+        # before it sets rho. PHBase.Iter0 runs the iter0 solve loop but does
+        # not call Compute_Xbar (that first happens in iterk_loop, i.e. at
+        # iteration 1), so when the post_iter0 hook fires the xbars Param is
+        # still at its 0.0 init value. Without computing xbar in post_iter0 the
+        # rho denominator abs(x - xbar) collapses to abs(x) -- distance from
+        # zero rather than from the iter0 consensus mean.
+        ph = self.ph_object
+
+        # Reproduce the state Iter0 leaves the models in right before it calls
+        # the post_iter0 hook: iter0 solutions still on the Vars, xbars == 0.
+        for s in ph.local_scenarios.values():
+            for ndn_i in s._mpisppy_data.nonant_indices:
+                s._mpisppy_model.xbars[ndn_i]._value = 0.0
+
+        expected_xbar = self._reference_xbar(ph)
+        # The test only discriminates the fix if the true mean is nonzero.
+        self.assertTrue(
+            any(abs(v) > 1e-6 for v in expected_xbar.values()),
+            "iter0 xbar is all ~0; test cannot distinguish the fix",
+        )
+
+        grad = GradRho(ph)
+        grad.best_xhat_buf = _NanXhatBuf(ph)
+        grad.post_iter0()
+
+        for s in ph.local_scenarios.values():
+            for ndn_i in s._mpisppy_data.nonant_indices:
+                self.assertAlmostEqual(
+                    s._mpisppy_model.xbars[ndn_i]._value,
+                    expected_xbar[ndn_i],
+                    places=9,
+                    msg=f"xbar at {ndn_i} not set to the iter0 mean; "
+                        "post_iter0 did not Compute_Xbar before computing rho",
+                )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Problem

`GradRho.post_iter0` sets the initial rhos while `s._mpisppy_model.xbars` is still at its `attach_xbars` init value of **0.0**.

In `PHBase.Iter0` the order is: run the iter0 solve loop → call the `post_iter0` extension hook → return. `Compute_Xbar` is *not* called during `Iter0`; its first invocation is in `iterk_loop` (iteration 1). So when grad_rho computes rho in `post_iter0`, every xbar is still 0.

The grad-rho denominator is `abs(x - xbar)`. With `xbar == 0` it collapses to `abs(x)` — the *magnitude* of each scenario's iter0 value rather than its deviation from the iter0 consensus mean. Where iter0 values are large relative to their spread, denominators are inflated and the initial rhos come out too small. (The numerator — the objective gradient — was already evaluated at real post-solve values, so only the denominator's xbar term was affected. From iteration 1 on, `Compute_Xbar` has run, so it was already correct thereafter.)

## Fix

Call `self.opt.Compute_Xbar()` at the top of `post_iter0`, before `update_caches()` (whose `convergence_diff` also reads xbar) and before `compute_and_update_rho()`. This is a cheap extra Allreduce and is idempotent with the `Compute_Xbar` that `iterk_loop` performs at iteration 1.

## Test

`test_post_iter0_uses_iter0_xbar_not_zero` runs a farmer iter0, resets xbars to the 0.0 state `Iter0` hands to the hook, then asserts `post_iter0` fills them with the probability-weighted mean of the iter0 nonant values. Verified to **fail without the fix and pass with it**.

- `test_gradient_rho.py`: 2 passed
- `test_grad_rho_bundles.py`: 5 passed (no regression)
- `ruff check`: clean
- `test_gradient_rho.py` is already wired into `run_coverage.bash` and `test_pr_and_main.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)