### PR TITLE
flex-ranks phase 4b: multistage xhat fields (strict coherence, no fix-up)

### DIFF
--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -980,6 +980,7 @@ jobs:
           mpiexec -np 6 coverage run $COV_ARGS -m mpi4py test_flexible_rank_duals.py
           mpiexec -np 6 coverage run $COV_ARGS -m mpi4py test_flexible_rank_xhat.py
           mpiexec -np 6 coverage run $COV_ARGS -m mpi4py test_flexible_rank_xfeas.py
+          mpiexec -np 6 coverage run $COV_ARGS -m mpi4py test_flexible_rank_xhat_multistage.py
 
       - name: Upload coverage data
         if: always()

--- a/doc/designs/flexible_rank_assignments.md
+++ b/doc/designs/flexible_rank_assignments.md
@@ -174,8 +174,9 @@ paired with the nonants it was evaluated at (FWPH turns that pair into a
 Frank-Wolfe column).  Both are guaranteed by reading the whole field
 with **strict coherence** — rejecting any mixed-iteration assembly.  An
 accepted read has every source at one write_id, so the assembled
-first-stage portion is already identical across scenarios and needs no
-post-assembly fix-up.  See §Coherence.
+first-stage portion is already NAC-consistent across the scenarios sharing
+each node — the whole root vector in two-stage, per node in multistage — and
+needs no post-assembly fix-up.  See §Coherence.
 
 #### Category 3 — global-sized fields
 
@@ -491,14 +492,15 @@ retry later.
 
 - **`BEST_XHAT` / `RECENT_XHATS`.**  Per-scenario
   `[first-stage nonants, obj_val]` blocks.  The first-stage portion is
-  NAC-redundant (identical across scenarios); the `obj_val` is genuinely
-  per-scenario.  These are assembled with the same overlap-map
-  multi-source reader as every other per-scenario field.
+  NAC-redundant (identical across the scenarios sharing each node); the
+  `obj_val` is genuinely per-scenario.  These are assembled with the same
+  overlap-map multi-source reader as every other per-scenario field.
 
   **The whole field is read with strict coherence**, which carries both
   invariants at once.  An accepted read has every source at one `write_id`,
-  so the assembled first-stage portion is already identical across scenarios
-  (NAC-consistent) *and* each `obj_val` stays paired with the nonants it was
+  so the assembled first-stage portion is already NAC-consistent across the
+  scenarios sharing each node (the whole root vector in two-stage, per node in
+  multistage) *and* each `obj_val` stays paired with the nonants it was
   evaluated at.  The pairing matters because the FWPH consumer derives a
   Frank-Wolfe column's recourse cost as `obj_val − first_stage_cost(nonants)`,
   so a mixed-iteration assembly — iteration *t*'s nonants beside iteration

--- a/mpisppy/cylinders/spcommunicator.py
+++ b/mpisppy/cylinders/spcommunicator.py
@@ -69,11 +69,12 @@ _GLOBAL_OR_SCALAR_FIELDS = frozenset((
 #     would stitch one scenario's first stage next to another's obj_val -- an
 #     inconsistent column that can invalidate the bound -- and would also break
 #     NAC across scenarios. Strict coherence rejects the mixed read: an accepted
-#     read has every source at one write_id, so the assembled first stage is
-#     already NAC-consistent across scenarios and every obj_val stays paired with
-#     its own nonants -- no post-assembly fix-up is needed. (Single-sourcing the
-#     first stage would also pair them, but does not generalize to multistage,
-#     where a scenario's nonant path spans several nodes held by different ranks.)
+#     read has every source at one write_id, so the assembled nonant portion is
+#     already NAC-consistent across the scenarios sharing each tree node and
+#     every obj_val stays paired with its own nonants -- no post-assembly fix-up
+#     is needed, at any number of stages. (Single-sourcing the first stage would
+#     also pair them, but does not generalize to multistage, where a scenario's
+#     nonant path spans several nodes held by different ranks.)
 #
 # Every other per-scenario field uses *relaxed* coherence (the assembled value
 # may mix iterations; its consumers re-evaluate, so it is always honest). XFEAS
@@ -689,29 +690,27 @@ class SPCommunicator:
         """Number of field items each scenario contributes, indexed by global
         scenario index, for a per-scenario field (used to build overlap maps).
 
-        For the nonant-valued fields this is the per-scenario nonant count,
-        which is uniform across scenarios in a two-stage problem
-        (``opt.nonant_length``). For the xhat fields each scenario contributes a
-        ``[nonants, obj_val]`` block, so the count is ``nonant_length + 1``; the
-        circular ``RECENT_XHATS`` returns the same single-version block size and
-        is expanded across versions in ``_build_overlap_map``.
+        For the nonant-valued fields this is the per-scenario nonant count
+        (``opt.nonant_length``, uniform across scenarios -- asserted in
+        ``spbase._attach_nonant_indices``). For the xhat fields each scenario
+        contributes a ``[nonants, obj_val]`` block, so the count is
+        ``nonant_length + 1``; the circular ``RECENT_XHATS`` returns the same
+        single-version block size and is expanded across versions in
+        ``_build_overlap_map``. These counts are stage-agnostic: a scenario's
+        block is routed wholesale to its local offset, so multi-source assembly
+        is identical for two-stage and multistage (a multistage block is just
+        the scenario's whole root->leaf nonant path instead of one root vector).
         """
         if field in (Field.NONANTS_VALS, Field.RELAXED_NONANTS_VALS, Field.DUALS):
             k = self.opt.nonant_length
             return [k] * len(self.opt.all_scenario_names)
         if field in (Field.BEST_XHAT, Field.RECENT_XHATS, Field.XFEAS):
-            # Each scenario's block is [first-stage nonants, per-scenario obj_val].
-            # Two-stage only: under multistage the NAC-redundant portion is
-            # per-tree-node (not one global first stage), so the nonant-vs-obj_val
-            # split needs per-node sourcing -- a later phase.
-            if self.opt.multistage:
-                raise NotImplementedError(
-                    f"Flexible (unequal) rank assignments: {self.__class__.__name__} "
-                    f"reads {field.name} on a multistage problem, whose per-node "
-                    f"first-stage sourcing is not implemented yet (two-stage is). "
-                    f"Run the cylinders that exchange {field.name} at equal rank "
-                    f"counts (rank_ratio == 1.0), or wait for the multistage phase."
-                )
+            # Each scenario's block is [nonants, per-scenario obj_val]. Works for
+            # any number of stages: the block is opaque to the assembler (routed
+            # by index), and strict coherence already makes the NAC-redundant
+            # nonant portion consistent across the scenarios sharing each tree
+            # node -- per node, with no per-node sourcing or fix-up needed (see
+            # the strict-coherence note on _flex_get_multi_source).
             k = self.opt.nonant_length
             return [k + 1] * len(self.opt.all_scenario_names)
         # Reached at startup (window creation), not mid-solve: this cylinder is
@@ -856,8 +855,10 @@ class SPCommunicator:
 
         The Category-2 xhat fields (BEST_XHAT, RECENT_XHATS) are strict, so an
         accepted read has every source at one write_id; their NAC-redundant
-        first-stage portion is then already identical across scenarios and each
-        obj_val stays paired with its own nonants -- no post-assembly fix-up.
+        nonant portion is then already consistent across the scenarios sharing
+        each tree node (the whole root vector in two-stage; per node in
+        multistage) and each obj_val stays paired with its own nonants -- no
+        post-assembly fix-up, at any number of stages.
         """
         if synchronize:
             self.cylinder_comm.Barrier()

--- a/mpisppy/tests/test_flex_xhat_assembly.py
+++ b/mpisppy/tests/test_flex_xhat_assembly.py
@@ -219,5 +219,100 @@ class TestFlexXhatAssembly(unittest.TestCase):
         self.assertEqual(len({_xfeas_fs(s) for s in LOCAL_SCEN_IDXS}), NSCEN_LOCAL)
 
 
+# --- multistage assembly (Phase 4b) ---------------------------------------
+#
+# In multistage a scenario's block is its whole root->leaf nonant path plus
+# obj_val, and non-anticipativity is a per-*node* property: the root segment is
+# shared by every scenario, while a stage-2 node's segment is shared only by the
+# scenarios in its subtree (different subtrees hold different stage-2 values).
+#
+# The assembler is index-based and stage-agnostic: it routes each scenario's
+# whole block from the rank that holds it, exactly as in two-stage. Strict
+# coherence guarantees all sources are at one write_id, so the source blocks are
+# one coherent incumbent in which scenarios sharing a node already carry that
+# node's values identically. Faithful routing therefore yields a per-node
+# NAC-consistent assembly with NO post-assembly fix-up -- and does NOT collapse
+# the distinct subtrees onto one another (which a whole-block "copy scenario 0"
+# fix-up would have done).
+#
+# Layout: 3-stage tree, root with R=2 nonants shared by all; two stage-2 subtrees
+# A and B with one nonant each. Per-scenario block = [root(2), stage2(1), obj].
+K_M = 3                        # root(2) + stage2(1)
+BLOCK_M = K_M + 1
+ROOT_LEN = 2
+# 6 scenarios in two subtrees of three: A = {0,1,2}, B = {3,4,5}.
+SUBTREE = {0: "A", 1: "A", 2: "A", 3: "B", 4: "B", 5: "B"}
+# Source ranks: rank 0 straddles the subtree boundary (holds A and one B scen),
+# rank 1 is wholly in B. Receiver holds one A scenario and three B scenarios,
+# straddling both source ranks -- so the assembly must keep A's and B's stage-2
+# values distinct while routing across ranks.
+MS_PEER_SLICES = [[0, 1, 2, 3], [4, 5]]
+MS_LOCAL_SCEN_IDXS = [2, 3, 4, 5]
+
+
+def _root_val(version):
+    return 7.0 + 100.0 * version              # shared by every scenario at root
+
+def _s2_val(scen, version):
+    # distinct per subtree, identical within a subtree
+    return (10.0 if SUBTREE[scen] == "A" else 20.0) + 100.0 * version
+
+def _ms_nonants(scen, version):
+    return np.array([_root_val(version)] * ROOT_LEN + [_s2_val(scen, version)])
+
+
+def _make_ms_source_buffer(scens_on_rank, nversions):
+    """A peer rank's send buffer for a multistage BEST_XHAT-style field: each
+    scenario block is [root(R), stage2(1), obj_val], the source data being one
+    coherent (single-write_id) incumbent."""
+    per_version = len(scens_on_rank) * BLOCK_M
+    buf = np.full(nversions * per_version, np.nan)
+    for v in range(nversions):
+        for j, s in enumerate(scens_on_rank):
+            off = v * per_version + j * BLOCK_M
+            buf[off:off + K_M] = _ms_nonants(s, v)
+            buf[off + K_M] = _obj(s, v)
+    return buf
+
+
+class TestFlexMultistageAssembly(unittest.TestCase):
+
+    def test_assembly_preserves_per_node_nac(self):
+        """Multi-node blocks routed wholesale across straddling ranks: the root
+        segment ends up identical across every scenario (root NAC), each subtree
+        keeps its own stage-2 value (per-node NAC, subtrees not collapsed), and
+        obj_val stays per-scenario -- all with no fix-up."""
+        items_per_scen = [BLOCK_M] * 6
+        segments = compute_overlap_segments(
+            MS_LOCAL_SCEN_IDXS, MS_PEER_SLICES, items_per_scen
+        )
+        sources = {
+            0: _make_ms_source_buffer(MS_PEER_SLICES[0], 1),
+            1: _make_ms_source_buffer(MS_PEER_SLICES[1], 1),
+        }
+        local_len = len(MS_LOCAL_SCEN_IDXS) * BLOCK_M
+        local_buf = _assemble(segments, sources, local_len)
+
+        expected = np.empty(local_len)
+        for j, s in enumerate(MS_LOCAL_SCEN_IDXS):
+            off = j * BLOCK_M
+            expected[off:off + K_M] = _ms_nonants(s, 0)
+            expected[off + K_M] = _obj(s, 0)
+        np.testing.assert_allclose(local_buf, expected)
+
+        # Root segment identical across every local scenario (root NAC)...
+        roots = [local_buf[j * BLOCK_M:j * BLOCK_M + ROOT_LEN]
+                 for j in range(len(MS_LOCAL_SCEN_IDXS))]
+        for r in roots[1:]:
+            np.testing.assert_allclose(r, roots[0])
+        # ...while the two subtrees keep DISTINCT stage-2 values: a whole-block
+        # collapse to scenario 0's would have erased subtree B's value.
+        s2 = {s: local_buf[j * BLOCK_M + ROOT_LEN]
+              for j, s in enumerate(MS_LOCAL_SCEN_IDXS)}
+        self.assertEqual(s2[2], _s2_val(2, 0))          # subtree A
+        self.assertEqual(s2[3], _s2_val(3, 0))          # subtree B
+        self.assertNotEqual(s2[2], s2[3])               # subtrees not collapsed
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/mpisppy/tests/test_flexible_rank_xhat_multistage.py
+++ b/mpisppy/tests/test_flexible_rank_xhat_multistage.py
@@ -1,0 +1,175 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+"""End-to-end integration test for the unequal-rank xhat fields on a
+*multistage* problem (Phase 4b).
+
+Phase 4a handled the two-stage xhat fields, where the entire NAC-redundant
+nonant block is one root node shared by every scenario. Multistage is the
+general case: non-anticipativity is a per-*node* property -- a node's nonants are
+shared only by the scenarios routed through it, while scenarios in different
+subtrees hold different later-stage decisions.
+
+The multi-source assembler does not need to know any of that. Each scenario's
+block is its whole root->leaf nonant path plus obj_val, routed wholesale from the
+rank that holds it (the layout is index-based and stage-agnostic). The xhat ring
+is read with *strict* coherence, so an accepted read has every source at one
+write_id -- one coherent incumbent in which every scenario through a node already
+carries that node's values identically. Faithful routing therefore yields a
+per-node NAC-consistent assembly with no post-assembly fix-up, and -- crucially --
+without collapsing the distinct subtrees onto one another. This test confirms
+that holds inside a real run.
+
+Setup: aircond with branching factors [4, 4] -- a 3-stage tree, 4 second-stage
+nodes (subtrees) of 4 scenarios each (16 scenarios) -- with an FWPH hub (which
+assembles the xhatshuffle spoke's BEST_XHAT / RECENT_XHATS) and an xhatshuffle
+inner-bound spoke, at *unequal* rank counts. The subtree count (4) and per-node
+child count (4) are chosen so both rank counts the test uses (2 and 4) give
+subtree-aligned scenario splits and satisfy the stage2ef divisibility rule, and
+so that a 2-rank cylinder holds *two whole subtrees per rank* -- the case where a
+hub rank assembles blocks spanning more than one second-stage node, which a
+naive whole-block collapse would get wrong.
+
+A misrouted segment or wrong version interleaving would feed FWPH inconsistent
+columns -- its outer bound would stop tracking the extensive-form optimum or the
+two asymmetry directions would disagree. We pin correctness with the same
+two-directional / ground-truth pattern as test_flexible_rank_xhat, using
+fullcomm windows in both directions:
+
+  * 4+2 (hub larger): each hub rank holds one subtree; spoke ranks straddle.
+  * 2+4 (spoke larger): each hub rank holds two whole subtrees, so it assembles
+    blocks spanning the root plus two distinct stage-2 nodes -- the
+    multistage-specific layout.
+
+mpiexec -np 6 python -m mpi4py -m pytest mpisppy/tests/test_flexible_rank_xhat_multistage.py
+"""
+
+import unittest
+
+import numpy as np
+from mpi4py import MPI
+
+from mpisppy.utils import config
+import mpisppy.utils.cfg_vanilla as vanilla
+import mpisppy.utils.sputils as sputils
+import mpisppy.tests.examples.aircond as aircond
+from mpisppy.spin_the_wheel import WheelSpinner
+from mpisppy.tests.utils import get_solver
+
+comm = MPI.COMM_WORLD
+
+solver_available, solver_name, persistent_available, persistent_solver_name = get_solver()
+# FWPH's master and the xhatshuffle stage-2 EF need a non-persistent solver.
+_, np_solver_name, _, _ = get_solver(persistent_OK=False)
+
+BRANCHING_FACTORS = [4, 4]
+# Extensive-form optimum for aircond with these branching factors and the
+# fixture's default parameters (a deterministic LP optimum, solver-independent).
+EF_OPT = 419.51919699962326
+
+
+def _build_dicts(max_iterations, hub_ratio, spoke_ratio):
+    # Fresh cfg/dicts per run: WheelSpinner.run mutates the dicts and may only
+    # run once, so each run needs its own.
+    cfg = config.Config()
+    cfg.multistage()
+    cfg.popular_args()
+    cfg.two_sided_args()
+    cfg.ph_args()
+    cfg.fwph_args()
+    cfg.xhatshuffle_args()
+    aircond.inparser_adder(cfg)
+    cfg.solver_name = np_solver_name
+    cfg.default_rho = 1.0
+    cfg.max_iterations = max_iterations
+    cfg.rel_gap = 1e-6
+    cfg.branching_factors = BRANCHING_FACTORS
+    cfg.max_solver_threads = 2
+
+    num_scens = int(np.prod(BRANCHING_FACTORS))
+    all_scenario_names = aircond.scenario_names_creator(num_scens)
+    all_nodenames = sputils.create_nodenames_from_branching_factors(BRANCHING_FACTORS)
+    scenario_creator_kwargs = aircond.kw_creator(cfg)
+    beans = (cfg, aircond.scenario_creator, aircond.scenario_denouement,
+             all_scenario_names)
+
+    hub_dict = vanilla.fwph_hub(
+        *beans, scenario_creator_kwargs=scenario_creator_kwargs,
+        all_nodenames=all_nodenames)
+    hub_dict["rank_ratio"] = hub_ratio
+
+    xhatshuffle_spoke = vanilla.xhatshuffle_spoke(
+        *beans, scenario_creator_kwargs=scenario_creator_kwargs,
+        all_nodenames=all_nodenames)
+    xhatshuffle_spoke["opt_kwargs"]["options"]["stage2_ef_solver_name"] = np_solver_name
+    xhatshuffle_spoke["opt_kwargs"]["options"]["branching_factors"] = BRANCHING_FACTORS
+    xhatshuffle_spoke["rank_ratio"] = spoke_ratio
+
+    return hub_dict, [xhatshuffle_spoke]
+
+
+def _run(max_iterations, hub_ratio, spoke_ratio):
+    hub_dict, spoke_list = _build_dicts(max_iterations, hub_ratio, spoke_ratio)
+    wheel = WheelSpinner(hub_dict, spoke_list)
+    wheel.spin()
+    # Bounds are populated on the hub's base rank (global rank 0); broadcast so
+    # every rank can assert in lockstep.
+    if wheel.global_rank == 0:
+        payload = (wheel.BestInnerBound, wheel.BestOuterBound)
+    else:
+        payload = None
+    return comm.bcast(payload, root=0)
+
+
+@unittest.skipUnless(comm.size == 6, "needs exactly 6 MPI ranks")
+@unittest.skipUnless(solver_available, "no solver is available")
+class TestFlexibleRankXhatMultistage(unittest.TestCase):
+
+    MAX_ITERS = 20
+
+    def test_fwph_hub_unequal_ranks_both_directions(self):
+        # 4-rank hub, 2-rank spoke: each hub rank holds one subtree; spoke ranks
+        # straddle and the hub stitches BEST_XHAT/RECENT_XHATS from several.
+        ib_42, ob_42 = _run(self.MAX_ITERS, 1.0, 0.5)
+        # 2-rank hub, 4-rank spoke: each hub rank holds two whole subtrees, so it
+        # assembles blocks spanning the root plus two distinct stage-2 nodes.
+        ib_24, ob_24 = _run(self.MAX_ITERS, 1.0, 2.0)
+
+        # Finite bounds (a torn/garbage read would give inf or error out).
+        for b in (ib_42, ob_42, ib_24, ob_24):
+            self.assertTrue(abs(b) < float("inf"))
+
+        # FWPH's outer bound is its master LP bound, fed by the assembled xhat
+        # columns; the two asymmetry directions must agree closely.
+        self.assertLess(
+            abs(ob_42 - ob_24), 1e-2 * abs(ob_42),
+            msg=f"4+2 outer bound {ob_42} disagrees with 2+4 {ob_24}",
+        )
+
+        for ib, ob in ((ib_42, ob_42), (ib_24, ob_24)):
+            # Minimizing aircond: outer bound is a lower bound (<= opt), inner
+            # bound (incumbent) is an upper bound (>= opt). The outer bound is
+            # FWPH's deterministic master LP bound, checked tightly (1%); the
+            # incumbent comes from the (order-sensitive) xhatshuffle spoke, so
+            # it gets a looser 2% near-optimal check.
+            self.assertLessEqual(ob, EF_OPT + 1e-2 * abs(EF_OPT))
+            self.assertGreaterEqual(ib, EF_OPT - 1e-2 * abs(EF_OPT))
+            self.assertLess(
+                abs(ob - EF_OPT), 1e-2 * abs(EF_OPT),
+                msg=f"outer bound {ob} is not near the EF optimum {EF_OPT}",
+            )
+            self.assertLess(
+                abs(ib - EF_OPT), 2e-2 * abs(EF_OPT),
+                msg=f"inner bound {ib} is not near the EF optimum {EF_OPT}",
+            )
+            # Valid bracketing.
+            self.assertLessEqual(ob, ib + 1e-6)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/run_coverage.bash
+++ b/run_coverage.bash
@@ -213,6 +213,9 @@ run_phase "test_flexible_rank_xhat (mpiexec -np 6)" \
 run_phase "test_flexible_rank_xfeas (mpiexec -np 6)" \
     mpiexec -np 6 $OVERSUBSCRIBE coverage run --rcfile="$PROJ_DIR/.coveragerc" -m mpi4py mpisppy/tests/test_flexible_rank_xfeas.py
 
+run_phase "test_flexible_rank_xhat_multistage (mpiexec -np 6)" \
+    mpiexec -np 6 $OVERSUBSCRIBE coverage run --rcfile="$PROJ_DIR/.coveragerc" -m mpi4py mpisppy/tests/test_flexible_rank_xhat_multistage.py
+
 # ---------- Tests that spawn mpiexec internally ----------
 
 PYARGS="-m coverage run --parallel-mode --rcfile=$PROJ_DIR/.coveragerc --data-file=$PROJ_DIR/.coverage"


### PR DESCRIPTION
> **📚 Stacked PRs — flexible rank assignments**
> Reviewed and merged bottom-up; each PR targets the one below it.
>
> 1. **Pyomo/mpi-sppy#725 — Phase 1: infrastructure** — ✅ merged
> 2. **Pyomo/mpi-sppy#731 — Phase 2: communication layer** — ✅ merged
> 3. **Pyomo/mpi-sppy#736 — Phase 3a: per-field coherence (DUALS strict)** — ✅ merged
> 4. **Pyomo/mpi-sppy#740 — Phase 3b: CLI rank-ratio flags** — ✅ merged
> 5. **Pyomo/mpi-sppy#741 — Phase 4a: two-stage xhat fields** — ✅ merged
> 6. **Phase 4b: multistage xhat fields** ← _this PR_ (targets `main`)
> 7. **DLWoodruff/mpi-sppy-1#17 — Phase 5: APH (asynchronous sender) verification** (targets `flex-ranks-phase4b-multistage`)
>
> _Later phases will be appended here as they open._

---

Enables the Category-2 xhat fields (`BEST_XHAT`, `RECENT_XHATS`, `XFEAS`) at
unequal rank counts on **multistage** problems. Phase 4a handled two-stage and
guarded multistage with a startup `NotImplementedError`; this PR lifts that
guard. No fix-up is added — **strict coherence already carries the per-node
non-anticipativity invariant.**

## The key realization

Phase 4a moved the xhat ring into `_STRICT_COHERENCE_FIELDS` and then *removed*
the post-assembly NAC fix-up, because under strict coherence it was a provable
no-op (#741). The same argument extends per node, so this phase does **not**
introduce the per-node fix-up it was originally scoped to add.

Non-anticipativity is a per-**node** property — a tree node's nonants are shared
only by the scenarios routed through it, while different subtrees hold different
later-stage decisions — but the multi-source assembler never needs to know that:

- Each scenario's block is its whole root→leaf nonant path plus `obj_val`,
  routed **wholesale** to its local offset. The layout is index-based and
  stage-agnostic (`nonant_length` is uniform across scenarios — asserted in
  `spbase._attach_nonant_indices`).
- The xhat ring is read with **strict coherence**, so an accepted read has every
  source at one `write_id` — one coherent incumbent in which every scenario
  through a node already holds that node's values identically.

So faithful routing yields a per-node NAC-consistent assembly with no fix-up, and
distinct subtrees are never collapsed.

## What's here (`mpisppy/cylinders/spcommunicator.py`)

- **`_items_per_scen_for_field`** drops the `opt.multistage` raise for these
  fields; `[nonant_length + 1]` items per scenario is correct for multistage too.
  That is the **entire** production change (~5 lines); the docstrings/comments are
  updated to explain the stage-agnostic, fix-up-free routing.

No new methods. The per-node fix-up machinery an earlier draft of this PR carried
(`_enforce_first_stage_nac_multistage`, `_first_stage_nac_node_groups`) is not
introduced — consistent with 4a's removal of the two-stage fix-up.

## Tests

- **Serial exact-value** (`test_flex_xhat_assembly.py`, new
  `TestFlexMultistageAssembly`): a 3-stage block layout `[root, stage2, obj_val]`
  assembled across straddling ranks, with a receiver holding scenarios from two
  different subtrees. Pins that faithful routing keeps the root segment
  NAC-consistent across every scenario while **preserving each subtree's distinct
  stage-2 value** — the case a whole-block collapse would corrupt — with no
  fix-up involved.
- **np=6 integration** (`test_flexible_rank_xhat_multistage.py`, new): FWPH hub +
  xhatshuffle spoke on **aircond `[4,4]`** (16 scenarios, 4 subtrees of 4) at
  **4+2** and **2+4**. Branching factors are chosen so both rank counts give
  subtree-aligned splits and satisfy the stage2ef divisibility rule, and so the
  2-rank hub holds **two whole subtrees per rank** — it assembles blocks spanning
  the root plus two distinct stage-2 nodes, the multistage-specific layout. Both
  asymmetry directions converge to the extensive-form optimum with validly
  bracketing bounds. This is the empirical proof that the assembly-only path (no
  fix-up) is per-node NAC-correct.

## Validation

`ruff` clean; serial assembly + coherence-policy suites pass; the np=6 multistage
integration test passes on 6/6 ranks at both 4+2 and 2+4; the np=6 two-stage
`test_flexible_rank_xhat` regression stays green. Both new tests are wired into
`run_coverage.bash` and `test_pr_and_main.yml`.

The design doc's §Category-2 / §Coherence are sharpened from "identical across
scenarios" to per-node phrasing now that multistage is live.

`XFEAS` (Category-1, relaxed, no fix-up) also rides this guard lift; its
multi-rank CG-hub path is exercised end-to-end in 4a's `test_flexible_rank_xfeas`
(two-stage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
