### PR TITLE
fix(flex-ranks): assemble extension-registered per-scenario fields multi-source (relaxed_ph_fixer / grad_rho crash at unequal ranks)

### DIFF
--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -985,6 +985,7 @@ jobs:
           mpiexec -np 6 coverage run $COV_ARGS -m mpi4py test_flexible_rank_xhat.py
           mpiexec -np 6 coverage run $COV_ARGS -m mpi4py test_flexible_rank_xfeas.py
           mpiexec -np 6 coverage run $COV_ARGS -m mpi4py test_flexible_rank_xhat_multistage.py
+          mpiexec -np 6 coverage run $COV_ARGS -m mpi4py test_flexible_rank_extension_fields.py
 
       - name: Upload coverage data
         if: always()

--- a/doc/designs/flexible_rank_assignments.md
+++ b/doc/designs/flexible_rank_assignments.md
@@ -629,8 +629,15 @@ unnecessary given the per-field analysis).
 
 #### `spcommunicator.py`
 
-- `register_receive_fields()` builds overlap maps for the unequal-rank
-  path; the equal-rank path retains the 1-to-1 rank correspondence.
+- `register_recv_field()` builds the overlap map for a per-scenario field
+  on the unequal-rank path (the equal-rank path retains the 1-to-1 rank
+  correspondence). It lives there, rather than in
+  `register_receive_fields()`, so that a field an *extension* registers
+  directly -- `relaxed_ph_fixer`'s `RELAXED_NONANTS_VALS`, `grad_rho`'s
+  `BEST_XHAT`, ... -- gets the same multi-source assembly as a cylinder's
+  own `receive_fields`. (Otherwise such a read falls to the single-source
+  path and tears, since the buffer and the peer field have different
+  lengths when the rank counts differ.)
 - `get_receive_buffer()` gains a multi-source assembly path (with the
   per-field coherence policy applied), selected when ratios differ; the
   single-source path is unchanged at equal ranks.

--- a/mpisppy/cylinders/spcommunicator.py
+++ b/mpisppy/cylinders/spcommunicator.py
@@ -471,6 +471,20 @@ class SPCommunicator:
             my_fa = RecvArray(length)
             self.receive_buffers[key] = my_fa
         ## End if
+        # On the unequal-rank path a per-scenario (local-sized) field is
+        # assembled from several of the peer cylinder's global ranks; precompute
+        # its overlap map (which also validates each remote segment -- the
+        # per-segment analogue of the equal-rank _validate_recv_field above).
+        # Global/scalar fields are read single-source and need no map. Building
+        # it here -- not only in register_receive_fields -- means a field an
+        # extension registers directly (relaxed_ph_fixer's RELAXED_NONANTS_VALS,
+        # grad_rho's BEST_XHAT, ...) gets the same multi-source assembly as the
+        # cylinder's own receive_fields. Without it those reads fall to the
+        # single-source path and tear (the buffer/field sizes differ across
+        # unequal ranks), so the run aborts.
+        if self._flex_ranks and field not in _GLOBAL_OR_SCALAR_FIELDS \
+                and (field, origin) not in self.overlap_maps:
+            self._build_overlap_map(field, origin)
         return my_fa
 
     def register_send_field(self, field: Field, length: int = -1) -> SendArray:
@@ -575,14 +589,10 @@ class SPCommunicator:
                     continue
                 cls = comm["spcomm_class"]
                 if field != Field.WHOLE and field in self.ranks_to_fields[strata_rank]:
+                    # register_recv_field also precomputes the per-scenario
+                    # overlap map on the unequal-rank path (see there).
                     buff = self.register_recv_field(field, strata_rank)
                     self.receive_field_spcomms[field].append((strata_rank, cls, buff))
-                    # On the unequal-rank path, a per-scenario (local-sized)
-                    # field is assembled from several remote buffers; precompute
-                    # its overlap map now. Global/scalar fields are read
-                    # single-source and need no map.
-                    if self._flex_ranks and field not in _GLOBAL_OR_SCALAR_FIELDS:
-                        self._build_overlap_map(field, strata_rank)
 
     def put_send_buffer(self, buf: SendArray, field: Field):
         """ Put the specified values into the specified locally-owned buffer

--- a/mpisppy/tests/test_flexible_rank_extension_fields.py
+++ b/mpisppy/tests/test_flexible_rank_extension_fields.py
@@ -1,0 +1,121 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+"""Unequal-rank regression test for per-scenario fields registered by an
+*extension* rather than a cylinder's class-level receive_fields.
+
+A spoke's own receive_fields get their multi-source overlap map built in
+register_receive_fields; an extension that registers a receive field directly
+(via register_recv_field) used to get no map, so at unequal ranks its read fell
+to the single-source path and tore -- the receive buffer and the peer's field
+have different lengths when the rank counts differ, which aborts the run at
+Iter0 (np.size(dest) == count assertion, or a NaN write_id read). Building the
+overlap map inside register_recv_field fixes every such extension uniformly.
+
+This exercises that path with the relaxed-PH fixer: a PH hub with the
+RelaxedPHFixer extension (which reads RELAXED_NONANTS_VALS from a relaxed-PH
+spoke) at unequal rank counts. Without the fix this aborts at Iter0 in both
+asymmetry directions; with it the run completes. (grad_rho reading BEST_XHAT is
+the same path and the same fix.)
+
+mpiexec -np 6 python -m mpi4py -m pytest mpisppy/tests/test_flexible_rank_extension_fields.py
+"""
+
+import math
+import unittest
+
+from mpi4py import MPI
+
+from mpisppy.utils import config
+import mpisppy.utils.cfg_vanilla as vanilla
+import mpisppy.tests.examples.farmer as farmer
+from mpisppy.spin_the_wheel import WheelSpinner
+from mpisppy.tests.utils import get_solver
+
+comm = MPI.COMM_WORLD
+
+solver_available, solver_name, persistent_available, persistent_solver_name = get_solver()
+
+
+def _build_dicts(num_scens, max_iterations, hub_ratio, spoke_ratio):
+    # Fresh cfg/dicts per run: WheelSpinner.run mutates the dicts and may only
+    # run once, so each run needs its own.
+    cfg = config.Config()
+    cfg.num_scens_required()
+    cfg.popular_args()
+    cfg.two_sided_args()
+    cfg.ph_args()
+    cfg.relaxed_ph_args()
+    cfg.relaxed_ph_fixer_args()
+    cfg.solver_name = solver_name
+    cfg.num_scens = num_scens
+    cfg.default_rho = 1.0
+    cfg.max_iterations = max_iterations
+    cfg.rel_gap = 1e-6
+    cfg.relaxed_ph = True
+    cfg.relaxed_ph_fixer = True
+
+    scenario_creator = farmer.scenario_creator
+    scenario_denouement = farmer.scenario_denouement
+    all_scenario_names = farmer.scenario_names_creator(num_scens)
+    scenario_creator_kwargs = farmer.kw_creator(cfg)
+    beans = (cfg, scenario_creator, scenario_denouement, all_scenario_names)
+
+    hub_dict = vanilla.ph_hub(*beans, scenario_creator_kwargs=scenario_creator_kwargs)
+    hub_dict["rank_ratio"] = hub_ratio
+    # RelaxedPHFixer reads RELAXED_NONANTS_VALS -- the extension-registered
+    # per-scenario field under test.
+    vanilla.add_relaxed_ph_fixer(hub_dict, cfg)
+
+    relaxed_ph_spoke = vanilla.relaxed_ph_spoke(
+        *beans, scenario_creator_kwargs=scenario_creator_kwargs
+    )
+    relaxed_ph_spoke["rank_ratio"] = spoke_ratio
+
+    return hub_dict, [relaxed_ph_spoke]
+
+
+def _run(num_scens, max_iterations, hub_ratio, spoke_ratio):
+    hub_dict, spoke_list = _build_dicts(
+        num_scens, max_iterations, hub_ratio, spoke_ratio
+    )
+    wheel = WheelSpinner(hub_dict, spoke_list)
+    # Without the fix this raises at Iter0 inside the fixer's multi-source read;
+    # reaching the return means the unequal-rank read assembled cleanly.
+    wheel.spin()
+    if wheel.global_rank == 0:
+        payload = (wheel.BestInnerBound, wheel.BestOuterBound)
+    else:
+        payload = None
+    return comm.bcast(payload, root=0)
+
+
+@unittest.skipUnless(comm.size == 6, "needs exactly 6 MPI ranks")
+@unittest.skipUnless(solver_available, "no solver is available")
+class TestFlexibleRankExtensionFields(unittest.TestCase):
+
+    NUM_SCENS = 10
+    MAX_ITERS = 10
+
+    def test_extension_field_unequal_ranks_both_directions(self):
+        # 4-rank hub, 2-rank spoke: each hub rank stitches the relaxed solution
+        # from several spoke buffers (multi-segment).
+        ib_42, ob_42 = _run(self.NUM_SCENS, self.MAX_ITERS, 1.0, 0.5)
+        # 2-rank hub, 4-rank spoke: each hub rank reads a sub-range of one spoke
+        # buffer (the other asymmetry direction).
+        ib_24, ob_24 = _run(self.NUM_SCENS, self.MAX_ITERS, 1.0, 2.0)
+
+        # The torn single-source read used to put NaN in the buffer (and abort
+        # before this point); a completed run with no NaN confirms the
+        # multi-source assembly was wired for the extension-registered field.
+        for b in (ib_42, ob_42, ib_24, ob_24):
+            self.assertFalse(math.isnan(b))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/run_coverage.bash
+++ b/run_coverage.bash
@@ -219,6 +219,9 @@ run_phase "test_flexible_rank_xfeas (mpiexec -np 6)" \
 run_phase "test_flexible_rank_xhat_multistage (mpiexec -np 6)" \
     mpiexec -np 6 $OVERSUBSCRIBE coverage run --rcfile="$PROJ_DIR/.coveragerc" -m mpi4py mpisppy/tests/test_flexible_rank_xhat_multistage.py
 
+run_phase "test_flexible_rank_extension_fields (mpiexec -np 6)" \
+    mpiexec -np 6 $OVERSUBSCRIBE coverage run --rcfile="$PROJ_DIR/.coveragerc" -m mpi4py mpisppy/tests/test_flexible_rank_extension_fields.py
+
 # ---------- Tests that spawn mpiexec internally ----------
 
 PYARGS="-m coverage run --parallel-mode --rcfile=$PROJ_DIR/.coveragerc --data-file=$PROJ_DIR/.coverage"


### PR DESCRIPTION
> **Related PRs — flexible-rank reduced-costs thread.** Three independent PRs off `main`. Recommended merge order:
> 1. **#758** — fix: extension-registered per-scenario fields assemble multi-source (relaxed_ph_fixer / grad_rho crash at unequal ranks)
> 2. **#759** — deprecate & remove `reduced_costs_rho`
> 3. **#757** — flex phase 7: `--reduced-costs-rank-ratio` flag
>
> After #759 lands, `reduced_costs_rho` always errors, so #757's `checker()` guard for it becomes dead code — when rebasing #757 last, drop that guard (its `--reduced-costs-rank-ratio` flag stays useful). #757 and #759 both edit `Config.checker()`, so expect a conflict there.

---

### The bug

A per-scenario receive field gets its multi-source overlap map (the addressing
that stitches it together across unequal rank counts) built in
`register_receive_fields()` — but only for a cylinder's **class-level**
`receive_fields`. An **extension** that registers a receive field directly via
`register_recv_field()` got no map, so at unequal ranks its read fell through to
the single-source path and **tore**: the local receive buffer and the peer's
published field have different lengths when the rank counts differ, which aborts
the run at Iter0 (`assert np.size(dest) == count` in `spwindow.py`, or
`ValueError: cannot convert float NaN to integer` from a wrong-region write_id
read).

This was reachable with two combinations of already-shipped flags:

```
--relaxed-ph --relaxed-ph-fixer --relaxed-ph-rank-ratio <non-1.0>   # RELAXED_NONANTS_VALS (relaxed_ph_fixer)
--grad-rho   --xhatshuffle      --xhatshuffle-rank-ratio <non-1.0>   # BEST_XHAT          (grad_rho)
```

Confirmed by running farmer with `--relaxed-ph --relaxed-ph-fixer
--relaxed-ph-rank-ratio 0.5` (and `2.0`): both directions abort at Iter0 before
this change.

### The fix

Build the overlap map inside `register_recv_field()` (gated on the unequal-rank
path, skipped for global/scalar fields), so **every** per-scenario field —
whether a cylinder's own or an extension's — is assembled multi-source the same
way, with no per-extension wiring. The now-redundant explicit build in
`register_receive_fields()` is removed. The equal-rank path is untouched (the new
build is gated on `_flex_ranks`).

### Test

`test_flexible_rank_extension_fields.py` (np=6) runs a PH hub with the
`RelaxedPHFixer` extension and a relaxed-PH spoke at unequal ranks in both
asymmetry directions (4+2 and 2+4). It aborts at Iter0 without the fix and
completes with it. Wired into `run_coverage.bash` and `test_pr_and_main.yml`.

The existing flex MPI tests (multisource / cylinders / duals / xhat / xfeas /
multistage) and the np=2 equal-rank regression are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

