### PR TITLE
flex-ranks phase 5: verify per-field coherence composes with an async sender

### DIFF
--- a/doc/designs/flexible_rank_assignments.md
+++ b/doc/designs/flexible_rank_assignments.md
@@ -738,9 +738,19 @@ differs from 1.0)
 
 **Phase 5: APH support**
 
-- Verify APH (asynchronous PH) works with the relaxed-coherence model.
-- The strict-coherence fields already retry on `write_id` mismatch, so
-  they should compose with async senders; verify and add tests.
+- Verify the coherence model composes with an *asynchronous* sender (APH),
+  where the several sources of a multi-source read can sit at different
+  `write_id`s -- the case the per-field policy was designed for.
+- The strict-coherence fields already retry on `write_id` mismatch and the
+  relaxed fields accept the floor, so no reader change is needed.  This is
+  verified deterministically by driving the multi-source reader against a
+  stand-in window with hand-set `write_id`s (`test_flex_coherence_policy.py`),
+  which can force a *particular* mixed-id snapshot that a timing-dependent
+  live run cannot.
+- A live `np=6` APH MPI integration test was prototyped but deferred: APH
+  runs its persistent-solver solves in a worker thread and intermittently
+  hangs in pyomo's threaded output capture (an APH/pyomo issue unrelated to
+  the coherence policy), which times out CI.  Tracked in Pyomo/mpi-sppy#753.
 
 
 ### Development and rollout strategy

--- a/mpisppy/tests/test_flex_coherence_policy.py
+++ b/mpisppy/tests/test_flex_coherence_policy.py
@@ -7,21 +7,32 @@
 # full copyright and license information.
 ###############################################################################
 """Unit tests for the per-field coherence policy used by the unequal-rank
-multi-source reader (spcommunicator.reduce_source_write_ids).
+multi-source reader (spcommunicator.reduce_source_write_ids) and for how the
+reader (_flex_get_multi_source) acts on it.
 
 The MPI integration tests run against a synchronous PH hub, where all sources
 of a field always carry the same write_id -- so strict and relaxed behave
-identically there and cannot distinguish the policies. These tests pin the
-policy logic directly: strict rejects a mixed-iteration read, relaxed accepts
-the floor."""
+identically there and cannot distinguish the policies. An asynchronous sender
+(e.g. an APH hub) is exactly where they differ, but timing makes it impossible
+to deterministically force a *particular* mixed-write_id snapshot at a read in
+a live MPI run. These tests pin the behavior directly, without MPI:
+reduce_source_write_ids' policy logic (strict rejects a mixed-iteration read,
+relaxed accepts the floor), and the reader's resulting retry semantics that an
+asynchronous sender relies on -- a strict mixed-id read is rejected without
+disturbing the receive buffer, and a later coherent read then succeeds."""
 
 import unittest
 
+import numpy as np
+
 from mpisppy.cylinders.spcommunicator import (
+    SPCommunicator,
+    RecvArray,
     reduce_source_write_ids,
     _STRICT_COHERENCE_FIELDS,
 )
-from mpisppy.cylinders.spwindow import Field
+from mpisppy.cylinders.overlap_map import OverlapSegment
+from mpisppy.cylinders.spwindow import Field, padded_len_n_doubles
 
 
 class TestReduceSourceWriteIds(unittest.TestCase):
@@ -82,6 +93,145 @@ class TestStrictCoherenceFields(unittest.TestCase):
 
     def test_nonants_vals_is_relaxed(self):
         self.assertNotIn(Field.NONANTS_VALS, _STRICT_COHERENCE_FIELDS)
+
+
+# --- reader retry semantics under mixed write_ids -------------------------
+#
+# An asynchronous sender (the APH hub) can leave the several remote ranks a
+# spoke assembles a per-scenario field from at different write_ids. The
+# coherence policy decides whether to accept such a read, and the reader
+# (_flex_get_multi_source) must act on a rejection *without corrupting* the
+# receive buffer, so a later coherent read still lands clean. These tests drive
+# the reader against a tiny stand-in window holding source buffers whose
+# write_ids we set by hand -- something the timing-dependent MPI test cannot do
+# deterministically.
+#
+# Layout: a peer cylinder of two source ranks (global ranks 0 and 1), each
+# publishing 2 data items; the receiver assembles a length-4 buffer, taking
+# rank 0's two items into local [0:2] and rank 1's into local [2:4]. synchronize
+# is False (the APH hub reads with synchronize=False), so no cylinder_comm is
+# involved and the stand-in needs only a window.
+_DATA_LEN = 2
+_LOGICAL_LEN = _DATA_LEN + 1
+_PADDED_LEN = padded_len_n_doubles(_LOGICAL_LEN)
+_RANK0_DATA = [1.0, 2.0]
+_RANK1_DATA = [3.0, 4.0]
+_ASSEMBLED = _RANK0_DATA + _RANK1_DATA   # what a clean read must produce
+_SEGMENTS = [
+    OverlapSegment(remote_rank=0, remote_offset=0, local_offset=0, count=2),
+    OverlapSegment(remote_rank=1, remote_offset=0, local_offset=2, count=2),
+]
+
+
+def _make_source(data, write_id):
+    """A peer rank's padded send buffer: data, then the write_id at the logical
+    end, then NaN padding -- the shape SPWindow.get returns."""
+    arr = np.full(_PADDED_LEN, np.nan)
+    arr[:_DATA_LEN] = data
+    arr[_LOGICAL_LEN - 1] = float(write_id)
+    return arr
+
+
+class _StubWindow:
+    """Stands in for SPWindow: hands back per-rank source buffers on get() and
+    advertises their layout. The source write_ids are mutable so a test can
+    flip a read from mixed to coherent between calls."""
+
+    def __init__(self):
+        self.sources = {
+            0: _make_source(_RANK0_DATA, 0),
+            1: _make_source(_RANK1_DATA, 0),
+        }
+        self.strata_buffer_layouts = {
+            r: {Field.DUALS: (_DATA_LEN, _LOGICAL_LEN, _PADDED_LEN),
+                Field.NONANTS_VALS: (_DATA_LEN, _LOGICAL_LEN, _PADDED_LEN)}
+            for r in (0, 1)
+        }
+
+    def set_write_ids(self, id0, id1):
+        self.sources[0][_LOGICAL_LEN - 1] = float(id0)
+        self.sources[1][_LOGICAL_LEN - 1] = float(id1)
+
+    def get(self, out_arr, rank, field):
+        out_arr[:] = self.sources[rank]
+
+
+def _make_reader():
+    """A minimal SPCommunicator stand-in carrying just what
+    _flex_get_multi_source touches (with synchronize=False)."""
+    sp = SPCommunicator.__new__(SPCommunicator)
+    sp.window = _StubWindow()
+    peer = 1
+    sp._overlap_source_ranks = {
+        (Field.DUALS, peer): [0, 1],
+        (Field.NONANTS_VALS, peer): [0, 1],
+    }
+    sp.overlap_maps = {
+        (Field.DUALS, peer): _SEGMENTS,
+        (Field.NONANTS_VALS, peer): _SEGMENTS,
+    }
+    return sp, peer
+
+
+class TestMultiSourceReaderRetry(unittest.TestCase):
+
+    def _read(self, sp, buf, field, peer):
+        return sp._flex_get_multi_source(buf, field, peer, synchronize=False)
+
+    def test_strict_rejects_mixed_without_disturbing_buffer(self):
+        # A strict (DUALS) read whose sources disagree must be rejected, leave
+        # is_new False, leave the accepted id where it was, and -- the part an
+        # async retry depends on -- not write any data into the buffer.
+        sp, peer = _make_reader()
+        buf = RecvArray(_DATA_LEN * 2)
+        sp.window.set_write_ids(5, 4)  # mixed
+
+        self.assertFalse(self._read(sp, buf, Field.DUALS, peer))
+        self.assertFalse(buf.is_new())
+        self.assertEqual(buf.id(), 0)
+        # Untouched: the buffer still holds its freshly-allocated NaNs, not a
+        # half-stitched value from the rejected read.
+        self.assertTrue(np.all(np.isnan(buf.value_array())))
+
+    def test_strict_accepts_after_sources_agree(self):
+        # The same buffer that just rejected a mixed read accepts the next read
+        # once the sources line up -- and lands the fully assembled value, with
+        # no residue from the rejected attempt.
+        sp, peer = _make_reader()
+        buf = RecvArray(_DATA_LEN * 2)
+
+        sp.window.set_write_ids(5, 4)
+        self.assertFalse(self._read(sp, buf, Field.DUALS, peer))
+
+        sp.window.set_write_ids(6, 6)  # now coherent
+        self.assertTrue(self._read(sp, buf, Field.DUALS, peer))
+        self.assertTrue(buf.is_new())
+        self.assertEqual(buf.id(), 6)
+        np.testing.assert_allclose(buf.value_array(), _ASSEMBLED)
+
+    def test_strict_same_id_is_not_new(self):
+        # After accepting id 6, re-reading the same coherent id reports not-new
+        # (new_id > last_id is false), so a consumer is not handed stale data
+        # twice.
+        sp, peer = _make_reader()
+        buf = RecvArray(_DATA_LEN * 2)
+        sp.window.set_write_ids(6, 6)
+        self.assertTrue(self._read(sp, buf, Field.DUALS, peer))
+        self.assertFalse(self._read(sp, buf, Field.DUALS, peer))
+        self.assertFalse(buf.is_new())
+
+    def test_relaxed_accepts_mixed_at_the_floor(self):
+        # A relaxed (NONANTS_VALS) read accepts mixed write_ids, assembling the
+        # value as-is and recording the floor (5) as the accepted id -- so it is
+        # reported new again only once every source has advanced past 5.
+        sp, peer = _make_reader()
+        buf = RecvArray(_DATA_LEN * 2)
+        sp.window.set_write_ids(7, 5)  # mixed; floor is 5
+
+        self.assertTrue(self._read(sp, buf, Field.NONANTS_VALS, peer))
+        self.assertTrue(buf.is_new())
+        self.assertEqual(buf.id(), 5)
+        np.testing.assert_allclose(buf.value_array(), _ASSEMBLED)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> **📚 Stacked PRs — flexible rank assignments**
> Reviewed and merged bottom-up; each PR targets the one below it.
>
> 1. **Pyomo/mpi-sppy#725 — Phase 1: infrastructure** — ✅ merged
> 2. **Pyomo/mpi-sppy#731 — Phase 2: communication layer** — ✅ merged
> 3. **Pyomo/mpi-sppy#736 — Phase 3a: per-field coherence (DUALS strict)** — ✅ merged
> 4. **Pyomo/mpi-sppy#740 — Phase 3b: CLI rank-ratio flags** — ✅ merged
> 5. **Pyomo/mpi-sppy#741 — Phase 4a: two-stage xhat fields** — ✅ merged
> 6. **Pyomo/mpi-sppy#750 — Phase 4b: multistage xhat fields** — ✅ merged
> 7. **Phase 5: async-sender (APH) coherence verification** ← _this PR_ (targets `main`)
>
> This is the final phase of the flexible-rank-assignments design.

---

Verifies that the per-field coherence model composes with an **asynchronous
sender**, where the several remote ranks a spoke assembles a per-scenario field
from can sit at **different `write_id`s** — the case the policy was designed
for. It turned out to need **no reader change**: the existing strict/relaxed
policy already handles the async case. This PR is the verification the design
called for.

## Why an async sender is the case to check

Every earlier flex integration test uses a synchronous hub (PH / FWPH): all hub
ranks finish an iteration and write their buffers in lockstep, so the sources a
spoke assembles a per-scenario field from always carry the same `write_id` —
strict and relaxed coherence behave identically and can't be told apart. An
asynchronous sender (an APH hub) is exactly where they differ:

- **relaxed** fields (`NONANTS_VALS`) accept a mixed-iteration assembly — the
  consumer re-evaluates each candidate, so a stale/blended value is honest;
- **strict** fields (`DUALS`) reject a mixed-iteration assembly and retry — a
  `W` stitched across iterations would not satisfy `Σ pₛWₛ = 0` and would yield
  an invalid Lagrangian bound.

## What's here

- **`test_flex_coherence_policy.py`** — the verification, done **deterministically**.
  Four cases drive `_flex_get_multi_source` against a stand-in window with
  hand-set `write_id`s: a strict mixed-id read is **rejected without disturbing
  the receive buffer**, a later coherent read **lands clean**, the same id
  re-read is not-new, and a relaxed read accepts at the floor. Driving the
  reader directly lets us force a *particular* mixed-id snapshot — something a
  timing-dependent live MPI run cannot do — so it pins the exact retry
  semantics an async sender depends on.
- **`doc/designs/flexible_rank_assignments.md`** — the Phase 5 section updated
  to record this outcome (no reader change; deterministic verification).

## What changed since the first push of this PR

The first version of this PR also added a live `np=6` APH MPI integration test
(`test_flexible_rank_aph.py`). It **intermittently hangs for minutes** and
timed out the cylinders CI job. Root-caused: APH runs its persistent-solver
solves in a **worker thread**, and those solves intermittently wedge in pyomo's
threaded output capture (`TeeStream`), whose join loop spins ~7 min before
raising — an **APH/pyomo issue unrelated to the coherence policy** (reproduces
at ~3/8 runs locally; `Synchronizer.run` also never joins the worker thread,
which amplifies it at shutdown). The flaky live test is **dropped**; the
underlying issue is tracked in **Pyomo/mpi-sppy#753**. The deterministic policy
test above is the reliable proof of the same property.

## Validation

`ruff` clean; the serial suite passes including the four coherence cases
(`python -m pytest mpisppy/tests/test_flex_coherence_policy.py`). That file is
already wired into the unit-tests CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
