### PR TITLE
Chance constraints (PySP-style SAA, EF only)

### DIFF
--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -94,6 +94,10 @@ jobs:
         run: |
           coverage run $COV_ARGS -m pytest mpisppy/tests/test_cvar.py -v
 
+      - name: Test chance_constraint
+        run: |
+          coverage run $COV_ARGS -m pytest mpisppy/tests/test_chance_constraint.py -v
+
       - name: Test afew
         run: |
           PYARGS="-m coverage run $COV_ARGS"

--- a/doc/designs/chance_constraint_design.md
+++ b/doc/designs/chance_constraint_design.md
@@ -1,0 +1,296 @@
+# Chance Constraints (PySP-style SAA) — Design
+
+Status: draft for review. Branch `CC` (off Pyomo/mpi-sppy `main`).
+
+## 1. Goal
+
+Support a sample-average-approximation (SAA) **chance constraint** of the form
+
+```
+    P( risky constraint holds )  >=  1 - α
+```
+
+mirroring PySP's `runef --cc-indicator-var=NAME --cc-alpha=α`. As in PySP, the
+user defines a binary **indicator variable** in each scenario model and the
+big-M constraints linking it to satisfaction; mpi-sppy adds the single
+aggregating constraint that turns the per-scenario indicators into a
+probabilistic guarantee.
+
+**Scope (decided): the extensive-form (EF) solve only.** Unlike CVaR, a chance
+constraint does not separate across scenarios (see §4), so it is not inherited
+by the decomposition cylinders. This matches PySP, which only solves the EF.
+The not-decomposable caveat is the analogue of the CVaR design's
+"not time-consistent" caveat and MUST appear verbatim in the docs — see §6.1.
+
+## 2. Background: the indicator-variable SAA chance constraint
+
+Let `z_s ∈ {0,1}` be a per-scenario indicator with the convention
+
+```
+    z_s = 1   ⇔   the risky constraint is SATISFIED in scenario s
+```
+
+The user enforces this link with their own big-M constraints (e.g.
+`g(x, ξ_s) <= M·(1 - z_s)`, so `z_s = 1` forces `g <= 0`). Given that link, the
+SAA chance constraint at confidence level `1 - α` is the single inequality
+
+```
+    Σ_s p_s · z_s  >=  1 - α
+```
+
+i.e. `E[z] >= 1 - α`, i.e. the probability mass of *satisfying* scenarios is at
+least `1 - α`, i.e. the violation probability is at most `α`. `α = 0` forces
+satisfaction in every scenario (a robust constraint); larger `α` buys a cheaper
+objective by letting the worst (most expensive to satisfy) scenarios fail.
+
+## 3. How PySP does it (reference: `Pyomo/pysp` → `pysp/ef.py`)
+
+`create_ef_instance(..., cc_indicator_var_name=None, cc_alpha=0.0)`. When
+`cc_indicator_var_name` is set, PySP modifies the *binding* (extensive-form)
+model only — it creates **no** variables and **no** linking constraints (those
+are the user's job in the ReferenceModel). For a scalar indicator it adds:
+
+```python
+cc_expression = 0
+for scenario in scenario_tree._scenarios:
+    scenario_instance = scenario_instances[scenario._name]
+    cc_var = scenario_instance.find_component(cc_indicator_var_name)
+    cc_expression += scenario._probability * cc_var
+
+def makeCCRule(expression):
+    def CCrule(model):
+        return (1.0 - cc_alpha, cc_expression, None)   # 1-α <= Σ p_s z_s
+    return CCrule
+
+cc_constraint_name = "cc_" + cc_indicator_var_name
+binding_instance.add_component(
+    cc_constraint_name, Constraint(name=cc_constraint_name, rule=makeCCRule(cc_expression)))
+```
+
+For an **indexed** indicator var, PySP parses a string index template
+(`extractVariableNameAndIndex`) and builds one chance constraint per matching
+index, named `cc_<var>_<index>`. The constraint sense is always the same:
+`Σ_s p_s z_s[i] >= 1 - α` for each index `i`.
+
+Two PySP artifacts we deliberately do **not** copy:
+- The string index-template parsing (`extractVariableNameAndIndex`,
+  `extractComponentIndices`) is a CLI-string convenience. We take a real Pyomo
+  component name and, if it is indexed, build one constraint per index of the
+  component (cleaner; see §6.3).
+- PySP's stray `print("multiple cc not yet supported.")` immediately before the
+  code that does, in fact, support multiple indices. We just support it.
+
+## 4. The structural insight (why this is the OPPOSITE of CVaR)
+
+CVaR was a free win because `E[Cost] + β·CVaR` *distributes over scenarios*: it
+became a per-scenario model transform (add η to the root node, a local δ_s, and
+rewrite each objective), and EF / PH / APH / Lagrangian / xhat all inherited it
+with **no algorithm changes** (see `cvar_design.md` §4).
+
+A chance constraint is structurally the reverse. The aggregating inequality
+
+```
+    Σ_s p_s · z_s  >=  1 - α
+```
+
+is a **single constraint that couples a (binary) variable from every
+scenario**. It is not separable, so there is no per-scenario transform that
+captures it:
+
+| Cylinder | What a coupling constraint means | Result |
+|---|---|---|
+| EF (`create_EF`) | all scenarios are sub-blocks of one model; add the one constraint over them | **reproduces PySP's EF-CC exactly** |
+| PH / APH hub | each rank solves its scenarios *independently*; a constraint spanning all scenarios cannot be placed in any one subproblem | not supported (Phase 1) |
+| Lagrangian / xhat spokes | same: the constraint is not local to a scenario | not supported (Phase 1) |
+
+**Central design choice:** implement the chance constraint as a *post-EF-
+construction transform on the assembled EF model*, NOT as a per-scenario
+transform and NOT as new hub/spoke logic. The EF model exposes every scenario
+as a named sub-block (`ef.ef._ef_scenario_names`, `getattr(ef.ef, sname)`), each
+carrying `_mpisppy_probability`; that is exactly enough to write the aggregating
+constraint over the indicator vars. (Decomposition would instead require
+Lagrangian dualization of this coupling constraint with a scalar price μ ≥ 0 and
+an outer 1-D search — a substantially harder, research-grade effort with an
+integrality duality gap. Out of scope; see §6.1.)
+
+Verified against the code: `_create_EF_from_scen_dict` adds each scenario via
+`EF_instance.add_component(sname, scenario_instance)` and records
+`EF_instance._ef_scenario_names`, and `ExtensiveForm` stores the assembled model
+as `self.ef` — so reaching `getattr(self.ef, sname).<indicator>` for every
+scenario is sufficient to add the constraint after construction.
+
+## 5. Implementation surface
+
+### 5.1 Core transform — new `mpisppy/utils/chance_constraint.py`
+
+```python
+def add_chance_constraint(ef_model, *, cc_indicator_var_name, cc_alpha):
+    """Add a PySP-style SAA chance constraint to an ALREADY-BUILT EF model.
+
+    For a scalar indicator var, adds to ``ef_model`` the single constraint
+
+        Σ_s p_s · z_s  >=  (1 - cc_alpha) · Σ_s p_s
+
+    where z_s = getattr(scenario_s, cc_indicator_var_name).  The Σ_s p_s factor
+    on the right is the total probability of the scenarios in this model (1.0 for
+    a full EF); carrying it makes the constraint correct even for normalized /
+    bundled EFs, and reduces to PySP's plain ``>= 1 - α`` for the full EF.
+
+    The user must define z_s (binary) and the big-M constraints linking it to
+    satisfaction, exactly as in PySP.  This function adds only the aggregator.
+
+    For an indexed indicator var, adds one such constraint per index.
+
+    Adds to ef_model:
+        _mpisppy_chance_constraint        (scalar case) or
+        _mpisppy_chance_constraint[idx]   (indexed case)
+    """
+    if not (0.0 <= cc_alpha < 1.0):
+        raise ValueError(f"cc_alpha must satisfy 0 <= alpha < 1 (got {cc_alpha})")
+
+    snames = ef_model._ef_scenario_names
+    total_prob = sum(getattr(ef_model, sn)._mpisppy_probability for sn in snames)
+
+    # representative component decides scalar vs. indexed
+    rep = getattr(ef_model, snames[0]).find_component(cc_indicator_var_name)
+    if rep is None:
+        raise ValueError(
+            f"chance-constraint indicator '{cc_indicator_var_name}' not found "
+            f"on scenario '{snames[0]}'")
+
+    def _agg(index=None):
+        expr = 0
+        for sn in snames:
+            s = getattr(ef_model, sn)
+            z = s.find_component(cc_indicator_var_name)
+            expr += s._mpisppy_probability * (z if index is None else z[index])
+        return expr >= (1.0 - cc_alpha) * total_prob
+
+    if rep.is_indexed():
+        con = pyo.Constraint(list(rep.keys()), rule=lambda m, *idx: _agg(idx if len(idx) > 1 else idx[0]))
+    else:
+        con = pyo.Constraint(expr=_agg())
+    ef_model.add_component("_mpisppy_chance_constraint", con)
+    _warn_if_not_binary(ef_model, cc_indicator_var_name)   # rank-0-gated; see §6.4
+```
+
+Notes:
+- **Post-construction, not a scenario_creator wrapper.** CVaR could wrap the
+  scenario_creator because it was per-scenario; the chance constraint needs all
+  scenarios present, so it operates on the assembled `ef.ef`.
+- **Normalization.** Dividing nothing (PySP) is correct only when `Σ p_s = 1`.
+  We multiply the RHS by `Σ p_s` so the constraint is also correct for
+  bundle-style normalized EFs, and identical to PySP for a full EF.
+
+### 5.2 EF wiring seam — `mpisppy/generic/ef.py`
+
+In `do_EF`, immediately after the EF is constructed and before solve:
+
+```python
+ef = ExtensiveForm(...)
+if cfg.cc_indicator_var is not None:
+    from mpisppy.utils import chance_constraint
+    chance_constraint.add_chance_constraint(
+        ef.ef, cc_indicator_var_name=cfg.cc_indicator_var, cc_alpha=cfg.cc_alpha)
+```
+
+Programmatic users of `ExtensiveForm` call `add_chance_constraint(ef.ef, ...)`
+themselves at the same point.
+
+### 5.3 Config / CLI — `mpisppy/utils/config.py`
+
+New `cfg.chance_constraint_args()` adding (flag names match PySP's `runef`):
+- `--cc-indicator-var` (str) — name of the user's per-scenario binary indicator;
+  presence of this flag enables the chance constraint.
+- `--cc-alpha` (float, 0 <= α < 1; default 0.0) — allowed violation probability.
+
+Validation (gated on rank 0 for warnings): `0 <= α < 1`; the indicator exists on
+each scenario; warn if its domain is not Binary (exactness needs binary z, §6.4).
+
+### 5.4 `generic_cylinders.py` guard
+
+Chance constraints are EF-only in Phase 1. If `--cc-indicator-var` is set but
+`--EF` is not, raise a clear error at parse/dispatch time:
+
+```
+chance constraints are currently supported only with --EF
+(a chance constraint couples all scenarios and is not separable;
+ see doc/designs/chance_constraint_design.md §4)
+```
+
+This prevents a silent no-op where a user requests a chance constraint under a
+decomposition run and gets the risk-neutral answer.
+
+## 6. Design decisions / deviations from PySP
+
+1. **EF-only (decided).** See §4. Decomposition is out of scope and flagged for
+   users in §6.1.
+2. **User supplies the indicator + big-M link; we add only the aggregator.**
+   Identical to PySP. We do not invent the indicator or guess the linking
+   constraints — the modeler knows which constraint is "risky" and what M is.
+3. **Indexed indicators by component, not by string template.** PySP parses a
+   CLI index string; we take the component and, if indexed, emit one constraint
+   per index of the component. Simpler and avoids the string-template parser.
+4. **Binary check is a warning, not an error.** A continuous "indicator" yields a
+   CVaR-like relaxation rather than a true chance constraint; we warn (rank 0)
+   but proceed, matching PySP's permissiveness.
+5. **Normalize the RHS by `Σ p_s`** so the constraint is correct for normalized
+   EFs and identical to PySP (`>= 1 - α`) for a full EF.
+6. **`α = 0` is allowed** (robust: satisfy every scenario), matching PySP's
+   default. We require `α < 1` (`α = 1` is a vacuous constraint).
+
+### 6.1 Documentation note (verbatim — to ship in the docs)
+
+> **Scope: chance constraints are supported only for the extensive-form (EF)
+> solve.** A chance constraint `Σ_s p_s z_s >= 1 - α` is a single constraint
+> that couples a (binary) indicator variable from every scenario, so — unlike
+> CVaR — it does not separate across scenarios and is **not** inherited by the
+> PH / APH / Lagrangian / xhat decomposition cylinders. This matches PySP, which
+> only solves the EF. Decomposing a chance constraint (e.g. Lagrangian
+> dualization of the coupling constraint with a scalar price) is possible but is
+> a substantially harder effort with an integrality duality gap. **If you need
+> chance constraints under decomposition, please contact the mpi-sppy
+> developers.**
+
+## 7. Correctness / validation
+
+- **Tiny closed-form instance.** N scenarios, known cost-to-satisfy per
+  scenario; with `α` allowing the cheapest `k` to be satisfied, check the EF-CC
+  optimum satisfies exactly the right set and `Σ p_s z_s >= 1 - α` is tight.
+- **`α = 0` ⇒ robust.** Reduces to the EF with every indicator forced to 1;
+  compare objective and solution.
+- **`α` large enough ⇒ inactive.** Reduces to the risk-neutral EF (regression
+  guard that the constraint is correctly slack).
+- **Indexed indicator ⇒ one constraint per index** (count and senses).
+- **mpi-sppy EF-CC vs. an independent PySP-style monolithic build** on the same
+  instance (objective and chosen scenario set agree).
+
+## 8. Rollout (a single review-sized PR)
+
+EF-only chance constraints are small enough to land in one PR. It contains:
+
+- `chance_constraint.py` (`add_chance_constraint`, scalar + indexed, normalized
+  RHS, binary warning);
+- `chance_constraint_args()` in config (`--cc-indicator-var`, `--cc-alpha`);
+- `do_EF` wiring + the EF-only guard in `generic_cylinders`;
+- `tests/test_chance_constraint.py` (tiny closed-form, `α=0` robust, `α`-inactive
+  regression, indexed), wired into `run_coverage.bash` AND `test_pr_and_main.yml`
+  in the same commit;
+- a small risk-constrained example (e.g. a newsvendor / farmer variant with a
+  service-level indicator) driven through
+  `generic_cylinders --EF --cc-indicator-var ... --cc-alpha ...`;
+- a docs section ("Chance Constraints") that MUST include the EF-only scope
+  caveat verbatim from §6.1, plus the programmatic `add_chance_constraint`
+  recipe.
+
+## 9. Files touched
+
+| Action | Path |
+|---|---|
+| new | `mpisppy/utils/chance_constraint.py` |
+| new | `mpisppy/tests/test_chance_constraint.py` (+ `run_coverage.bash`, `test_pr_and_main.yml`) |
+| edit | `mpisppy/utils/config.py` (`chance_constraint_args`) |
+| edit | `mpisppy/generic/ef.py` (`do_EF` wiring) |
+| edit | `mpisppy/generic_cylinders.py` (EF-only guard) |
+| new | chance-constraint example / `--cc-*` pass-through |
+| docs | `doc/source/…` Chance Constraints section (must include the §6.1 EF-only caveat) |

--- a/doc/src/chance_constraints.rst
+++ b/doc/src/chance_constraints.rst
@@ -1,0 +1,99 @@
+.. _Chance Constraints:
+
+Chance Constraints
+==================
+
+As a placeholder, mpi-sppy supports a PySP-style, sample-average-approximation
+(SAA) chance constraint of the form
+
+.. math::
+
+   P(\text{risky constraint holds}) \ge 1 - \alpha .
+
+As in PySP, you define a binary **indicator variable** in each scenario model
+together with your own big-M constraints linking it to satisfaction; mpi-sppy
+adds the single aggregating constraint that turns the per-scenario indicators
+into a probabilistic guarantee.
+
+.. warning::
+
+   **Scope: chance constraints are supported only for the extensive-form (EF)
+   solve.** A chance constraint :math:`\sum_s p_s z_s \ge 1 - \alpha` is a single
+   constraint that couples a (binary) indicator variable from every scenario, so
+   -- unlike CVaR -- it does not separate across scenarios and is **not**
+   inherited by the PH / APH / Lagrangian / xhat decomposition cylinders. This
+   matches PySP, which only solves the EF. Decomposing a chance constraint (e.g.
+   Lagrangian dualization of the coupling constraint with a scalar price) is
+   possible but is a substantially harder effort with an integrality duality
+   gap. **If you need chance constraints under decomposition, please contact the
+   mpi-sppy developers.**
+
+The indicator convention
+------------------------
+
+For each scenario ``s`` define a binary variable ``z_s`` with
+
+.. math::
+
+   z_s = 1 \iff \text{the risky constraint is satisfied in scenario } s ,
+
+and add your own big-M constraint(s) enforcing the link (so that ``z_s = 1``
+forces satisfaction). mpi-sppy then adds
+
+.. math::
+
+   \sum_s p_s\, z_s \ \ge\ 1 - \alpha ,
+
+i.e. ``E[z] >= 1 - alpha``: the probability mass of *satisfying* scenarios is at
+least :math:`1 - \alpha`, so the violation probability is at most
+:math:`\alpha`. Setting ``alpha = 0`` forces satisfaction in every scenario (a
+robust constraint); a larger ``alpha`` buys a cheaper objective by letting the
+worst (most expensive to satisfy) scenarios fail. The indicator must be
+**binary** for the constraint to be exact; a continuous "indicator" yields a
+relaxation and triggers a warning.
+
+If the indicator variable is indexed, mpi-sppy adds one chance constraint per
+index of the variable.
+
+Command line (generic_cylinders)
+--------------------------------
+
+Use the ``--EF`` flag together with:
+
+- ``--cc-indicator-var NAME`` -- the name of your per-scenario binary indicator
+  (its presence enables the chance constraint);
+- ``--cc-alpha ALPHA`` -- the allowed violation probability, ``0 <= alpha < 1``
+  (default ``0.0``).
+
+For example, the bundled capacity example builds enough capacity to meet demand
+with probability at least :math:`1 - \alpha`:
+
+.. code-block:: bash
+
+   python -m mpisppy.generic_cylinders \
+       --module-name examples/chance_constraint/cc_capacity \
+       --num-scens 10 --EF --EF-solver-name gurobi \
+       --cc-indicator-var served --cc-alpha 0.2
+
+With the deterministic ramp demands in that example, the cost-minimizing
+capacity is the :math:`(1-\alpha)`-quantile of demand (here, ``80``). Requesting
+a chance constraint without ``--EF`` is rejected at parse time.
+
+Programmatic use
+----------------
+
+When you build the EF yourself (via ``ExtensiveForm`` or
+``sputils.create_EF``), call :func:`mpisppy.utils.chance_constraint.add_chance_constraint`
+on the assembled model after construction and before solving:
+
+.. code-block:: python
+
+   import mpisppy.utils.sputils as sputils
+   from mpisppy.utils import chance_constraint
+
+   ef = sputils.create_EF(scenario_names, scenario_creator)
+   chance_constraint.add_chance_constraint(
+       ef, cc_indicator_var_name="served", cc_alpha=0.2)
+   # ... now solve ef ...
+
+.. autofunction:: mpisppy.utils.chance_constraint.add_chance_constraint

--- a/doc/src/index.rst
+++ b/doc/src/index.rst
@@ -27,6 +27,7 @@ MPI is used.
    generic_cylinders.rst
    examples.rst
    ef.rst
+   chance_constraints.rst
 
 .. toctree::
    :maxdepth: 2

--- a/examples/chance_constraint/cc_capacity.py
+++ b/examples/chance_constraint/cc_capacity.py
@@ -1,0 +1,84 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+# A tiny chance-constrained capacity example for generic_cylinders (EF only).
+#
+# Build capacity x (first stage, cost per unit). Scenario s has demand d_s and a
+# binary indicator ``served`` that is 1 only if the capacity covers the demand
+# (big-M link: x >= d_s - M*(1 - served)). The chance constraint added by
+# mpi-sppy,
+#
+#     Sum_s p_s * served_s  >=  1 - alpha,
+#
+# then requires the demand to be met with probability at least 1 - alpha.
+#
+# With deterministic ramp demands d_i = 10*(i+1) and uniform probabilities, the
+# cost-minimizing capacity is the (1 - alpha)-quantile of demand. For example
+# num_scens=10, cc_alpha=0.2 => serve the 8 smallest demands => x* = 80.
+#
+# Run (extensive form only):
+#   python -m mpisppy.generic_cylinders --module-name examples/chance_constraint/cc_capacity \
+#       --num-scens 10 --EF --solver-name gurobi --cc-indicator-var served --cc-alpha 0.2
+
+import pyomo.environ as pyo
+import mpisppy.utils.sputils as sputils
+
+UNIT_CAPACITY_COST = 1.0
+
+
+def _demand(scenario_index):
+    # deterministic ramp so the optimum is easy to verify by hand
+    return 10.0 * (scenario_index + 1)
+
+
+def scenario_creator(sname, num_scens=None, **kwargs):
+    assert num_scens is not None, "cc_capacity needs num_scens"
+    i = sputils.extract_num(sname)
+    d = _demand(i)
+    big_m = _demand(num_scens - 1)        # max possible demand
+
+    model = pyo.ConcreteModel(name=sname)
+    model.x = pyo.Var(bounds=(0.0, big_m))            # first-stage capacity
+    model.served = pyo.Var(domain=pyo.Binary)         # 1 == demand met
+
+    # big-M link: served == 1 forces x >= d
+    model.serve_link = pyo.Constraint(expr=model.x >= d - big_m * (1 - model.served))
+
+    model.FirstStageCost = pyo.Expression(expr=UNIT_CAPACITY_COST * model.x)
+    model.cost = pyo.Objective(expr=model.FirstStageCost, sense=pyo.minimize)
+
+    model._mpisppy_probability = 1.0 / num_scens
+    sputils.attach_root_node(model, model.FirstStageCost, [model.x])
+    return model
+
+
+def scenario_names_creator(num_scens, start=None):
+    if start is None:
+        start = 0
+    return [f"scen{i}" for i in range(start, start + num_scens)]
+
+
+def inparser_adder(cfg):
+    cfg.num_scens_required()
+
+
+def kw_creator(cfg):
+    return {"num_scens": cfg.get("num_scens", None)}
+
+
+def sample_tree_scen_creator(sname, stage, sample_branching_factors, seed,
+                             given_scenario=None, **scenario_creator_kwargs):
+    # two-stage: defer to the standard creator
+    sca = scenario_creator_kwargs.copy()
+    sca["num_scens"] = sample_branching_factors[0]
+    return scenario_creator(sname, **sca)
+
+
+def scenario_denouement(rank, scenario_name, scenario):
+    if scenario_name == "scen0":
+        print(f"capacity x = {pyo.value(scenario.x):.1f}")

--- a/mpisppy/generic/ef.py
+++ b/mpisppy/generic/ef.py
@@ -56,6 +56,13 @@ def do_EF(module, cfg, scenario_creator, scenario_creator_kwargs,
                        all_nodenames=ef_dict["all_nodenames"]
                        )
 
+    # PySP-style chance constraint (EF only; couples all scenarios). The
+    # config.checker guard guarantees --EF when cc_indicator_var is set.
+    if cfg.get("cc_indicator_var", None) is not None:
+        from mpisppy.utils import chance_constraint
+        chance_constraint.add_chance_constraint(
+            ef.ef, cc_indicator_var_name=cfg.cc_indicator_var, cc_alpha=cfg.cc_alpha)
+
     if ef.extensions is not None:
         ef.extobject.pre_solve()
 

--- a/mpisppy/generic/parsing.py
+++ b/mpisppy/generic/parsing.py
@@ -122,6 +122,7 @@ def parse_args(m):
     # maybe it should just require it.
 
     cfg.EF_base()  # If EF is slected, most other options will be moot
+    cfg.chance_constraint_args()  # EF-only (see config.checker)
     # There are some arguments here that will not make sense for all models
     cfg.popular_args()
     cfg.two_sided_args()

--- a/mpisppy/tests/test_chance_constraint.py
+++ b/mpisppy/tests/test_chance_constraint.py
@@ -1,0 +1,199 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+# Tests for PySP-style chance constraints (mpisppy/utils/chance_constraint.py):
+#   - structural checks of the EF transform (no solver needed)
+#   - EF-CC vs a closed-form "satisfy the cheapest (1-alpha) mass" on a tiny
+#     deterministic instance
+#   - alpha = 0 forces every scenario to be satisfied (robust)
+#   - removing the chance constraint reduces to the risk-neutral EF
+#   - indexed indicator => one chance constraint per index
+#   - input validation
+
+import math
+import unittest
+import pyomo.environ as pyo
+
+import mpisppy.utils.sputils as sputils
+import mpisppy.utils.chance_constraint as cc
+from mpisppy.tests.utils import get_solver, limit_solver_threads
+
+solver_available, solver_name, persistent_available, persistent_solver_name = \
+    get_solver()
+
+
+# ---------------------------------------------------------------------------
+# A tiny deterministic instance with a known closed form.
+#
+# Satisfying scenario s (its binary indicator z_s = 1) costs a known amount a_s;
+# leaving it unsatisfied (z_s = 0) is free.  The risk-neutral optimum is therefore
+# z_s = 0 for all s (cost 0).  The chance constraint
+#
+#     Sum_s p_s z_s >= 1 - alpha
+#
+# forces enough scenarios satisfied; to minimize cost the EF satisfies the
+# CHEAPEST ceil((1-alpha) * N) of them (uniform probabilities).
+#
+# Costs {1, 2, 3, 4}, uniform p_s = 1/4:
+#   alpha = 0     -> satisfy 4 (all): cost (1+2+3+4)/4 = 2.5
+#   alpha = 0.5   -> satisfy 2      : cost (1+2)/4     = 0.75
+#   alpha = 0.75  -> satisfy 1      : cost (1)/4       = 0.25
+# ---------------------------------------------------------------------------
+TINY_COSTS = {"s0": 1.0, "s1": 2.0, "s2": 3.0, "s3": 4.0}
+
+
+def tiny_scenario_creator(sname, **kwargs):
+    costs = kwargs.get("costs", TINY_COSTS)
+    model = pyo.ConcreteModel(name=sname)
+    model.x = pyo.Var(bounds=(0.0, 0.0))            # trivial first-stage nonant
+    model.z = pyo.Var(domain=pyo.Binary)            # indicator: 1 == satisfied
+    cost_expr = costs[sname] * model.z + model.x
+    model.cost = pyo.Objective(expr=cost_expr, sense=pyo.minimize)
+    model._mpisppy_probability = 1.0 / len(costs)
+    sputils.attach_root_node(model, model.x, [model.x])
+    return model
+
+
+# Indexed indicator: each scenario carries z[0], z[1].  The cost of satisfying
+# index j in scenario s is COSTS_IDX[j][s]; the two indices are independent, so
+# each gets its own chance constraint and its own cheapest-k selection.
+COSTS_IDX = {
+    0: {"s0": 1.0, "s1": 2.0, "s2": 3.0, "s3": 4.0},   # cheapest: s0, s1, ...
+    1: {"s0": 4.0, "s1": 3.0, "s2": 2.0, "s3": 1.0},   # cheapest: s3, s2, ...
+}
+
+
+def indexed_scenario_creator(sname, **kwargs):
+    model = pyo.ConcreteModel(name=sname)
+    model.x = pyo.Var(bounds=(0.0, 0.0))
+    model.z = pyo.Var([0, 1], domain=pyo.Binary)
+    cost_expr = sum(COSTS_IDX[j][sname] * model.z[j] for j in (0, 1)) + model.x
+    model.cost = pyo.Objective(expr=cost_expr, sense=pyo.minimize)
+    model._mpisppy_probability = 1.0 / 4
+    sputils.attach_root_node(model, model.x, [model.x])
+    return model
+
+
+def _make_ef(scenario_creator, names, scenario_creator_kwargs=None):
+    return sputils.create_EF(
+        names, scenario_creator,
+        scenario_creator_kwargs=scenario_creator_kwargs, suppress_warnings=True)
+
+
+def _solve(model):
+    solver = pyo.SolverFactory(solver_name)
+    limit_solver_threads(solver, solver_name)
+    if "_persistent" in solver_name:
+        solver.set_instance(model)
+    results = solver.solve(model, tee=False)
+    pyo.assert_optimal_termination(results)
+    return results
+
+
+def _z_values(ef, names, index=None):
+    out = {}
+    for sname in names:
+        z = getattr(ef, sname).z
+        out[sname] = round(pyo.value(z if index is None else z[index]))
+    return out
+
+
+class StructureTests(unittest.TestCase):
+    """The EF transform's structure; these do not need a solver."""
+
+    def test_scalar_constraint_added(self):
+        ef = _make_ef(tiny_scenario_creator, list(TINY_COSTS))
+        con = cc.add_chance_constraint(ef, cc_indicator_var_name="z", cc_alpha=0.5)
+        self.assertIs(con, ef._mpisppy_chance_constraint)
+        self.assertFalse(con.is_indexed())
+        # RHS = (1 - alpha) * total_prob = 0.5 * 1.0
+        self.assertAlmostEqual(pyo.value(con.lower), 0.5, places=6)
+
+    def test_indexed_one_constraint_per_index(self):
+        ef = _make_ef(indexed_scenario_creator, list(TINY_COSTS))
+        con = cc.add_chance_constraint(ef, cc_indicator_var_name="z", cc_alpha=0.5)
+        self.assertTrue(con.is_indexed())
+        self.assertEqual(set(con.keys()), {0, 1})
+
+    def test_missing_indicator_raises(self):
+        ef = _make_ef(tiny_scenario_creator, list(TINY_COSTS))
+        with self.assertRaises(ValueError):
+            cc.add_chance_constraint(ef, cc_indicator_var_name="nope", cc_alpha=0.5)
+
+    def test_bad_alpha_raises(self):
+        for bad in (1.0, -0.1, 1.5):
+            ef = _make_ef(tiny_scenario_creator, list(TINY_COSTS))
+            with self.assertRaises(ValueError):
+                cc.add_chance_constraint(ef, cc_indicator_var_name="z", cc_alpha=bad)
+
+
+@unittest.skipIf(not solver_available, "no solver is available")
+class EFClosedFormTests(unittest.TestCase):
+    """EF-CC on the tiny instance vs the closed-form cheapest-k selection."""
+
+    def _solve_cc(self, alpha):
+        names = list(TINY_COSTS)
+        ef = _make_ef(tiny_scenario_creator, names)
+        cc.add_chance_constraint(ef, cc_indicator_var_name="z", cc_alpha=alpha)
+        _solve(ef)
+        return ef, names
+
+    def _expected(self, alpha):
+        # satisfy the cheapest k = ceil((1-alpha) * N) scenarios
+        k = math.ceil((1.0 - alpha) * len(TINY_COSTS))
+        cheapest = sorted(TINY_COSTS, key=lambda s: TINY_COSTS[s])[:k]
+        obj = sum(TINY_COSTS[s] for s in cheapest) / len(TINY_COSTS)
+        return set(cheapest), obj
+
+    def test_alpha_half(self):
+        ef, names = self._solve_cc(0.5)
+        chosen, obj = self._expected(0.5)               # {s0, s1}, 0.75
+        self.assertAlmostEqual(pyo.value(ef.EF_Obj), obj, places=4)
+        z = _z_values(ef, names)
+        self.assertEqual({s for s, v in z.items() if v == 1}, chosen)
+
+    def test_alpha_large_picks_fewer(self):
+        ef, names = self._solve_cc(0.75)
+        chosen, obj = self._expected(0.75)              # {s0}, 0.25
+        self.assertAlmostEqual(pyo.value(ef.EF_Obj), obj, places=4)
+        self.assertEqual({s for s, v in _z_values(ef, names).items() if v == 1},
+                         chosen)
+
+    def test_alpha_zero_is_robust(self):
+        ef, names = self._solve_cc(0.0)
+        chosen, obj = self._expected(0.0)               # all four, 2.5
+        self.assertAlmostEqual(pyo.value(ef.EF_Obj), obj, places=4)
+        self.assertEqual(set(_z_values(ef, names).values()), {1})
+
+    def test_no_chance_constraint_is_risk_neutral(self):
+        # Without the chance constraint the optimum leaves everything unsatisfied.
+        ef = _make_ef(tiny_scenario_creator, list(TINY_COSTS))
+        _solve(ef)
+        self.assertAlmostEqual(pyo.value(ef.EF_Obj), 0.0, places=4)
+
+
+@unittest.skipIf(not solver_available, "no solver is available")
+class IndexedTests(unittest.TestCase):
+    """An indexed indicator yields an independent cheapest-k per index."""
+
+    def test_each_index_selects_its_own_cheapest(self):
+        names = list(TINY_COSTS)
+        ef = _make_ef(indexed_scenario_creator, names)
+        cc.add_chance_constraint(ef, cc_indicator_var_name="z", cc_alpha=0.5)
+        _solve(ef)
+        # alpha = 0.5 => satisfy the 2 cheapest scenarios for each index
+        sat0 = {s for s, v in _z_values(ef, names, index=0).items() if v == 1}
+        sat1 = {s for s, v in _z_values(ef, names, index=1).items() if v == 1}
+        self.assertEqual(sat0, {"s0", "s1"})            # cheapest for index 0
+        self.assertEqual(sat1, {"s3", "s2"})            # cheapest for index 1
+        # objective: (1+2)/4 for index 0 plus (1+2)/4 for index 1
+        self.assertAlmostEqual(pyo.value(ef.EF_Obj), 0.75 + 0.75, places=4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mpisppy/utils/chance_constraint.py
+++ b/mpisppy/utils/chance_constraint.py
@@ -1,0 +1,127 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+# Chance constraints (PySP-style sample-average approximation), applied as a
+# transform on an already-built extensive form (EF).
+#
+# The user defines, in each scenario model, a binary indicator variable z_s with
+# the convention
+#
+#     z_s = 1   <=>   the risky constraint is SATISFIED in scenario s
+#
+# plus their own big-M constraints linking z_s to satisfaction (exactly as in
+# PySP -- this module creates no indicator and no linking constraint).  Given
+# those indicators, the SAA chance constraint at confidence level 1 - alpha is
+# the single aggregating inequality
+#
+#     Sum_s p_s * z_s  >=  1 - alpha
+#
+# i.e. E[z] >= 1 - alpha, i.e. the violation probability is at most alpha.
+#
+# Unlike CVaR (mpisppy/utils/cvar.py), this aggregator couples a variable from
+# every scenario, so it does NOT separate and is supported only for the EF.
+# See doc/designs/chance_constraint_design.md.
+
+import warnings
+
+import pyomo.environ as pyo
+from mpisppy import MPI
+
+
+def add_chance_constraint(ef_model, *, cc_indicator_var_name, cc_alpha):
+    """Add a PySP-style SAA chance constraint to an already-built EF model.
+
+    For a scalar indicator variable, adds to ``ef_model`` the single constraint
+
+        Sum_s p_s * z_s  >=  (1 - cc_alpha) * Sum_s p_s
+
+    where ``z_s = getattr(scenario_s, cc_indicator_var_name)``.  The ``Sum_s p_s``
+    factor on the right is the total probability of the scenarios in this model
+    (1.0 for a full EF); carrying it makes the constraint correct even for
+    normalized / bundled EFs and reduces to PySP's plain ``>= 1 - alpha`` when
+    the probabilities sum to one.
+
+    For an indexed indicator variable, adds one such constraint per index of the
+    variable (one chance constraint per index, joint over scenarios).
+
+    The user is responsible for defining ``z_s`` (binary) and the big-M
+    constraints linking it to satisfaction, exactly as in PySP.  This function
+    adds only the aggregator.
+
+    Args:
+        ef_model (Pyomo ConcreteModel): an assembled extensive form, i.e.
+            ``ExtensiveForm.ef`` or the result of ``sputils.create_EF``.  It must
+            carry ``_ef_scenario_names`` and expose each scenario as a sub-block
+            with a ``_mpisppy_probability`` attribute.
+        cc_indicator_var_name (str): the name of the per-scenario indicator
+            variable (scalar or indexed).
+        cc_alpha (float): the allowed violation probability, 0 <= alpha < 1.
+            alpha = 0 forces satisfaction in every scenario (a robust constraint).
+
+    Returns:
+        pyo.Constraint: the constraint component added to ``ef_model`` (scalar or
+        indexed), also reachable as ``ef_model._mpisppy_chance_constraint``.
+    """
+    if not (0.0 <= cc_alpha < 1.0):
+        raise ValueError(f"cc_alpha must satisfy 0 <= alpha < 1 (got {cc_alpha})")
+
+    snames = getattr(ef_model, "_ef_scenario_names", None)
+    if not snames:
+        raise ValueError(
+            "add_chance_constraint needs an assembled EF model carrying "
+            "_ef_scenario_names (e.g. ExtensiveForm.ef or sputils.create_EF(...))")
+
+    total_prob = sum(getattr(ef_model, sn)._mpisppy_probability for sn in snames)
+    rhs = (1.0 - cc_alpha) * total_prob
+
+    rep = getattr(ef_model, snames[0]).find_component(cc_indicator_var_name)
+    if rep is None:
+        raise ValueError(
+            f"chance-constraint indicator '{cc_indicator_var_name}' not found on "
+            f"scenario '{snames[0]}'")
+
+    def _aggregate(index):
+        # Sum_s p_s * z_s[index]  (index is None for a scalar indicator)
+        expr = 0
+        for sn in snames:
+            z = getattr(ef_model, sn).find_component(cc_indicator_var_name)
+            if z is None:
+                raise ValueError(
+                    f"chance-constraint indicator '{cc_indicator_var_name}' not "
+                    f"found on scenario '{sn}'")
+            zs = z if index is None else z[index]
+            expr += getattr(ef_model, sn)._mpisppy_probability * zs
+        return expr >= rhs
+
+    if rep.is_indexed():
+        def _rule(_m, *idx):
+            return _aggregate(idx[0] if len(idx) == 1 else idx)
+        con = pyo.Constraint(rep.index_set(), rule=_rule)
+    else:
+        con = pyo.Constraint(expr=_aggregate(None))
+
+    ef_model.add_component("_mpisppy_chance_constraint", con)
+    _warn_if_not_binary(rep, cc_indicator_var_name)
+    return con
+
+
+def _warn_if_not_binary(indicator, name):
+    """Warn (on rank 0) if the indicator is not binary.
+
+    Exactness of the chance constraint requires binary indicators; a continuous
+    "indicator" yields a CVaR-like relaxation rather than a true chance
+    constraint.  We warn but proceed, matching PySP's permissiveness.  Gated on
+    rank 0 so an HPC run does not print one copy per process.
+    """
+    if MPI.COMM_WORLD.Get_rank() != 0:
+        return
+    vardata = next(iter(indicator.values())) if indicator.is_indexed() else indicator
+    if not vardata.is_binary():
+        warnings.warn(
+            f"chance-constraint indicator '{name}' is not binary; the result is "
+            "a relaxation, not a true chance constraint")

--- a/mpisppy/utils/config.py
+++ b/mpisppy/utils/config.py
@@ -168,6 +168,13 @@ class Config(pyofig.ConfigDict):
         if self.get("hub_only_solver_logs") and not self.get("solver_log_dir"):
             _bad_options("--hub-only-solver-logs requires --solver-log-dir")
 
+        if self.get("cc_indicator_var", None) is not None and not self.get("EF"):
+            # A chance constraint Sum_s p_s z_s >= 1-alpha couples all scenarios
+            # and is not separable, so it is supported only for the EF (matching
+            # PySP). See doc/designs/chance_constraint_design.md.
+            _bad_options("--cc-indicator-var (chance constraint) is currently "
+                         "supported only with --EF")
+
     def add_solver_specs(self, prefix=""):
         sstr = f"{prefix}_solver" if prefix else "solver"
         if prefix:
@@ -489,6 +496,27 @@ class Config(pyofig.ConfigDict):
     def EF_multistage(self):
         self.EF_base()
         # branching factors???
+
+    #### chance constraints (PySP-style SAA; EF only) ####
+    def chance_constraint_args(self):
+        # The user supplies a per-scenario binary indicator (z_s == 1 means the
+        # risky constraint is satisfied in scenario s) and the big-M link; we add
+        # the aggregator Sum_s p_s z_s >= 1 - cc_alpha to the EF.  See
+        # doc/designs/chance_constraint_design.md.  EF only: the aggregator
+        # couples all scenarios, so it does not separate for decomposition.
+        self.add_to_config("cc_indicator_var",
+                           description="Name of the per-scenario binary indicator "
+                                       "variable for a chance constraint (z==1 means "
+                                       "the risky constraint is satisfied). Enables "
+                                       "the chance constraint; EF only.",
+                           domain=str,
+                           default=None)
+        self.add_to_config("cc_alpha",
+                           description="Allowed violation probability for the chance "
+                                       "constraint, 0 <= alpha < 1 (alpha=0 forces "
+                                       "satisfaction in every scenario). Default 0.0.",
+                           domain=float,
+                           default=0.0)
 
     ##### common additions to the command line #####
 

--- a/run_coverage.bash
+++ b/run_coverage.bash
@@ -68,6 +68,9 @@ run_phase "test_ef_ph (serial)" \
 run_phase "test_cvar (serial)" \
     coverage run --rcfile=.coveragerc -m pytest mpisppy/tests/test_cvar.py -v
 
+run_phase "test_chance_constraint (serial)" \
+    coverage run --rcfile=.coveragerc -m pytest mpisppy/tests/test_chance_constraint.py -v
+
 run_phase "test_component_map_usage (serial)" \
     coverage run --rcfile=.coveragerc -m pytest mpisppy/tests/test_component_map_usage.py -v
 


### PR DESCRIPTION
## Summary

Adds PySP-style sample-average-approximation (SAA) chance constraints, supporting

> P(risky constraint holds) ≥ 1 − α

mirroring PySP's `runef --cc-indicator-var=NAME --cc-alpha=α`. As in PySP, the user defines a per-scenario binary **indicator** `z_s` (`z_s = 1` ⇔ the risky constraint is satisfied) plus their own big-M link; mpi-sppy adds the single aggregating constraint

> Σ_s p_s · z_s ≥ 1 − α

to the assembled extensive form. This reproduces PySP's EF chance constraint exactly. Scalar and indexed indicators are supported (one constraint per index); a non-binary indicator warns (on rank 0) and proceeds.

Design doc: `doc/designs/chance_constraint_design.md`.

## Scope: EF only (matches PySP)

Unlike CVaR, the aggregator `Σ_s p_s z_s ≥ 1 − α` is a single constraint that **couples a binary from every scenario**, so it does not separate and is **not** inherited by the PH / APH / Lagrangian / xhat decomposition cylinders. This matches PySP, which only solves the EF. `cfg.checker()` rejects `--cc-indicator-var` without `--EF`. Decomposition (Lagrangian dualization of the coupling constraint) is flagged as out of scope in the design doc and docs.

## What's included

- `mpisppy/utils/chance_constraint.py` — `add_chance_constraint(ef, *, cc_indicator_var_name, cc_alpha)`, a post-EF-construction transform reaching scenario sub-blocks via `ef._ef_scenario_names`.
- `mpisppy/utils/config.py` — `chance_constraint_args()` (`--cc-indicator-var`, `--cc-alpha`) + the EF-only guard in `checker()`.
- `mpisppy/generic/parsing.py`, `mpisppy/generic/ef.py` — CLI wiring (added after EF construction, before solve).
- `examples/chance_constraint/cc_capacity.py` — a capacity/service-level example whose cost-minimizing optimum is the (1−α)-quantile of demand.
- `mpisppy/tests/test_chance_constraint.py` — closed-form cheapest-k, α=0 robust, no-CC risk-neutral, indexed, validation; wired into `run_coverage.bash` and `test_pr_and_main.yml`.
- `doc/src/chance_constraints.rst` — docs including the EF-only scope caveat and the programmatic recipe.

## Testing

- 9/9 unit tests pass.
- End-to-end CLI matches the closed form: α=0.2 → x*=80, α=0 → 100 (robust), α=0.45 → 60, no-CC → 0.
- No regression in the normal EF / PH paths; `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)