### PR TITLE
Flex ranks phase 7: reduced_costs rank-ratio flag (equal-rank only for the deprecated reduced-cost rho)

### DIFF
--- a/doc/designs/flexible_rank_assignments.md
+++ b/doc/designs/flexible_rank_assignments.md
@@ -779,7 +779,12 @@ Coverage therefore tracks field support, not spoke convenience:
 | `relaxed_ph` | `relaxed_ph_rank_ratio` | `DUALS`, `RELAXED_NONANTS_VALS` | landed |
 | `subgradient` | `subgradient_rank_ratio` | `XFEAS`; `NONANTS_VALS` (recv) | landed |
 | `fwph` | `fwph_rank_ratio` | `BEST_XHAT` / `RECENT_XHATS` (recv); `NONANTS_VALS` (recv) | landed |
-| `reduced_costs` | — | `SCENARIO_REDUCED_COST` | needs assembler + consumer rework — see phase 7 |
+| `reduced_costs` | `reduced_costs_rank_ratio` | `DUALS`, `NONANTS_VALS` (recv); `SCENARIO_REDUCED_COST`† | flag landed (phase 7) |
+
+† `SCENARIO_REDUCED_COST`'s only consumer is the deprecated `ReducedCostsRho`,
+so it was left without a multi-source assembler (see Phase 7). The spoke's
+other uses work at unequal ranks; `checker()` rejects the one unsupported
+combination (`--reduced-costs-rho` with a non-1.0 `reduced_costs_rank_ratio`).
 
 - Added `ph_dual_rank_ratio`, `relaxed_ph_rank_ratio`,
   `subgradient_rank_ratio`, and `fwph_rank_ratio` (the spokes whose every
@@ -792,32 +797,49 @@ Coverage therefore tracks field support, not spoke convenience:
   `NONANTS_VALS`, and the xhat/`XFEAS` blocks routed wholesale per
   scenario), so they work at any stage count.
 - This is config-only (additive); the equal-rank path is untouched.
-- `reduced_costs` is **not** folded in here: it is the one remaining
-  spoke whose field has no assembler, and adding one is a behavioral
-  change (phase 7), not config wiring.
+- `reduced_costs` was deferred to phase 7: it was the one remaining spoke
+  whose per-scenario field had no assembler, and adding one is a
+  behavioral change, not config wiring.
 
-**Phase 7: `reduced_costs` spoke (`SCENARIO_REDUCED_COST`)**
+**Phase 7: `reduced_costs` spoke flag (`reduced_costs_rank_ratio`)**
 
-`SCENARIO_REDUCED_COST` is a genuinely per-scenario field with the same
-`_local_nonant_length` layout as `NONANTS_VALS` / `DUALS` (one reduced
-cost per nonant per scenario; relaxed coherence, since it only steers
-rho). The two pieces of work:
+The reduced-costs spoke's flex-relevant fields split into two groups. Its
+Lagrangian outer bound (`DUALS`) and the nonants it receives from the hub
+(`NONANTS_VALS`) already have multi-source assemblers, and the
+reduced-cost *fixer* reads `EXPECTED_REDUCED_COST`, a global field read
+single-source. So the spoke runs correctly at unequal ranks for those
+uses, and phase 7 exposes `reduced_costs_rank_ratio` for them (one
+`add_to_config` in `reduced_costs_args`, one `build_spoke_list` line,
+mirroring the phase-6 flags).
 
-- **Assembler (trivial).** Add `SCENARIO_REDUCED_COST` to the
-  per-scenario branch of `_items_per_scen_for_field` (returns
-  `[nonant_length] * num_scenarios`) and leave it out of
-  `_STRICT_COHERENCE_FIELDS` (relaxed).
-- **Consumer rework (the real change).** `ReducedCostsRho`
-  (`extensions/reduced_costs_rho.py`) currently asserts
-  `len(fields_to_ranks[SCENARIO_REDUCED_COST]) == 1` and reads from a
-  single peer rank — the same single-source assumption that the
-  `XFEAS` → CG hub consumer had before phase 4a. Teach it to read
-  multi-source across the spoke's ranks (drop the assert; assemble via
-  the overlap map), then add a `reduced_costs` flag and an end-to-end
-  multi-rank test. Same shape and review size as the `XFEAS`/CG work.
+The exception is `SCENARIO_REDUCED_COST` — one reduced cost per nonant per
+scenario, the same `_local_nonant_length` layout as `NONANTS_VALS` /
+`DUALS`, and the one per-scenario field whose *only* consumer is an
+extension (`ReducedCostsRho`, on the PH hub) rather than a cylinder's
+class-level `receive_fields`. `ReducedCostsRho` is **itself scheduled for
+deprecation** (reduced-cost rho has not proven effective in practice;
+Pyomo/mpi-sppy#673), so building out multi-source support for its
+private field was judged not worth it. `SCENARIO_REDUCED_COST` is
+therefore left without an assembler. To stop the new flag from silently
+mis-assembling it, `Config.checker()` rejects the single unsupported
+combination — `--reduced-costs-rho` together with a non-1.0
+`reduced_costs_rank_ratio` — with an actionable message (run reduced-cost
+rho at equal ranks). The flag remains available for the spoke's
+non-deprecated uses.
 
-Only after phase 7 does the phase-6 table's last row flip to a landed
-`reduced_costs_rank_ratio`.
+Should that deprecation ever be reversed, the work is small and follows
+the `XFEAS` → CG-hub precedent: add `SCENARIO_REDUCED_COST` to the
+per-scenario branch of `_items_per_scen_for_field`
+(`[nonant_length] * num_scenarios`, relaxed coherence), route the
+extension-registered field through the overlap-map builder, drop the
+`checker()` guard, and add an end-to-end multi-rank test.
+
+Tests: `test_flexible_rank_cli.py` covers the `reduced_costs_rank_ratio`
+flag (default and `build_spoke_list` injection) and the `checker()` guard.
+
+With phase 7 every spoke now exposes a `--<spoke>-rank-ratio` flag;
+`SCENARIO_REDUCED_COST` is the only per-scenario field still without a
+multi-source assembler, by deliberate choice (deprecated consumer).
 
 
 ### Development and rollout strategy

--- a/mpisppy/generic/spokes.py
+++ b/mpisppy/generic/spokes.py
@@ -164,6 +164,7 @@ def build_spoke_list(cfg, beans, scenario_creator_kwargs,
                                               all_nodenames=all_nodenames,
                                               rho_setter=None,
                                               average_scenario_creator=average_scenario_creator)
+        reduced_costs_spoke["rank_ratio"] = cfg.reduced_costs_rank_ratio
 
     list_of_spoke_dict = list()
     if cfg.fwph:

--- a/mpisppy/tests/test_flexible_rank_cli.py
+++ b/mpisppy/tests/test_flexible_rank_cli.py
@@ -36,6 +36,7 @@ def _full_cfg():
     cfg.xhatshuffle_args()
     cfg.xhatxbar_args()
     cfg.reduced_costs_args()
+    cfg.reduced_costs_rho_args()
     cfg.sep_rho_args()
     cfg.coeff_rho_args()
     cfg.sensi_rho_args()
@@ -56,6 +57,7 @@ class TestFlexibleRankCLI(unittest.TestCase):
         self.assertEqual(cfg.ph_dual_rank_ratio, 1.0)
         self.assertEqual(cfg.relaxed_ph_rank_ratio, 1.0)
         self.assertEqual(cfg.subgradient_rank_ratio, 1.0)
+        self.assertEqual(cfg.reduced_costs_rank_ratio, 1.0)
 
     def test_build_spoke_list_injects_rank_ratio(self):
         cfg = _full_cfg()
@@ -76,6 +78,8 @@ class TestFlexibleRankCLI(unittest.TestCase):
         cfg.relaxed_ph_rank_ratio = 5.0
         cfg.subgradient = True
         cfg.subgradient_rank_ratio = 0.125
+        cfg.reduced_costs = True
+        cfg.reduced_costs_rank_ratio = 0.75
 
         scenario_creator = farmer.scenario_creator
         scenario_denouement = farmer.scenario_denouement
@@ -91,7 +95,7 @@ class TestFlexibleRankCLI(unittest.TestCase):
         # exactly the enabled spokes, each carrying its requested ratio
         ratios = sorted(d["rank_ratio"] for d in spokes)
         self.assertEqual(ratios, sorted([0.5, 0.25, 2.0, 4.0,
-                                         8.0, 3.0, 5.0, 0.125]))
+                                         8.0, 3.0, 5.0, 0.125, 0.75]))
         # and every spoke dict got an explicit rank_ratio
         self.assertTrue(all("rank_ratio" in d for d in spokes))
 
@@ -111,6 +115,26 @@ class TestFlexibleRankCLI(unittest.TestCase):
             rho_setter=None, all_nodenames=None,
         )
         self.assertEqual([d["rank_ratio"] for d in spokes], [1.0])
+
+    def test_checker_rejects_reduced_costs_rho_at_unequal_ranks(self):
+        # reduced-cost rho is the only consumer of SCENARIO_REDUCED_COST, which
+        # has no multi-source assembler, so running the reduced_costs spoke at
+        # unequal ranks with reduced-cost rho is rejected at config time rather
+        # than silently mis-assembling the per-scenario reduced costs.
+        cfg = _full_cfg()
+        cfg.reduced_costs = True
+        cfg.reduced_costs_rho = True
+        cfg.reduced_costs_rank_ratio = 0.5
+        with self.assertRaises(ValueError):
+            cfg.checker()
+
+    def test_checker_allows_reduced_costs_rho_at_equal_ranks(self):
+        # The deprecated combination is fine at equal ranks (the default).
+        cfg = _full_cfg()
+        cfg.reduced_costs = True
+        cfg.reduced_costs_rho = True
+        cfg.reduced_costs_rank_ratio = 1.0
+        cfg.checker()  # must not raise
 
 
 if __name__ == "__main__":

--- a/mpisppy/utils/config.py
+++ b/mpisppy/utils/config.py
@@ -165,6 +165,21 @@ class Config(pyofig.ConfigDict):
         if self.get("rc_fixer") and not self.get("reduced_costs"):
             _bad_options("--rc-fixer requires --reduced-costs")
 
+        if self.get("reduced_costs_rho") \
+           and self.get("reduced_costs_rank_ratio", 1.0) != 1.0:
+            # reduced-cost rho is the only consumer of the per-scenario
+            # SCENARIO_REDUCED_COST field, and that field has no multi-source
+            # assembler (it is the deprecated rho's, so it was not built out);
+            # at unequal ranks the consumer would misread it. The spoke's other
+            # uses (the reduced-cost fixer, the Lagrangian bound) are fine at
+            # unequal ranks, so only this combination is rejected.
+            _bad_options(
+                "--reduced-costs-rho does not support a reduced_costs spoke at "
+                "unequal ranks; set --reduced-costs-rank-ratio 1.0. (Reduced-cost "
+                "rho is scheduled for deprecation; see "
+                "https://github.com/Pyomo/mpi-sppy/issues/673.)"
+            )
+
         if self.get("hub_only_solver_logs") and not self.get("solver_log_dir"):
             _bad_options("--hub-only-solver-logs requires --solver-log-dir")
 
@@ -792,6 +807,13 @@ class Config(pyofig.ConfigDict):
                               description="have a reduced costs spoke",
                               domain=bool,
                               default=False)
+
+        self.add_to_config('reduced_costs_rank_ratio',
+                           description="MPI ranks for the reduced costs spoke "
+                                       "relative to the hub (flexible rank "
+                                       "assignments; default 1.0 = equal)",
+                           domain=float,
+                           default=1.0)
 
         self.add_solver_specs("reduced_costs")
 


### PR DESCRIPTION
> **Related PRs — flexible-rank reduced-costs thread.** ✅ #758 (extension-field multi-source fix) is **MERGED**. Two PRs remain off `main`; recommended merge order:
> 1. **#759** — deprecate & remove `reduced_costs_rho`
> 2. **#757** — flex phase 7: `--reduced-costs-rank-ratio` flag
>
> After #759 lands, `reduced_costs_rho` always errors, so #757's `checker()` guard for it becomes dead code — when rebasing #757 last, drop that guard (its `--reduced-costs-rank-ratio` flag stays useful). #757 and #759 both edit `Config.checker()`, so expect a conflict there.

---

Completes the per-spoke rank-ratio flag coverage for flexible (unequal) rank
assignments by exposing `--reduced-costs-rank-ratio`.

### What works at unequal ranks

The reduced-costs spoke's flex-relevant fields already have what they need:

- the Lagrangian outer bound (`DUALS`) and the nonants it receives from the hub
  (`NONANTS_VALS`) have multi-source assemblers from earlier phases;
- the reduced-cost **fixer** reads `EXPECTED_REDUCED_COST`, a global field read
  single-source.

So the spoke runs correctly at unequal ranks for those uses, and this PR exposes
the flag for them — one `add_to_config` in `reduced_costs_args` plus one
`build_spoke_list` line, mirroring the phase-6 flags. The equal-rank path is
untouched.

### The one unsupported case: reduced-cost rho

`SCENARIO_REDUCED_COST` is the only per-scenario field whose **sole** consumer is
`ReducedCostsRho` — which is itself scheduled for deprecation (reduced-cost rho
has not proven effective in practice, #673). Rather than build out a multi-source
assembler for a deprecated-only field, it is deliberately left without one.

To keep the new flag from *silently* mis-assembling that field, `Config.checker()`
rejects the single unsupported combination — `--reduced-costs-rho` together with a
non-1.0 `--reduced-costs-rank-ratio` — with an actionable message (run reduced-cost
rho at equal ranks). If the deprecation is ever reversed, the remaining work is the
small `XFEAS`→CG-hub-style addition noted in the design doc.

### Tests

`test_flexible_rank_cli.py` covers the `reduced_costs_rank_ratio` flag (default and
`build_spoke_list` injection) and the `checker()` guard (rejected at unequal ranks,
allowed at equal ranks).

`ruff` clean; serial flex tests green; the existing `np=6` flex MPI tests and the
`np=2` equal-rank regression are unaffected (no communicator-layer changes in this
PR).

The per-spoke flag coverage table in `doc/designs/flexible_rank_assignments.md` is
now complete; `SCENARIO_REDUCED_COST` is the only per-scenario field still without a
multi-source assembler, by deliberate choice (deprecated consumer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


