### PR TITLE
Add some tests for sep_rho, prox_approx, ciutils, reduced_costs_fixer

### DIFF
--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -1155,7 +1155,11 @@ jobs:
             mpisppy/tests/test_flexible_rank_ratios.py \
             mpisppy/tests/test_flex_coherence_policy.py \
             mpisppy/tests/test_flexible_rank_cli.py \
-            mpisppy/tests/test_flex_xhat_assembly.py
+            mpisppy/tests/test_flex_xhat_assembly.py \
+            mpisppy/tests/test_ciutils.py \
+            mpisppy/tests/test_prox_approx.py \
+            mpisppy/tests/test_sep_rho.py \
+            mpisppy/tests/test_reduced_costs_fixer.py
 
       - name: Upload coverage data
         if: always()

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -124,6 +124,10 @@ jobs:
         run: |
           coverage run $COV_ARGS -m pytest mpisppy/tests/test_feasible_xhat.py -v
 
+      - name: Test prox_approx end-to-end
+        run: |
+          coverage run $COV_ARGS -m pytest mpisppy/tests/test_prox_approx_e2e.py -v
+
       - name: Test docs
         run: |
           cd ./doc/

--- a/mpisppy/tests/test_ciutils.py
+++ b/mpisppy/tests/test_ciutils.py
@@ -1,0 +1,200 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+"""Tests for the pure-logic helpers in mpisppy/confidence_intervals/ciutils.py.
+
+These exercise the deterministic math and validation helpers that do not need a
+solver or MPI: prime factorization, branching-factor construction/scaling,
+node-list ordering validation, and numeric gap correction.
+"""
+
+import unittest
+
+import pyomo.environ as pyo
+
+import mpisppy.confidence_intervals.ciutils as ciutils
+
+
+def _product_of_factors(factor_dict):
+    """Reconstruct n from the {prime: multiplicity} dict that _prime_factors returns."""
+    prod = 1
+    for factor, mult in factor_dict.items():
+        prod *= factor ** mult
+    return prod
+
+
+class _FakeNode:
+    """Stand-in for scenario_tree.ScenarioNode exposing only what is_sorted reads."""
+    def __init__(self, name, stage, parent_name):
+        self.name = name
+        self.stage = stage
+        self.parent_name = parent_name
+
+
+class Test_prime_factors(unittest.TestCase):
+    def test_zero_is_special_cased(self):
+        self.assertEqual(ciutils._prime_factors(0), {0: 1})
+
+    def test_one_has_no_prime_factors(self):
+        self.assertEqual(ciutils._prime_factors(1), {})
+
+    def test_negative_raises(self):
+        with self.assertRaises(ValueError):
+            ciutils._prime_factors(-6)
+
+    def test_prime_input(self):
+        # a prime factors to itself with multiplicity one
+        self.assertEqual(ciutils._prime_factors(7), {7: 1})
+
+    def test_prime_power(self):
+        # 8 == 2**3
+        self.assertEqual(ciutils._prime_factors(8), {2: 3})
+
+    def test_composite_multiplicities_and_product(self):
+        # 360 = 2^3 * 3^2 * 5
+        factors = ciutils._prime_factors(360)
+        # multiplicities are the values; keys may be float due to internal /=
+        self.assertEqual(sum(factors.values()), 6)
+        self.assertEqual(_product_of_factors(factors), 360)
+
+    def test_product_invariant_over_a_range(self):
+        for n in range(2, 50):
+            factors = ciutils._prime_factors(n)
+            self.assertEqual(_product_of_factors(factors), n)
+
+
+class Test_branching_factors_from_numscens(unittest.TestCase):
+    def test_two_stage_returns_none(self):
+        self.assertIsNone(ciutils.branching_factors_from_numscens(100, 2))
+
+    def test_exact_factorization(self):
+        # 8 == 2*2*2 over 3 branching factors (4 stages)
+        bf = ciutils.branching_factors_from_numscens(8, 4)
+        self.assertEqual(len(bf), 3)
+        self.assertEqual(int(self._prod(bf)), 8)
+
+    def test_count_matches_num_stages_minus_one(self):
+        bf = ciutils.branching_factors_from_numscens(27, 3)
+        self.assertEqual(len(bf), 2)
+        self.assertEqual(int(self._prod(bf)), 27)
+
+    def test_increments_numscens_when_not_factorable(self):
+        # 7 is prime and cannot be split into 2 factors >= 2, so the routine
+        # bumps numscens up to the next workable count (8) and never returns
+        # fewer leaves than requested.
+        bf = ciutils.branching_factors_from_numscens(7, 3)
+        self.assertEqual(len(bf), 2)
+        self.assertGreaterEqual(self._prod(bf), 7)
+
+    @staticmethod
+    def _prod(factors):
+        p = 1
+        for f in factors:
+            p *= f
+        return p
+
+
+class Test_scalable_branching_factors(unittest.TestCase):
+    def test_docstring_example(self):
+        # documented behavior: 233 scaled like [5,3,2] -> [10,6,4] (240 leaves)
+        self.assertEqual(
+            ciutils.scalable_branching_factors(233, [5, 3, 2]),
+            [10, 6, 4],
+        )
+
+    def test_too_few_scens_falls_back_to_twos(self):
+        # numscens below 2**(numstages-1) -> all branching factors are 2
+        self.assertEqual(
+            ciutils.scalable_branching_factors(4, [5, 3, 2]),
+            [2, 2, 2],
+        )
+
+    def test_result_covers_requested_scens(self):
+        numscens = 1000
+        ref = [4, 3, 2]
+        bf = ciutils.scalable_branching_factors(numscens, ref)
+        self.assertEqual(len(bf), len(ref))
+        prod = 1
+        for f in bf:
+            prod *= f
+        self.assertGreaterEqual(prod, numscens)
+        # every branching factor is an integer value and at least 1
+        self.assertTrue(all(f == int(f) and f >= 1 for f in bf))
+
+
+class Test_is_sorted(unittest.TestCase):
+    def test_well_constructed_list_passes(self):
+        nodes = [
+            _FakeNode("ROOT", 1, None),
+            _FakeNode("ROOT_0", 2, "ROOT"),
+            _FakeNode("ROOT_0_1", 3, "ROOT_0"),
+        ]
+        # no exception == well constructed
+        ciutils.is_sorted(nodes)
+
+    def test_wrong_stage_raises(self):
+        nodes = [
+            _FakeNode("ROOT", 1, None),
+            _FakeNode("ROOT_0", 3, "ROOT"),  # stage should be 2
+        ]
+        with self.assertRaises(RuntimeError):
+            ciutils.is_sorted(nodes)
+
+    def test_wrong_parent_raises(self):
+        nodes = [
+            _FakeNode("ROOT", 1, None),
+            _FakeNode("ROOT_0", 2, "NOT_ROOT"),  # parent should be ROOT
+        ]
+        with self.assertRaises(RuntimeError):
+            ciutils.is_sorted(nodes)
+
+
+class Test_correcting_numeric(unittest.TestCase):
+    def test_minimize_clips_small_negative_to_zero(self):
+        # tiny negative gap inside tolerance is numerical noise -> clip to 0
+        G = ciutils.correcting_numeric(
+            -1e-9, cfg={}, relative_error=True, threshold=1e-4, objfct=100.0
+        )
+        self.assertEqual(G, 0.0)
+
+    def test_minimize_passes_through_positive(self):
+        G = ciutils.correcting_numeric(
+            5.0, cfg={}, relative_error=True, threshold=1e-4, objfct=100.0
+        )
+        self.assertEqual(G, 5.0)
+
+    def test_minimize_keeps_large_wrong_sign_gap(self):
+        # a genuinely wrong-sign gap (beyond tolerance) is returned unchanged
+        G = ciutils.correcting_numeric(
+            -50.0, cfg={}, relative_error=False, threshold=1e-2, objfct=100.0
+        )
+        self.assertEqual(G, -50.0)
+
+    def test_maximize_clips_small_positive_to_zero(self):
+        cfg = {"pyo_opt_sense": pyo.maximize}
+        G = ciutils.correcting_numeric(
+            1e-9, cfg=cfg, relative_error=True, threshold=1e-4, objfct=100.0
+        )
+        self.assertEqual(G, 0.0)
+
+    def test_maximize_keeps_large_wrong_sign_gap(self):
+        cfg = {"pyo_opt_sense": pyo.maximize}
+        G = ciutils.correcting_numeric(
+            50.0, cfg=cfg, relative_error=False, threshold=1e-2, objfct=100.0
+        )
+        self.assertEqual(G, 50.0)
+
+    def test_missing_objfct_raises(self):
+        with self.assertRaises(RuntimeError):
+            ciutils.correcting_numeric(
+                1.0, cfg={}, relative_error=False, threshold=1e-2, objfct=None
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mpisppy/tests/test_prox_approx.py
+++ b/mpisppy/tests/test_prox_approx.py
@@ -1,0 +1,245 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+"""Tests for mpisppy/utils/prox_approx.py.
+
+The proximal-term linearization manager builds an outer (piecewise-linear)
+approximation of y = x**2.  These tests exercise the deterministic geometry and
+the tolerance-aware cut bookkeeping directly, with persistent_solver=None, so no
+solver is required.  A small stand-in scenario mirrors the structure phbase
+attaches (scenario._mpisppy_model.{xsqvar,xsqvar_cuts,xbars,rho,W} and
+scenario._mpisppy_data.nonant_cost_coeffs).
+"""
+
+import types
+import unittest
+
+import pyomo.environ as pyo
+
+from mpisppy.utils.prox_approx import (
+    ProxApproxManager,
+    ProxApproxManagerContinuous,
+    ProxApproxManagerDiscrete,
+    _compute_mb,
+    _f_ls,
+    _df_ls,
+)
+
+NDN_I = ("ROOT", 0)
+
+
+def _make_scenario(integer=False, lb=-100, ub=100, xbar=0.0, rho=1.0, W=0.0, cost=0.0):
+    """Build the minimal structure a ProxApproxManager reads from a scenario."""
+    # the x variable being linearized
+    xmodel = pyo.ConcreteModel()
+    domain = pyo.Integers if integer else pyo.Reals
+    xmodel.x = pyo.Var(within=domain, bounds=(lb, ub))
+
+    # the block phbase calls scenario._mpisppy_model
+    mm = pyo.ConcreteModel()
+    mm.xsqvar = pyo.Var([NDN_I], bounds=(0, None), initialize=0.0)
+    mm.xsqvar_cuts = pyo.Constraint([NDN_I], pyo.Integers)
+    mm.xbars = pyo.Param([NDN_I], mutable=True, initialize=xbar)
+    mm.rho = pyo.Param([NDN_I], mutable=True, initialize=rho)
+    mm.W = pyo.Param([NDN_I], mutable=True, initialize=W)
+
+    scenario = types.SimpleNamespace(
+        _mpisppy_model=mm,
+        _mpisppy_data=types.SimpleNamespace(nonant_cost_coeffs={NDN_I: cost}),
+    )
+    return scenario, xmodel.x
+
+
+def _continuous(**kw):
+    scenario, xvar = _make_scenario(integer=False, **kw)
+    return ProxApproxManagerContinuous(scenario, xvar, NDN_I)
+
+
+def _discrete(**kw):
+    scenario, xvar = _make_scenario(integer=True, **kw)
+    return ProxApproxManagerDiscrete(scenario, xvar, NDN_I)
+
+
+class Test_pure_helpers(unittest.TestCase):
+    def test_compute_mb_known_value(self):
+        # secant of y=x^2 over [3,4]: slope 2*3+1=7, intercept -3*4=-12
+        self.assertEqual(_compute_mb(3), (7, -12))
+
+    def test_compute_mb_is_secant_through_lattice_points(self):
+        # the line m*x+b must pass through (n, n^2) and (n+1, (n+1)^2)
+        for n in range(-5, 6):
+            m, b = _compute_mb(n)
+            self.assertEqual(m * n + b, n ** 2)
+            self.assertEqual(m * (n + 1) + b, (n + 1) ** 2)
+
+    def test_f_ls_zero_on_parabola(self):
+        # residual is (x-xpnt, x^2-ypnt); zero when the point is on y=x^2
+        self.assertEqual(_f_ls([5.0], 5.0, 25.0), (0.0, 0.0))
+
+    def test_f_ls_offset(self):
+        self.assertEqual(_f_ls([2.0], 1.0, 10.0), (1.0, 4.0 - 10.0))
+
+    def test_df_ls_jacobian(self):
+        # derivative of the residual wrt the projection variable
+        self.assertEqual(_df_ls([3.0], 1.0, 1.0), ((3.0,), (6.0,)))
+
+
+class Test_factory_dispatch(unittest.TestCase):
+    def test_continuous_var_gets_continuous_manager(self):
+        scenario, xvar = _make_scenario(integer=False)
+        mgr = ProxApproxManager(scenario, xvar, NDN_I)
+        self.assertIsInstance(mgr, ProxApproxManagerContinuous)
+
+    def test_integer_var_gets_discrete_manager(self):
+        scenario, xvar = _make_scenario(integer=True)
+        mgr = ProxApproxManager(scenario, xvar, NDN_I)
+        self.assertIsInstance(mgr, ProxApproxManagerDiscrete)
+
+
+class Test_check_and_add_value(unittest.TestCase):
+    """The tolerance-aware sorted-insert bookkeeping (no model side effects)."""
+
+    def setUp(self):
+        # cut_values is seeded with [0.0] by __init__
+        self.mgr = _continuous(lb=-1000, ub=1000)
+        self.assertEqual(list(self.mgr.cut_values), [0.0])
+
+    def test_append_when_far_enough(self):
+        self.assertTrue(self.mgr.check_and_add_value(5.0, 0.1))
+        self.assertEqual(list(self.mgr.cut_values), [0.0, 5.0])
+
+    def test_reject_append_within_tolerance(self):
+        self.mgr.check_and_add_value(5.0, 0.1)
+        # 5.05 is within 0.1 of the current max (5.0) -> rejected
+        self.assertFalse(self.mgr.check_and_add_value(5.05, 0.1))
+        self.assertEqual(list(self.mgr.cut_values), [0.0, 5.0])
+
+    def test_insert_at_front(self):
+        self.assertTrue(self.mgr.check_and_add_value(-3.0, 0.1))
+        self.assertEqual(list(self.mgr.cut_values), [-3.0, 0.0])
+
+    def test_reject_front_within_tolerance(self):
+        self.mgr.check_and_add_value(-3.0, 0.1)
+        # -3.05 is within 0.1 of the current min (-3.0) -> rejected
+        self.assertFalse(self.mgr.check_and_add_value(-3.05, 0.1))
+        self.assertEqual(list(self.mgr.cut_values), [-3.0, 0.0])
+
+    def test_insert_in_middle(self):
+        self.mgr.check_and_add_value(5.0, 0.1)
+        self.assertTrue(self.mgr.check_and_add_value(2.5, 0.1))
+        self.assertEqual(list(self.mgr.cut_values), [0.0, 2.5, 5.0])
+
+    def test_reject_middle_close_to_right_neighbor(self):
+        self.mgr.check_and_add_value(5.0, 0.1)
+        # 4.95 is within 0.1 of its right neighbor (5.0) -> rejected
+        self.assertFalse(self.mgr.check_and_add_value(4.95, 0.1))
+        self.assertEqual(list(self.mgr.cut_values), [0.0, 5.0])
+
+    def test_reject_middle_close_to_left_neighbor(self):
+        self.mgr.check_and_add_value(5.0, 0.1)
+        # 0.05 is within 0.1 of its left neighbor (0.0) -> rejected
+        self.assertFalse(self.mgr.check_and_add_value(0.05, 0.1))
+        self.assertEqual(list(self.mgr.cut_values), [0.0, 5.0])
+
+    def test_values_stay_sorted(self):
+        for v in (5.0, -3.0, 2.5, 8.0, -1.0):
+            self.mgr.check_and_add_value(v, 0.1)
+        vals = list(self.mgr.cut_values)
+        self.assertEqual(vals, sorted(vals))
+
+
+class Test_continuous_add_cut(unittest.TestCase):
+    def test_adds_tangent_cut(self):
+        mgr = _continuous(lb=-100, ub=100)
+        added = mgr.add_cut(5.0, 1e-6, None)
+        self.assertEqual(added, 1)
+        self.assertEqual(mgr.cut_index, 1)
+        self.assertEqual(len(mgr.cuts), 1)
+        # the cut is the tangent of y=x^2 at a=5: xsqvar - 2*a*x + a^2 >= 0,
+        # which is tight (==0) at (x=a, xsqvar=a^2)
+        con = list(mgr.cuts.values())[0]
+        mgr.xvar.value = 5.0
+        mgr.xvarsqrd.value = 25.0
+        self.assertEqual(pyo.value(con.lower), 0)
+        self.assertFalse(con.has_ub())
+        self.assertAlmostEqual(pyo.value(con.body), 0.0)
+
+    def test_tangent_is_a_lower_bound_off_the_point(self):
+        mgr = _continuous(lb=-100, ub=100)
+        mgr.add_cut(5.0, 1e-6, None)
+        con = list(mgr.cuts.values())[0]
+        # off the tangent point the true parabola sits above the cut line,
+        # so the cut body (xsqvar - line) is positive when xsqvar = x^2
+        mgr.xvar.value = 7.0
+        mgr.xvarsqrd.value = 49.0
+        self.assertGreater(pyo.value(con.body), 0.0)
+
+    def test_value_clamped_to_bounds(self):
+        mgr = _continuous(lb=0, ub=10)
+        mgr.add_cut(50.0, 1e-6, None)  # 50 is outside [0,10] -> clamped to 10
+        self.assertIn(10.0, list(mgr.cut_values))
+        self.assertNotIn(50.0, list(mgr.cut_values))
+
+    def test_duplicate_cut_rejected(self):
+        mgr = _continuous(lb=-100, ub=100)
+        self.assertEqual(mgr.add_cut(5.0, 0.1, None), 1)
+        # same point within tolerance -> no new cut
+        self.assertEqual(mgr.add_cut(5.0, 0.1, None), 0)
+        self.assertEqual(mgr.cut_index, 1)
+        self.assertEqual(len(mgr.cuts), 1)
+
+
+class Test_discrete_add_cut(unittest.TestCase):
+    def test_interior_point_adds_two_secant_cuts(self):
+        mgr = _discrete(lb=-100, ub=100)
+        added = mgr.add_cut(3.0, 1.0, None)
+        self.assertEqual(added, 2)
+        # one cut to the right (indexed by val+1) and one to the left (by val)
+        self.assertIn((*NDN_I, 4), mgr.cuts)
+        self.assertIn((*NDN_I, 3), mgr.cuts)
+
+    def test_rounds_to_nearest_integer(self):
+        mgr = _discrete(lb=-100, ub=100)
+        mgr.add_cut(2.7, 1.0, None)  # rounds to 3
+        self.assertIn((*NDN_I, 4), mgr.cuts)
+        self.assertIn((*NDN_I, 3), mgr.cuts)
+
+    def test_repeat_adds_no_new_cuts(self):
+        mgr = _discrete(lb=-100, ub=100)
+        mgr.add_cut(3.0, 1.0, None)
+        self.assertEqual(mgr.add_cut(3.0, 1.0, None), 0)
+
+    def test_at_upper_bound_only_left_cut(self):
+        mgr = _discrete(lb=0, ub=3)
+        added = mgr.add_cut(3.0, 1.0, None)  # val==ub -> no right cut
+        self.assertEqual(added, 1)
+        self.assertIn((*NDN_I, 3), mgr.cuts)
+        self.assertNotIn((*NDN_I, 4), mgr.cuts)
+
+    def test_at_lower_bound_only_right_cut(self):
+        mgr = _discrete(lb=3, ub=10)
+        added = mgr.add_cut(3.0, 1.0, None)  # val==lb -> no left cut
+        self.assertEqual(added, 1)
+        self.assertIn((*NDN_I, 4), mgr.cuts)
+        self.assertNotIn((*NDN_I, 3), mgr.cuts)
+
+    def test_secant_cut_is_tight_at_both_endpoints(self):
+        mgr = _discrete(lb=-100, ub=100)
+        mgr.add_cut(3.0, 1.0, None)
+        # the right cut is the secant over (3,4): tight at x=3 and x=4
+        con = mgr.cuts[(*NDN_I, 4)]
+        self.assertEqual(pyo.value(con.lower), 0)
+        self.assertFalse(con.has_ub())
+        for xval in (3, 4):
+            mgr.xvar.value = xval
+            mgr.xvarsqrd.value = xval ** 2
+            self.assertAlmostEqual(pyo.value(con.body), 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mpisppy/tests/test_prox_approx_e2e.py
+++ b/mpisppy/tests/test_prox_approx_e2e.py
@@ -1,0 +1,150 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+"""End-to-end equivalence test for proximal-term linearization.
+
+``mpisppy/utils/prox_approx.py`` builds a piecewise-linear outer approximation
+of the PH proximal term ``(x - xbar)**2`` so that an LP/MIP solver can be used
+in place of a QP solver.  The unit tests in ``test_prox_approx.py`` check the
+cut geometry and bookkeeping directly (with ``persistent_solver=None``); they
+never solve a subproblem, so they cannot tell whether the approximation
+actually steers PH to the right place.
+
+This test drives the real PH engine on a small stochastic LP (farmer-3) and
+verifies the *consequence*: PH run with ``linearize_proximal_terms=True`` must
+converge to the same first-stage solution as PH run with the exact quadratic
+prox term -- and both must match the extensive-form (EF) optimum, so a shared
+but wrong fixed point cannot pass.  A solver is required (the exact-prox run
+needs a QP-capable solver); ``get_solver`` only ever returns cplex/gurobi/
+xpress, all of which handle the quadratic prox.
+"""
+
+import unittest
+
+import pyomo.environ as pyo
+
+import mpisppy.opt.ph
+import mpisppy.utils.sputils as sputils
+from mpisppy.tests.examples import farmer
+from mpisppy.tests.utils import get_solver, limit_solver_threads
+
+solver_available, solver_name, persistent_available, persistent_solver_name = \
+    get_solver()
+
+SCENARIO_NAMES = ["scen0", "scen1", "scen2"]
+SCENARIO_KWARGS = {"num_scens": 3, "crops_multiplier": 1}
+
+# Per-crop agreement is ~0.01 acres at 100 PH iterations; 1.0 acre (0.2% of the
+# 500-acre total) leaves a large margin against solver/version differences while
+# still being a meaningful equivalence check.
+ACRE_TOL = 1.0
+
+
+def _ph_options(linearize):
+    opts = {
+        "solver_name": solver_name,
+        "PHIterLimit": 100,
+        "defaultPHrho": 1.0,
+        # tiny threshold so both runs take the full iteration budget and
+        # converge tightly (the assertions are on the solution, not on
+        # whether convergence was declared)
+        "convthresh": 1e-8,
+        "verbose": False,
+        "display_timing": False,
+        "display_progress": False,
+        # keep test solves single-threaded on shared CI runners
+        "solver_options_layers": [sputils.solver_options_layer("default", {"threads": 1})],
+        "linearize_proximal_terms": linearize,
+    }
+    if linearize:
+        # tight tolerance so the piecewise-linear approximation tracks the
+        # quadratic prox closely
+        opts["proximal_linearization_tolerance"] = 1e-4
+    return opts
+
+
+def _run_ph_first_stage(linearize):
+    """Run PH to (near) convergence; return the ROOT consensus xbar keyed by
+    crop, and the reported objective."""
+    ph = mpisppy.opt.ph.PH(
+        _ph_options(linearize),
+        SCENARIO_NAMES,
+        farmer.scenario_creator,
+        None,
+        scenario_creator_kwargs=SCENARIO_KWARGS,
+    )
+    _, obj, _ = ph.ph_main()
+    # Two-stage: every scenario shares the single ROOT-node consensus, so the
+    # xbar read off any one local scenario is the first-stage solution.
+    scenario = next(iter(ph.local_scenarios.values()))
+    xbar = {
+        xvar.index(): scenario._mpisppy_model.xbars[ndn_i].value
+        for ndn_i, xvar in scenario._mpisppy_data.nonant_indices.items()
+    }
+    return xbar, obj
+
+
+def _ef_first_stage():
+    """Ground truth: the extensive-form first-stage solution, keyed by crop."""
+    ef = sputils.create_EF(
+        SCENARIO_NAMES, farmer.scenario_creator,
+        scenario_creator_kwargs=SCENARIO_KWARGS,
+    )
+    solver = pyo.SolverFactory(solver_name)
+    limit_solver_threads(solver, solver_name)
+    if "_persistent" in solver_name:
+        # persistent solvers need the instance attached before solve()
+        solver.set_instance(ef)
+    solver.solve(ef)
+    rep = getattr(ef, ef._ef_scenario_names[0])
+    xbar = {crop: pyo.value(rep.DevotedAcreage[crop]) for crop in rep.DevotedAcreage}
+    return xbar, pyo.value(ef.EF_Obj)
+
+
+@unittest.skipUnless(solver_available, "no solver available")
+class TestProxApproxEndToEnd(unittest.TestCase):
+    """PH with linearized prox must match PH with the exact quadratic prox."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.ef_sol, cls.ef_obj = _ef_first_stage()
+        cls.quad_sol, cls.quad_obj = _run_ph_first_stage(linearize=False)
+        cls.lin_sol, cls.lin_obj = _run_ph_first_stage(linearize=True)
+
+    def test_linearized_matches_quadratic_first_stage(self):
+        # the core check: linearizing the prox term does not move the answer
+        self.assertEqual(set(self.quad_sol), set(self.lin_sol))
+        for crop, quad in self.quad_sol.items():
+            self.assertAlmostEqual(
+                quad, self.lin_sol[crop], delta=ACRE_TOL,
+                msg=f"{crop}: quadratic={quad} linearized={self.lin_sol[crop]}",
+            )
+
+    def test_both_match_extensive_form(self):
+        # guard against both runs sharing the same wrong fixed point
+        for crop, ef in self.ef_sol.items():
+            self.assertAlmostEqual(
+                self.quad_sol[crop], ef, delta=ACRE_TOL,
+                msg=f"{crop}: quadratic={self.quad_sol[crop]} ef={ef}",
+            )
+            self.assertAlmostEqual(
+                self.lin_sol[crop], ef, delta=ACRE_TOL,
+                msg=f"{crop}: linearized={self.lin_sol[crop]} ef={ef}",
+            )
+
+    def test_objectives_agree(self):
+        scale = abs(self.ef_obj)
+        # linearized vs quadratic PH objective
+        self.assertAlmostEqual(self.quad_obj, self.lin_obj, delta=scale * 1e-4)
+        # both PH objectives recover the EF optimum at convergence
+        self.assertAlmostEqual(self.quad_obj, self.ef_obj, delta=scale * 1e-3)
+        self.assertAlmostEqual(self.lin_obj, self.ef_obj, delta=scale * 1e-3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mpisppy/tests/test_reduced_costs_fixer.py
+++ b/mpisppy/tests/test_reduced_costs_fixer.py
@@ -1,0 +1,263 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+"""Tests for the variable-fixing heuristic in
+mpisppy/extensions/reduced_costs_fixer.py.
+
+ReducedCostsFixer.reduced_costs_fixing() fixes non-anticipative variables to a
+bound when their (expected) reduced cost is large and consistent with that
+bound, and unfixes them when the reduced cost decays or xbar drifts away.  The
+spoke communication is bypassed here: reduced costs are passed in directly so
+the fix/unfix decision logic can be checked deterministically without MPI or a
+solver.
+
+Note: pre_iter0() classifies any *already fixed* variable as modeler-fixed (to
+be left alone forever).  So to exercise the unfix paths we fix the
+"heuristic-fixed" variables only after pre_iter0(), exactly as the real
+iteration loop would.
+"""
+
+import types
+import unittest
+
+import numpy as np
+import pyomo.environ as pyo
+from pyomo.common.collections import ComponentSet
+
+from mpisppy.extensions.reduced_costs_fixer import ReducedCostsFixer
+
+NDN = "ROOT"
+
+
+class _Val:
+    """Stand-in for an xbar Param data object (read via .value)."""
+    def __init__(self, value):
+        self.value = value
+
+
+def _make_opt(minimizing=True, fix_fraction=1.0, zero_rc_tol=1e-9, bound_tol=1e-6):
+    rc_options = {
+        "verbose": False,
+        "debug": False,
+        "zero_rc_tol": zero_rc_tol,
+        "fix_fraction_target_pre_iter0": 0.0,
+        "fix_fraction_target_iter0": fix_fraction,
+        "fix_fraction_target_iterK": fix_fraction,
+        "rc_bound_tol": bound_tol,
+    }
+    return types.SimpleNamespace(
+        is_minimizing=minimizing,
+        cylinder_rank=0,
+        nonant_length=0,
+        options={"verbose": False, "rc_options": rc_options},
+        local_scenarios={},
+    )
+
+
+def _build(specs, minimizing=True, fix_fraction=1.0, zero_rc_tol=1e-9, bound_tol=1e-6):
+    """Build (ext, vars) from a list of nonant specs.
+
+    Each spec is a dict with keys: lb, ub, value, xbar, and optional flags
+    'modeler_fixed', 'heuristic_fixed', 'surrogate', 'integer'.
+    """
+    n = len(specs)
+
+    def _bounds(m, i):
+        return (specs[i].get("lb", 0.0), specs[i].get("ub", 10.0))
+
+    def _domain(m, i):
+        return pyo.Integers if specs[i].get("integer") else pyo.Reals
+
+    sm = pyo.ConcreteModel()
+    sm.v = pyo.Var(range(n), bounds=_bounds, domain=_domain)
+
+    nonant_indices = {}
+    xbars = {}
+    surrogates = ComponentSet()  # id-based; tolerates unhashable VarData
+    for i, sp in enumerate(specs):
+        var = sm.v[i]
+        var._value = sp["value"]
+        if sp.get("modeler_fixed"):
+            var.fix(sp["value"])
+        nonant_indices[(NDN, i)] = var
+        xbars[(NDN, i)] = _Val(sp["xbar"])
+        if sp.get("surrogate"):
+            surrogates.add(var)
+
+    scenario = types.SimpleNamespace(
+        _solver_plugin=None,  # is_persistent(None) is False -> no update_var calls
+        _mpisppy_data=types.SimpleNamespace(
+            nonant_indices=nonant_indices,
+            all_surrogate_nonants=surrogates,
+        ),
+        _mpisppy_model=types.SimpleNamespace(xbars=xbars),
+    )
+
+    opt = _make_opt(minimizing, fix_fraction, zero_rc_tol, bound_tol)
+    opt.local_scenarios = {"Scen1": scenario}
+    opt.nonant_length = n
+
+    ext = ReducedCostsFixer(opt)
+    ext.pre_iter0()
+    # simulate variables the heuristic fixed on a previous iteration
+    for i, sp in enumerate(specs):
+        if sp.get("heuristic_fixed"):
+            sm.v[i].fix(sp["value"])
+    # simulate an iterK call
+    ext.fix_fraction_target = fix_fraction
+    return ext, [sm.v[i] for i in range(n)]
+
+
+class Test_fix_decisions_minimize(unittest.TestCase):
+    def test_fix_to_lb_when_positive_rc_at_lower_bound(self):
+        ext, v = _build([{"lb": 0, "ub": 10, "value": 0.0, "xbar": 0.0}])
+        ext.reduced_costs_fixing(np.array([5.0]))
+        self.assertTrue(v[0].fixed)
+        self.assertEqual(v[0].value, 0.0)  # fixed at lb
+
+    def test_fix_to_ub_when_negative_rc_at_upper_bound(self):
+        ext, v = _build([{"lb": 0, "ub": 10, "value": 10.0, "xbar": 10.0}])
+        ext.reduced_costs_fixing(np.array([-5.0]))
+        self.assertTrue(v[0].fixed)
+        self.assertEqual(v[0].value, 10.0)  # fixed at ub
+
+    def test_interior_xbar_not_fixed(self):
+        # large rc but xbar is far from either bound -> not fixed
+        ext, v = _build([{"lb": 0, "ub": 10, "value": 5.0, "xbar": 5.0}])
+        ext.reduced_costs_fixing(np.array([5.0]))
+        self.assertFalse(v[0].fixed)
+
+    def test_rc_below_zero_tol_not_fixed(self):
+        ext, v = _build(
+            [{"lb": 0, "ub": 10, "value": 0.0, "xbar": 0.0}],
+            zero_rc_tol=1e-6,
+        )
+        # |rc| below zero_rc_tol -> treated as zero -> not fixed
+        ext.reduced_costs_fixing(np.array([1e-9]))
+        self.assertFalse(v[0].fixed)
+
+
+class Test_target_quantile(unittest.TestCase):
+    def test_low_fraction_fixes_only_largest_rc(self):
+        # fix_fraction 0 -> target is the max |rc|, so only the biggest is fixed
+        specs = [
+            {"lb": 0, "ub": 10, "value": 0.0, "xbar": 0.0},
+            {"lb": 0, "ub": 10, "value": 0.0, "xbar": 0.0},
+        ]
+        ext, v = _build(specs, fix_fraction=0.0)
+        ext.reduced_costs_fixing(np.array([3.0, 9.0]))
+        self.assertFalse(v[0].fixed)  # rc 3 < target 9
+        self.assertTrue(v[1].fixed)   # rc 9 >= target 9
+
+    def test_full_fraction_fixes_all_qualifying(self):
+        # fix_fraction 1 -> target is the min nonzero |rc|, so both qualify
+        specs = [
+            {"lb": 0, "ub": 10, "value": 0.0, "xbar": 0.0},
+            {"lb": 0, "ub": 10, "value": 0.0, "xbar": 0.0},
+        ]
+        ext, v = _build(specs, fix_fraction=1.0)
+        ext.reduced_costs_fixing(np.array([3.0, 9.0]))
+        self.assertTrue(v[0].fixed)
+        self.assertTrue(v[1].fixed)
+
+
+class Test_unfix_paths(unittest.TestCase):
+    def test_unfix_when_rc_drops_below_target(self):
+        # a heuristic-fixed var whose rc is now ~0 gets released
+        ext, v = _build(
+            [{"lb": 0, "ub": 10, "value": 0.0, "xbar": 0.0, "heuristic_fixed": True}],
+            zero_rc_tol=1e-6,
+        )
+        self.assertTrue(v[0].fixed)
+        ext.reduced_costs_fixing(np.array([1e-9]))
+        self.assertFalse(v[0].fixed)
+
+    def test_unfix_when_xbar_drifts_from_fixed_value(self):
+        # rc is still large, but xbar has moved away from the fixed value
+        ext, v = _build(
+            [{"lb": 0, "ub": 10, "value": 0.0, "xbar": 3.0, "heuristic_fixed": True}],
+            bound_tol=1e-6,
+        )
+        self.assertTrue(v[0].fixed)
+        ext.reduced_costs_fixing(np.array([5.0]))
+        self.assertFalse(v[0].fixed)
+
+    def test_nan_rc_unfixes_a_fixed_var(self):
+        # var0 was heuristic-fixed; its rc is now nan (not converged in LP-LR).
+        # var1 carries a real rc so the all-nan early-return does not fire.
+        specs = [
+            {"lb": 0, "ub": 10, "value": 0.0, "xbar": 0.0, "heuristic_fixed": True},
+            {"lb": 0, "ub": 10, "value": 5.0, "xbar": 5.0},
+        ]
+        ext, v = _build(specs)
+        self.assertTrue(v[0].fixed)
+        ext.reduced_costs_fixing(np.array([np.nan, 5.0]))
+        self.assertFalse(v[0].fixed)  # nan -> released
+
+    def test_nan_rc_leaves_unfixed_var_alone(self):
+        # one real rc keeps the early all-nan guard from firing
+        specs = [
+            {"lb": 0, "ub": 10, "value": 0.0, "xbar": 0.0},
+            {"lb": 0, "ub": 10, "value": 0.0, "xbar": 0.0},
+        ]
+        ext, v = _build(specs)
+        ext.reduced_costs_fixing(np.array([np.nan, 5.0]))
+        self.assertFalse(v[0].fixed)  # nan -> untouched
+        self.assertTrue(v[1].fixed)   # real positive rc at lb -> fixed
+
+
+class Test_skips_and_guards(unittest.TestCase):
+    def test_modeler_fixed_var_is_left_alone(self):
+        # fixed before pre_iter0 -> recorded as modeler-fixed -> never touched
+        ext, v = _build(
+            [{"lb": 0, "ub": 10, "value": 5.0, "xbar": 5.0, "modeler_fixed": True}]
+        )
+        self.assertIn((NDN, 0), ext._modeler_fixed_nonants)
+        ext.reduced_costs_fixing(np.array([5.0]))
+        self.assertTrue(v[0].fixed)
+        self.assertEqual(v[0].value, 5.0)  # not moved to a bound
+
+    def test_surrogate_nonant_is_skipped(self):
+        # qualifies on rc/bound, but is a surrogate -> skipped, stays unfixed
+        ext, v = _build(
+            [{"lb": 0, "ub": 10, "value": 0.0, "xbar": 0.0, "surrogate": True}]
+        )
+        ext.reduced_costs_fixing(np.array([5.0]))
+        self.assertFalse(v[0].fixed)
+
+    def test_all_nan_reduced_costs_is_a_noop(self):
+        ext, v = _build(
+            [{"lb": 0, "ub": 10, "value": 0.0, "xbar": 0.0, "heuristic_fixed": True}]
+        )
+        self.assertTrue(v[0].fixed)
+        # all reduced costs nan -> returns immediately, so the fixed var that
+        # would otherwise be released stays fixed (no unfixing happens)
+        ext.reduced_costs_fixing(np.array([np.nan]))
+        self.assertTrue(v[0].fixed)
+
+
+class Test_fix_decisions_maximize(unittest.TestCase):
+    def test_fix_to_lb_when_negative_rc_at_lower_bound(self):
+        ext, v = _build(
+            [{"lb": 0, "ub": 10, "value": 0.0, "xbar": 0.0}], minimizing=False
+        )
+        ext.reduced_costs_fixing(np.array([-5.0]))
+        self.assertTrue(v[0].fixed)
+        self.assertEqual(v[0].value, 0.0)
+
+    def test_fix_to_ub_when_positive_rc_at_upper_bound(self):
+        ext, v = _build(
+            [{"lb": 0, "ub": 10, "value": 10.0, "xbar": 10.0}], minimizing=False
+        )
+        ext.reduced_costs_fixing(np.array([5.0]))
+        self.assertTrue(v[0].fixed)
+        self.assertEqual(v[0].value, 10.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mpisppy/tests/test_sep_rho.py
+++ b/mpisppy/tests/test_sep_rho.py
@@ -1,0 +1,197 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+"""Tests for the SEP rho setter in mpisppy/extensions/sep_rho.py.
+
+SepRho (Watson & Woodruff, 2011) sets, per non-anticipative variable with a
+nonzero objective coefficient c:
+
+    integer    var:  rho = |c| / (xmax - xmin + 1) * multiplier
+    continuous var:  rho = |c| / max(1, E|x - xbar|) * multiplier
+
+and leaves rho untouched where c == 0.  These tests drive the real extension
+code (including its single-rank MPI all-reduces) with a controlled stand-in PH
+so the per-variable arithmetic can be checked exactly, with no solver.
+"""
+
+import types
+import warnings
+import unittest
+
+import pyomo.environ as pyo
+
+import mpisppy.MPI as MPI
+from mpisppy.extensions.sep_rho import SepRho
+
+NDN = "ROOT"
+NLEN = 4
+# index -> is this nonant integer-valued?
+INTEGER_FLAGS = [False, True, False, False]
+# the same objective coefficients are used for every scenario
+COSTS = [10.0, -15.0, 7.0, 0.0]
+# nonant 3 has c == 0, so its rho must never change from this seed
+INIT_RHOS = [99.0, 99.0, 99.0, 42.0]
+# probability-weighted mean of each nonant across the two scenarios below
+XBARS = [15.0, 6.0, 10.25, 1.5]
+# per-scenario nonant values (rows are scenarios)
+SCEN_VALS = {
+    "Scen1": [10.0, 4, 10.0, 1.0],
+    "Scen2": [20.0, 8, 10.5, 2.0],
+}
+
+
+class _Holder:
+    """Mimics a mutable Pyomo Param data object (only ._value is read/written)."""
+    def __init__(self, value):
+        self._value = value
+
+
+class _Scenario:
+    """Hashable scenario stand-in (SepRho caches cost coeffs keyed on the
+    scenario object, and types.SimpleNamespace is unhashable)."""
+    def __init__(self, **kw):
+        self.__dict__.update(kw)
+
+
+def _make_scenario(name, prob):
+    sm = pyo.ConcreteModel()
+
+    def _domain(m, i):
+        return pyo.Integers if INTEGER_FLAGS[i] else pyo.Reals
+
+    sm.v = pyo.Var(range(NLEN), domain=_domain)
+    for i, val in enumerate(SCEN_VALS[name]):
+        sm.v[i]._value = val
+
+    nonant_vardata_list = [sm.v[i] for i in range(NLEN)]
+    node = types.SimpleNamespace(name=NDN, nonant_vardata_list=nonant_vardata_list)
+
+    data = types.SimpleNamespace(
+        nlens={NDN: NLEN},
+        nonant_indices={(NDN, i): sm.v[i] for i in range(NLEN)},
+        nonant_cost_coeffs={(NDN, i): COSTS[i] for i in range(NLEN)},
+    )
+    model = types.SimpleNamespace(
+        xbars={(NDN, i): _Holder(XBARS[i]) for i in range(NLEN)},
+        rho={(NDN, i): _Holder(INIT_RHOS[i]) for i in range(NLEN)},
+    )
+    # keep a handle to the Pyomo model alive so the Vars are not gc'd
+    return _Scenario(
+        _pyomo_model=sm,
+        _mpisppy_node_list=[node],
+        _mpisppy_data=data,
+        _mpisppy_model=model,
+        _mpisppy_probability=prob,
+    )
+
+
+def _make_ph(multiplier=1.0):
+    scenarios = {
+        "Scen1": _make_scenario("Scen1", 0.5),
+        "Scen2": _make_scenario("Scen2", 0.5),
+    }
+    return types.SimpleNamespace(
+        cylinder_rank=0,
+        _PHIter=0,
+        local_scenarios=scenarios,
+        comms={NDN: MPI.COMM_WORLD},
+        options={"sep_rho_options": {"cfg": types.SimpleNamespace(),
+                                     "multiplier": multiplier}},
+    )
+
+
+def _make_ext(ph):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        return SepRho(ph)
+
+
+@unittest.skipIf(MPI.COMM_WORLD.Get_size() > 1,
+                 "serial unit test; run without mpiexec")
+class Test_sep_rho_reductions(unittest.TestCase):
+    """The cross-scenario all-reduce helpers compute xmax, xmin, and E|x-xbar|."""
+
+    def setUp(self):
+        self.ph = _make_ph()
+        self.ext = _make_ext(self.ph)
+
+    def test_xmax(self):
+        xmax = SepRho._compute_xmax(self.ph)
+        self.assertEqual(xmax[(NDN, 0)], 20.0)
+        self.assertEqual(xmax[(NDN, 1)], 8.0)
+        self.assertEqual(xmax[(NDN, 2)], 10.5)
+
+    def test_xmin(self):
+        xmin = SepRho._compute_xmin(self.ph)
+        self.assertEqual(xmin[(NDN, 0)], 10.0)
+        self.assertEqual(xmin[(NDN, 1)], 4.0)
+        self.assertEqual(xmin[(NDN, 2)], 10.0)
+
+    def test_primal_residual_is_probability_weighted_abs_gap(self):
+        resid = self.ext._compute_primal_residual_norm(self.ph)
+        # 0.5*|10-15| + 0.5*|20-15| = 5.0
+        self.assertAlmostEqual(resid[(NDN, 0)], 5.0)
+        # 0.5*|4-6| + 0.5*|8-6| = 2.0
+        self.assertAlmostEqual(resid[(NDN, 1)], 2.0)
+        # 0.5*|10-10.25| + 0.5*|10.5-10.25| = 0.25
+        self.assertAlmostEqual(resid[(NDN, 2)], 0.25)
+
+
+@unittest.skipIf(MPI.COMM_WORLD.Get_size() > 1,
+                 "serial unit test; run without mpiexec")
+class Test_sep_rho_formula(unittest.TestCase):
+    def _run(self, multiplier=1.0):
+        ph = _make_ph(multiplier=multiplier)
+        ext = _make_ext(ph)
+        ext.compute_and_update_rho()
+        return ph
+
+    def _rho(self, ph, sname, i):
+        return ph.local_scenarios[sname]._mpisppy_model.rho[(NDN, i)]._value
+
+    def test_continuous_nonant_uses_residual(self):
+        ph = self._run()
+        # |10| / max(1, 5.0) = 2.0
+        for sname in ("Scen1", "Scen2"):
+            self.assertAlmostEqual(self._rho(ph, sname, 0), 2.0)
+
+    def test_continuous_residual_clamped_at_one(self):
+        ph = self._run()
+        # residual 0.25 < 1, so denominator is max(1, 0.25) = 1 -> |7|/1 = 7.0
+        self.assertAlmostEqual(self._rho(ph, "Scen1", 2), 7.0)
+
+    def test_integer_nonant_uses_range_and_abs_cost(self):
+        ph = self._run()
+        # |-15| / (8 - 4 + 1) = 3.0  (note abs of a negative coefficient)
+        for sname in ("Scen1", "Scen2"):
+            self.assertAlmostEqual(self._rho(ph, sname, 1), 3.0)
+
+    def test_zero_cost_coeff_leaves_rho_untouched(self):
+        ph = self._run()
+        # c == 0 -> rho keeps its seeded value
+        self.assertEqual(self._rho(ph, "Scen1", 3), 42.0)
+        self.assertEqual(self._rho(ph, "Scen2", 3), 42.0)
+
+    def test_multiplier_scales_every_updated_rho(self):
+        ph = self._run(multiplier=2.0)
+        self.assertAlmostEqual(self._rho(ph, "Scen1", 0), 4.0)   # 2.0 * 2
+        self.assertAlmostEqual(self._rho(ph, "Scen1", 1), 6.0)   # 3.0 * 2
+        self.assertAlmostEqual(self._rho(ph, "Scen1", 2), 14.0)  # 7.0 * 2
+        # the zero-cost nonant is still skipped, so no scaling applies
+        self.assertEqual(self._rho(ph, "Scen1", 3), 42.0)
+
+    def test_multiplier_default_reads_from_options(self):
+        # multiplier defaults to 1.0 when omitted from sep_rho_options
+        ph = _make_ph()
+        del ph.options["sep_rho_options"]["multiplier"]
+        ext = _make_ext(ph)
+        self.assertEqual(ext.multiplier, 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/run_coverage.bash
+++ b/run_coverage.bash
@@ -158,6 +158,25 @@ run_phase "test_xhat_from_file (serial)" \
 run_phase "test_incumbent_writing (serial)" \
     coverage run --rcfile=.coveragerc -m pytest mpisppy/tests/test_incumbent_writing.py -v
 
+# Pure-logic serial unit tests (no MPI, no solver). The CI "run unit tests"
+# job (.github/workflows/test_pr_and_main.yml) runs these under coverage; keep
+# this list in sync with that job so local and CI coverage numbers match.
+run_phase "serial unit tests (serial)" \
+    coverage run --rcfile=.coveragerc -m pytest -v \
+        mpisppy/tests/test_sputils.py \
+        mpisppy/tests/test_config.py \
+        mpisppy/tests/test_log.py \
+        mpisppy/tests/test_scenario_tree.py \
+        mpisppy/tests/test_nice_join.py \
+        mpisppy/tests/test_solver_spec.py \
+        mpisppy/tests/test_extensions.py \
+        mpisppy/tests/test_buffer_inspect.py \
+        mpisppy/tests/test_comm_lor_check.py \
+        mpisppy/tests/test_ciutils.py \
+        mpisppy/tests/test_prox_approx.py \
+        mpisppy/tests/test_sep_rho.py \
+        mpisppy/tests/test_reduced_costs_fixer.py
+
 run_phase "test_conf_int_farmer (spawns mpiexec)" \
     coverage run --rcfile=.coveragerc mpisppy/tests/test_conf_int_farmer.py
 

--- a/run_coverage.bash
+++ b/run_coverage.bash
@@ -98,6 +98,9 @@ run_phase "test_admm_bundler (serial)" \
 run_phase "test_proper_bundler (serial)" \
     coverage run --rcfile=.coveragerc -m pytest mpisppy/tests/test_proper_bundler.py -v
 
+run_phase "test_prox_approx_e2e (serial)" \
+    coverage run --rcfile=.coveragerc -m pytest mpisppy/tests/test_prox_approx_e2e.py -v
+
 run_phase "test_aph (spawns mpiexec)" \
     coverage run --rcfile=.coveragerc mpisppy/tests/test_aph.py
 


### PR DESCRIPTION
## What

Adds tests for deterministic logic that was under-covered. Two parts:

1. **Solver-free, MPI-free unit tests** for four modules, wired into the CI no-solver unit-test job and `run_coverage.bash`.
2. **A solver-gated end-to-end test** that PH with the linearized proximal term agrees with PH using the exact quadratic prox, wired into the cplex/xpress regression job and `run_coverage.bash`.

## Unit tests added

| Module | Coverage | What the tests verify |
|---|---|---|
| `extensions/sep_rho.py` | 21% → 92% | the SEP rho formula — integer `\|c\|/(xmax−xmin+1)` vs continuous `\|c\|/max(1,E\|x−xbar\|)`, abs of a negative cost, the `max(1,·)` clamp, multiplier scaling, zero-cost skip — and the cross-scenario xmax/xmin/residual all-reduces |
| `extensions/reduced_costs_fixer.py` | 42% → 67% | the fix/unfix heuristic — fix-to-bound by reduced-cost sign and bound proximity (both senses), the quantile target cutoff, unfix on rc decay / xbar drift / nan, and the modeler-fixed / surrogate / all-nan guards |
| `utils/prox_approx.py` | no direct test before (≈50% indirect, continuous path only, via `test_proper_bundler`) | tolerance-aware cut insertion at every bisect branch, tangent/secant cut geometry (tight at the lattice points, lower-bounding off them), bound clamping, dedup — and, importantly, the **discrete/integer** manager and `_compute_mb`, which farmer (continuous) never exercised |
| `confidence_intervals/ciutils.py` | partial before | prime factorization, branching-factor construction/scaling, node-list ordering validation, sign-aware numeric gap correction |

All four run as fast serial unit tests (no MPI, no solver). They check actual computed values against the formulas, not just that the code runs.

## End-to-end test added

`tests/test_prox_approx_e2e.py` drives the real PH engine on farmer-3. The unit tests above call `prox_approx` with `persistent_solver=None` and never solve a subproblem, so they verify cut *geometry* but not the *consequence*: that linearizing the prox term steers PH to the right answer. This test runs PH twice — `linearize_proximal_terms=True` vs the exact quadratic prox — and asserts:

- the converged first-stage solution matches between the two runs (within 1.0 acre; observed ≈0.01),
- both runs match the extensive-form optimum (so a shared-but-wrong fixed point can't pass),
- the reported objectives agree and recover the EF optimum.

It is solver-gated (`@skipUnless`); the exact-prox run needs a QP-capable solver, and `get_solver` only returns cplex/gurobi/xpress, all of which qualify.

## Harness

- The four unit-test files are added to the CI `run unit tests` (no-solver) job and to `run_coverage.bash`.
- `test_prox_approx_e2e.py` is added to the **regression job** (which installs cplex + xpress) and to `run_coverage.bash` — not the no-solver job, where the QP run would be skipped and contribute nothing.
- `run_coverage.bash` also gains the serial unit-test block (`test_sputils`, `test_config`, `test_log`, `test_scenario_tree`, `test_nice_join`, `test_solver_spec`, `test_extensions`, `test_buffer_inspect`, `test_comm_lor_check`) that CI already runs under coverage but the local harness was missing — so local coverage numbers now match CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
