### PR TITLE
Flex ranks phase 6: per-spoke rank-ratio flags (ph_dual/relaxed_ph/subgradient/fwph)

### DIFF
--- a/doc/designs/flexible_rank_assignments.md
+++ b/doc/designs/flexible_rank_assignments.md
@@ -753,6 +753,66 @@ differs from 1.0)
   the coherence policy), which times out CI.  Tracked in Pyomo/mpi-sppy#753.
 
 
+**Phase 6: Complete per-spoke rank-ratio flag coverage**
+
+A spoke may expose a `--<spoke>-rank-ratio` flag exactly when **every
+per-scenario field it sends or receives has a multi-source assembler**.
+The flag *is* the gate (a non-1.0 ratio is what selects the unequal-rank
+path), so exposing it for a spoke whose fields are not yet supported only
+surfaces the startup `NotImplementedError` — honest, but useless.
+Coverage therefore tracks field support, not spoke convenience:
+
+| Spoke (`cfg` gate) | Flag | Per-scenario field(s) | Status |
+|---|---|---|---|
+| `lagrangian` | `lagrangian_rank_ratio` | `DUALS`; `NONANTS_VALS` (recv) | landed |
+| `xhatshuffle` | `xhatshuffle_rank_ratio` | `BEST_XHAT` / `RECENT_XHATS` | landed |
+| `xhatxbar` | `xhatxbar_rank_ratio` | `BEST_XHAT` / `RECENT_XHATS` | landed |
+| `ph_xfeas_spoke` | `ph_xfeas_spoke_rank_ratio` | `XFEAS` | landed |
+| `ph_dual` | `ph_dual_rank_ratio` | `DUALS` | ready — any stage count |
+| `relaxed_ph` | `relaxed_ph_rank_ratio` | `DUALS`, `RELAXED_NONANTS_VALS` | ready — any stage count |
+| `subgradient` | `subgradient_rank_ratio` | `XFEAS`; `NONANTS_VALS` (recv) | ready two-stage; multistage needs phase 4b |
+| `fwph` | `fwph_rank_ratio` | `BEST_XHAT` / `RECENT_XHATS` (recv); `NONANTS_VALS` (recv) | ready two-stage; multistage needs phase 4b |
+| `reduced_costs` | — | `SCENARIO_REDUCED_COST` | needs assembler + consumer rework — see phase 7 |
+
+- Add `ph_dual_rank_ratio`, `relaxed_ph_rank_ratio`,
+  `subgradient_rank_ratio`, and `fwph_rank_ratio` (the spokes whose every
+  per-scenario field already has a multi-source assembler). Each is
+  mechanical: one `add_to_config(...)` in the matching `*_args` method,
+  one `<spoke>_dict["rank_ratio"] = cfg.<gate>_rank_ratio` line in
+  `build_spoke_list`, and one assertion in `test_flexible_rank_cli.py`,
+  mirroring `ph_xfeas_spoke_rank_ratio`. `ph_dual` / `relaxed_ph` carry
+  only fields without a multistage guard, so they work at any stage
+  count; `subgradient` / `fwph` carry the xhat/`XFEAS` fields, so a
+  multistage flex run errors cleanly at startup until phase 4b lands.
+- This is config-only (additive); the equal-rank path is untouched.
+- `reduced_costs` is **not** folded in here: it is the one remaining
+  spoke whose field has no assembler, and adding one is a behavioral
+  change (phase 7), not config wiring.
+
+**Phase 7: `reduced_costs` spoke (`SCENARIO_REDUCED_COST`)**
+
+`SCENARIO_REDUCED_COST` is a genuinely per-scenario field with the same
+`_local_nonant_length` layout as `NONANTS_VALS` / `DUALS` (one reduced
+cost per nonant per scenario; relaxed coherence, since it only steers
+rho). The two pieces of work:
+
+- **Assembler (trivial).** Add `SCENARIO_REDUCED_COST` to the
+  per-scenario branch of `_items_per_scen_for_field` (returns
+  `[nonant_length] * num_scenarios`) and leave it out of
+  `_STRICT_COHERENCE_FIELDS` (relaxed).
+- **Consumer rework (the real change).** `ReducedCostsRho`
+  (`extensions/reduced_costs_rho.py`) currently asserts
+  `len(fields_to_ranks[SCENARIO_REDUCED_COST]) == 1` and reads from a
+  single peer rank — the same single-source assumption that the
+  `XFEAS` → CG hub consumer had before phase 4a. Teach it to read
+  multi-source across the spoke's ranks (drop the assert; assemble via
+  the overlap map), then add a `reduced_costs` flag and an end-to-end
+  multi-rank test. Same shape and review size as the `XFEAS`/CG work.
+
+Only after phase 7 does the phase-6 table's last row flip to a landed
+`reduced_costs_rank_ratio`.
+
+
 ### Development and rollout strategy
 
 These changes touch a low-level, implementation-sensitive corner of the

--- a/doc/designs/flexible_rank_assignments.md
+++ b/doc/designs/flexible_rank_assignments.md
@@ -768,22 +768,22 @@ Coverage therefore tracks field support, not spoke convenience:
 | `xhatshuffle` | `xhatshuffle_rank_ratio` | `BEST_XHAT` / `RECENT_XHATS` | landed |
 | `xhatxbar` | `xhatxbar_rank_ratio` | `BEST_XHAT` / `RECENT_XHATS` | landed |
 | `ph_xfeas_spoke` | `ph_xfeas_spoke_rank_ratio` | `XFEAS` | landed |
-| `ph_dual` | `ph_dual_rank_ratio` | `DUALS` | ready — any stage count |
-| `relaxed_ph` | `relaxed_ph_rank_ratio` | `DUALS`, `RELAXED_NONANTS_VALS` | ready — any stage count |
-| `subgradient` | `subgradient_rank_ratio` | `XFEAS`; `NONANTS_VALS` (recv) | ready two-stage; multistage needs phase 4b |
-| `fwph` | `fwph_rank_ratio` | `BEST_XHAT` / `RECENT_XHATS` (recv); `NONANTS_VALS` (recv) | ready two-stage; multistage needs phase 4b |
+| `ph_dual` | `ph_dual_rank_ratio` | `DUALS` | landed |
+| `relaxed_ph` | `relaxed_ph_rank_ratio` | `DUALS`, `RELAXED_NONANTS_VALS` | landed |
+| `subgradient` | `subgradient_rank_ratio` | `XFEAS`; `NONANTS_VALS` (recv) | landed |
+| `fwph` | `fwph_rank_ratio` | `BEST_XHAT` / `RECENT_XHATS` (recv); `NONANTS_VALS` (recv) | landed |
 | `reduced_costs` | — | `SCENARIO_REDUCED_COST` | needs assembler + consumer rework — see phase 7 |
 
-- Add `ph_dual_rank_ratio`, `relaxed_ph_rank_ratio`,
+- Added `ph_dual_rank_ratio`, `relaxed_ph_rank_ratio`,
   `subgradient_rank_ratio`, and `fwph_rank_ratio` (the spokes whose every
-  per-scenario field already has a multi-source assembler). Each is
+  per-scenario field already has a multi-source assembler). Each was
   mechanical: one `add_to_config(...)` in the matching `*_args` method,
   one `<spoke>_dict["rank_ratio"] = cfg.<gate>_rank_ratio` line in
   `build_spoke_list`, and one assertion in `test_flexible_rank_cli.py`,
-  mirroring `ph_xfeas_spoke_rank_ratio`. `ph_dual` / `relaxed_ph` carry
-  only fields without a multistage guard, so they work at any stage
-  count; `subgradient` / `fwph` carry the xhat/`XFEAS` fields, so a
-  multistage flex run errors cleanly at startup until phase 4b lands.
+  mirroring `ph_xfeas_spoke_rank_ratio`. All four carry only fields whose
+  assembler is stage-agnostic (`DUALS`, `RELAXED_NONANTS_VALS`,
+  `NONANTS_VALS`, and the xhat/`XFEAS` blocks routed wholesale per
+  scenario), so they work at any stage count.
 - This is config-only (additive); the equal-rank path is untouched.
 - `reduced_costs` is **not** folded in here: it is the one remaining
   spoke whose field has no assembler, and adding one is a behavioral

--- a/mpisppy/generic/spokes.py
+++ b/mpisppy/generic/spokes.py
@@ -43,6 +43,7 @@ def build_spoke_list(cfg, beans, scenario_creator_kwargs,
                                       all_nodenames=all_nodenames,
                                       rho_setter=rho_setter,
                                       )
+        fw_spoke["rank_ratio"] = cfg.fwph_rank_ratio
 
     # Standard Lagrangian bound spoke
     if cfg.lagrangian:
@@ -78,6 +79,7 @@ def build_spoke_list(cfg, beans, scenario_creator_kwargs,
         if cfg.grad_rho:
             modified_cfg["grad_order_stat"] = cfg.ph_dual_grad_order_stat
             vanilla.add_grad_rho(ph_dual_spoke, modified_cfg)
+        ph_dual_spoke["rank_ratio"] = cfg.ph_dual_rank_ratio
 
     # PH xhat-feasible spoke
     if cfg.ph_xfeas_spoke:
@@ -115,6 +117,7 @@ def build_spoke_list(cfg, beans, scenario_creator_kwargs,
             vanilla.add_coeff_rho(relaxed_ph_spoke, cfg)
         if cfg.sensi_rho:
             vanilla.add_sensi_rho(relaxed_ph_spoke, cfg)
+        relaxed_ph_spoke["rank_ratio"] = cfg.relaxed_ph_rank_ratio
 
     # subgradient outer bound spoke
     if cfg.subgradient:
@@ -130,6 +133,7 @@ def build_spoke_list(cfg, beans, scenario_creator_kwargs,
             vanilla.add_coeff_rho(subgradient_spoke, cfg)
         if cfg.sensi_rho:
             vanilla.add_sensi_rho(subgradient_spoke, cfg)
+        subgradient_spoke["rank_ratio"] = cfg.subgradient_rank_ratio
 
     # xhat shuffle bound spoke
     if cfg.xhatshuffle:

--- a/mpisppy/tests/test_flexible_rank_cli.py
+++ b/mpisppy/tests/test_flexible_rank_cli.py
@@ -52,6 +52,10 @@ class TestFlexibleRankCLI(unittest.TestCase):
         self.assertEqual(cfg.xhatshuffle_rank_ratio, 1.0)
         self.assertEqual(cfg.xhatxbar_rank_ratio, 1.0)
         self.assertEqual(cfg.ph_xfeas_spoke_rank_ratio, 1.0)
+        self.assertEqual(cfg.fwph_rank_ratio, 1.0)
+        self.assertEqual(cfg.ph_dual_rank_ratio, 1.0)
+        self.assertEqual(cfg.relaxed_ph_rank_ratio, 1.0)
+        self.assertEqual(cfg.subgradient_rank_ratio, 1.0)
 
     def test_build_spoke_list_injects_rank_ratio(self):
         cfg = _full_cfg()
@@ -64,6 +68,14 @@ class TestFlexibleRankCLI(unittest.TestCase):
         cfg.xhatxbar_rank_ratio = 2.0
         cfg.ph_xfeas_spoke = True
         cfg.ph_xfeas_spoke_rank_ratio = 4.0
+        cfg.fwph = True
+        cfg.fwph_rank_ratio = 8.0
+        cfg.ph_dual = True
+        cfg.ph_dual_rank_ratio = 3.0
+        cfg.relaxed_ph = True
+        cfg.relaxed_ph_rank_ratio = 5.0
+        cfg.subgradient = True
+        cfg.subgradient_rank_ratio = 0.125
 
         scenario_creator = farmer.scenario_creator
         scenario_denouement = farmer.scenario_denouement
@@ -76,9 +88,10 @@ class TestFlexibleRankCLI(unittest.TestCase):
             rho_setter=None, all_nodenames=None,
         )
 
-        # exactly the four enabled spokes, each carrying its requested ratio
+        # exactly the enabled spokes, each carrying its requested ratio
         ratios = sorted(d["rank_ratio"] for d in spokes)
-        self.assertEqual(ratios, sorted([0.5, 0.25, 2.0, 4.0]))
+        self.assertEqual(ratios, sorted([0.5, 0.25, 2.0, 4.0,
+                                         8.0, 3.0, 5.0, 0.125]))
         # and every spoke dict got an explicit rank_ratio
         self.assertTrue(all("rank_ratio" in d for d in spokes))
 

--- a/mpisppy/utils/config.py
+++ b/mpisppy/utils/config.py
@@ -678,6 +678,13 @@ class Config(pyofig.ConfigDict):
                            domain=bool,
                            default=False)
 
+        self.add_to_config('fwph_rank_ratio',
+                           description="MPI ranks for the fwph spoke "
+                                       "relative to the hub (flexible rank "
+                                       "assignments; default 1.0 = equal)",
+                           domain=float,
+                           default=1.0)
+
         self.add_to_config(name="fwph_hub",
                            description="Use FWPH hub instead of PH (default False)",
                            domain=bool,
@@ -874,6 +881,13 @@ class Config(pyofig.ConfigDict):
                               domain=bool,
                               default=False)
 
+        self.add_to_config('subgradient_rank_ratio',
+                              description="MPI ranks for the subgradient spoke "
+                                          "relative to the hub (flexible rank "
+                                          "assignments; default 1.0 = equal)",
+                              domain=float,
+                              default=1.0)
+
         self.add_solver_specs("subgradient")
         self.add_mipgap_specs("subgradient")
 
@@ -902,6 +916,12 @@ class Config(pyofig.ConfigDict):
                             description="have a relaxed PH spoke",
                             domain=bool,
                             default=False)
+        self.add_to_config("relaxed_ph_rank_ratio",
+                            description="MPI ranks for the relaxed_ph spoke "
+                                        "relative to the hub (flexible rank "
+                                        "assignments; default 1.0 = equal)",
+                            domain=float,
+                            default=1.0)
         self.add_to_config("relaxed_ph_rescale_rho_factor",
                             description="Used to rescale rho initially (default=1.0)",
                             domain=float,
@@ -941,6 +961,13 @@ class Config(pyofig.ConfigDict):
                             description="have a dual PH spoke",
                             domain=bool,
                             default=False)
+
+        self.add_to_config("ph_dual_rank_ratio",
+                            description="MPI ranks for the ph_dual spoke "
+                                        "relative to the hub (flexible rank "
+                                        "assignments; default 1.0 = equal)",
+                            domain=float,
+                            default=1.0)
 
         self.add_solver_specs("ph_dual")
 


### PR DESCRIPTION
## Flexible rank assignments — Phase 6: complete per-spoke rank-ratio flag coverage

Phases 1–5 of the flexible (unequal) rank-assignment work are all in `main`. This phase completes the per-spoke `--<spoke>-rank-ratio` flag coverage for the four spokes whose **every per-scenario field already has a stage-agnostic multi-source assembler**, so the flag is honest the moment it is exposed:

| Spoke (`cfg` gate) | New flag | Per-scenario field(s) |
|---|---|---|
| `ph_dual` | `--ph-dual-rank-ratio` | `DUALS` |
| `relaxed_ph` | `--relaxed-ph-rank-ratio` | `DUALS`, `RELAXED_NONANTS_VALS` |
| `subgradient` | `--subgradient-rank-ratio` | `XFEAS`; `NONANTS_VALS` (recv) |
| `fwph` | `--fwph-rank-ratio` | `BEST_XHAT` / `RECENT_XHATS` (recv); `NONANTS_VALS` (recv) |

### What changed (config-only, additive)

Each flag mirrors the existing `ph_xfeas_spoke_rank_ratio` exactly:

- **`mpisppy/utils/config.py`** — one `add_to_config(..., domain=float, default=1.0)` in each spoke's `*_args` method.
- **`mpisppy/generic/spokes.py`** — one `<spoke>["rank_ratio"] = cfg.<gate>_rank_ratio` line in `build_spoke_list`.
- **`mpisppy/tests/test_flexible_rank_cli.py`** — assert the four new defaults and that all enabled spokes carry their requested ratio through the builder.
- **`doc/designs/flexible_rank_assignments.md`** — the parked Phase 6/7 plan, with the four rows marked landed.

The equal-rank path (`rank_ratio == 1.0`) is byte-identical; a non-1.0 ratio selects the existing unequal-rank assembly. All four spokes carry only fields whose assembler is stage-agnostic (`DUALS`, `RELAXED_NONANTS_VALS`, `NONANTS_VALS`, and the per-scenario `XFEAS`/xhat blocks routed wholesale per scenario), so they work at any stage count.

### Not included

`reduced_costs` is deliberately left out: its `SCENARIO_REDUCED_COST` field has no multi-source assembler, and adding one is a behavioral change (`ReducedCostsRho` asserts a single source rank and must be taught multi-source). That is Phase 7, scoped in the design doc.

### Testing

- `test_flexible_rank_cli.py` (3 serial tests, already wired into `run_coverage.bash` and CI).
- `ruff check` clean.
- All four `--*-rank-ratio` flags verified present on `generic_cylinders.py --help`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
