### PR TITLE
test(stoch-admm): fix flaky outer-bound parser in test_stoch_admmWrapper

### DIFF
--- a/mpisppy/tests/test_stoch_admmWrapper.py
+++ b/mpisppy/tests/test_stoch_admmWrapper.py
@@ -215,19 +215,25 @@ class TestStochAdmmWrapper(unittest.TestCase):
         """Extract the last outer bound from PH output."""
         import re
         target_line = "Iter.           Best Bound  Best Incumbent      Rel. Gap        Abs. Gap"
-        result_by_line = stdout.strip().split('\n')
+        # An iteration row looks like:
+        #   [    0.23]    30  L  -27422.8799   inf   inf%   inf
+        # The flag token after the iteration number is optional and may be
+        # '*' (new incumbent), 'L'/'B' (bound updates), or a combination, so
+        # accept any run of flag characters before the Best Bound value. The
+        # header itself prints more than once (iter 0 and finalization), so
+        # keep scanning every row and keep the last bound seen rather than
+        # only inspecting the single line after a header.
+        iter_re = re.compile(r'\[\s*\d+\.\d+\]\s+\d+\s+(?:[*A-Za-z]+\s+)?(-?[\d.]+)')
         outer_bound = None
         in_results = False
-        for line in result_by_line:
+        for line in stdout.strip().split('\n'):
             if target_line in line:
                 in_results = True
                 continue
             if in_results:
-                # Match a line with iteration number and bounds
-                match = re.search(r'\[\s*\d+\.\d+\]\s+\d+\s+(?:L\s*B?|B\s*L?)?\s+([-.\d]+)', line)
+                match = iter_re.search(line)
                 if match:
                     outer_bound = float(match.group(1))
-                in_results = False
         return outer_bound
 
     @unittest.skipUnless(solver_available, "no solver available")


### PR DESCRIPTION
## What

`test_stoch_admmWrapper.py::test_bundled_vs_unbundled` fails intermittently in CI with `AssertionError: unexpectedly None : Could not extract outer bound from bundled run`, even though the underlying `mpiexec` run completes cleanly (rc=0) and prints the bounds table. The flakiness is in the `_extracting_outer_bound` parser, not in the algorithm.

Observed on the CVaR PR (#746) CI, but the test and all code it exercises are byte-identical to `main` — the CVaR branch does not touch this path. A re-run of that job passed, confirming flakiness.

## Root cause

`_extracting_outer_bound` had two fragilities:

1. It inspected only the **single line immediately after** each `Best Bound` header, then stopped. The spoke prints that header twice (at iteration 0 and again at finalization), so which row got inspected depended on output timing.
2. Its regex `...(?:L\s*B?|B\s*L?)?\s+([-.\d]+)` matched an `L`/`B` flag or no flag, but **not the `*` (new-incumbent) flag**. Whenever the inspected row carried a `*`, extraction returned `None` and the assertion failed.

## Fix

Scan every iteration row while inside the results block and keep the last bound seen, and accept any run of flag characters (`*`, `L`, `B`, or a combination) before the Best Bound value.

Verified against real bundled output and both `*`-flag failure modes; the full `test_stoch_admmWrapper.py` suite (27 tests) passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)