### PR TITLE
Multi-stage xhat file: read and write (by-name CSV)

### DIFF
--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -1037,6 +1037,12 @@ jobs:
           cd mpisppy/tests
           mpiexec -np 4 coverage run $COV_ARGS -m mpi4py test_cg_multirank_hub.py
 
+      - name: run multi-stage xhat-file round-trip test
+        timeout-minutes: 10
+        run: |
+          cd mpisppy/tests
+          mpiexec -np 4 coverage run $COV_ARGS -m mpi4py test_xhat_file_multistage.py
+
       - name: run DCG serial tests
         timeout-minutes: 10
         run: |

--- a/doc/designs/multistage_xhat_write_design.md
+++ b/doc/designs/multistage_xhat_write_design.md
@@ -1,4 +1,4 @@
-# Design: Writing a multi-stage xhat (nonant tree) to a file
+# Design: Reading and writing a multi-stage xhat (nonant tree) file
 
 **Status:** Draft — up for discussion. Nothing implemented yet.
 **Author:** dlw (captured with Claude Code assistance)
@@ -17,16 +17,17 @@ consumes a full `{node_name: array}` cache across every tree node, and
 `ciutils.read_xhat`). So the missing pieces are narrower than the docs
 imply.
 
-This note covers **only the write side**, as a first, self-contained,
-green-on-its-own PR. We establish *and produce* the canonical on-disk
-format that the later reader will consume. Reading, the `ciutils`
-generalization, the multi-stage `feasible_xhat_creator` contract, and
-any new CLI surface are explicitly **out of scope here** (see below).
+This note covers **both write and read** of the canonical multi-stage
+xhat file, as one self-contained PR. (It began as write-only; the read
+side was folded in so the file format is exercised end-to-end by a real
+write→read→fix round trip, rather than shipping a producer with no
+consumer.) The `ciutils` generalization and the multi-stage
+`feasible_xhat_creator` contract remain out of scope (see below).
 
-Rationale for writing first: the reader must consume a concrete format,
-and the most useful producer of that format — a real multi-stage
-cylinders run's incumbent — does not exist today. Settling the format
-by *writing* it first lets the reader phase be pure consumption.
+The read side reuses the existing `--xhat-from-file` surface
+(`xhatbase._try_file_xhat`), which previously accepted only a two-stage
+`.npy` ROOT vector; it now also accepts the canonical `.csv` for any
+number of stages, matched to the model by variable name.
 
 ## What mpi-sppy writes today
 
@@ -179,23 +180,36 @@ rank 0 `os.makedirs` the parent dir if any and
 delegators. EF parity comes free: `ef_nonants_csv` already produces the
 same format via the shared serializer.
 
-## Explicitly out of scope (deferred to the reader phase)
+### 4. The reader (`--xhat-from-file` for any number of stages)
 
-- **The reader** (`{node: array}` from the CSV) and any change to
-  `--xhat-from-file` / `xhatbase._try_file_xhat`.
-- **`ciutils.write_xhat`/`read_xhat` generalization.** Deliberately not
-  touched here: `write_xhat` receives a bare `{node: array}` cache with
-  **no variable names**, so it cannot emit the by-name CSV without a
-  model. Whether the multi-stage `ciutils` path becomes model-aware
-  (by-name) or stays model-free (a positional `.npz`/`node,index,value`)
-  is a reader-phase decision about round-trip semantics, made where the
-  consumers (MMW, zhat4xhat) and their model access are in view. The
-  by-name CSV format chosen here is the input to that decision, not a
-  prejudgment of it.
+`sputils.read_nonant_tree_csv(file_name, node_varname_order)` is the
+inverse of the serializer: it parses the CSV to `{node: {name: value}}`
+and returns `{node: np.ndarray}` ordered to a caller-supplied per-node
+variable order. Because the file is keyed by node-local **name**, the
+consumer supplies the order it wants — typically each
+`node.nonant_vardata_list`'s node-local names — so the array lands in the
+cache's positional order without depending on file row order. Parsing
+splits each data line on the **first** comma (node) and the **last**
+comma (value) so multi-index Var names (`x[a,b]`) survive.
+
+`xhatbase._try_file_xhat` dispatches on extension: `.csv` →
+`read_nonant_tree_csv` against the spoke's own local scenarios (any
+number of stages; a file may carry more nodes than a rank needs, and the
+extras are ignored); anything else → the existing two-stage `.npy`
+`ciutils.read_xhat` path (a multi-stage `.npy` still hard-fails, now
+pointing at the `.csv` format). The assembled cache flows into the
+unchanged `self.opt.evaluate(...)` / `update_if_improving(...)` path.
+
+## Explicitly out of scope
+
+- **`ciutils.write_xhat`/`read_xhat` generalization.** Deliberately left
+  alone: `write_xhat` receives a bare `{node: array}` cache with **no
+  variable names**, and `read_xhat` is model-free (`np.load`), used by
+  MMW/zhat4xhat with no reference model. The by-name CSV needs a model to
+  resolve order, so it lives in `sputils` (writer has the model; reader
+  takes the order map) and `--xhat-from-file` dispatches to it. `ciutils`
+  stays the model-free two-stage `.npy` path, untouched.
 - The multi-stage `feasible_xhat_creator` contract and docs.
-
-This boundary keeps the writing PR small and avoids baking half of a
-reader decision into the writer.
 
 ## Backward compatibility
 
@@ -216,23 +230,35 @@ reader decision into the writer.
 5. `cfg.write_xhat_file_args()` (`--write-xhat-file`), wired into the
    generic parsing and into both `generic/decomp.py::_write_solutions`
    (cylinders) and `generic/ef.py` (EF).
-6. Tests (below), wired into `run_coverage.bash` **and**
-   `test_pr_and_main.yml` in the same commit.
-7. Doc: short note in `doc/src/` on the format + `--write-xhat-file`;
-   mention the EF `.csv` format change.
+6. **Reader:** `sputils.read_nonant_tree_csv`; `.csv` dispatch in
+   `xhatbase._try_file_xhat` (+ `_read_xhat_csv`); `xhat_from_file`
+   description updated for the multi-stage `.csv`.
+7. Tests (below); all added to existing harness-wired files
+   (`test_sputils.py`, `test_xhat_from_file.py`, `test_ef_ph.py`), so no
+   new coverage-harness wiring is needed.
+8. Doc: short note in `doc/src/` on the format + `--write-xhat-file` +
+   the multi-stage `--xhat-from-file`; mention the EF `.csv` format
+   change.
 
 ## Tests
 
-- **Serial / EF:** `ef_nonants_csv` (now node-local) writes the expected
-  rows for a small multi-stage example (e.g. `hydro`); reload the values
-  into a fresh scenario by name and assert they match. Update
-  `test_ef_nonants_csv_creates_file`.
-- **Cylinders gather (needs MPI):** a 2-rank multi-stage run; assert
-  rank 0's `write_tree_nonants` file contains every node exactly once and
-  values match the incumbent. Add to the mpiexec test list.
-- **No-MPI path:** `gather_nonant_tree` returns the single local dict
-  under the `MPI.py` mock.
-- Coverage-harness wiring as in (5) above.
+- **Serializer / EF round-trip (no solver):** `write_nonant_tree_csv`
+  format + node order; `ef_nonants_csv` (now node-local) round-trips
+  position-for-position against `nonant_cache_from_ef`. Updated
+  `test_ef_nonants_csv_creates_file` and the `test_ef_ph` hydro EF check.
+- **Reader (no solver):** `read_nonant_tree_csv` round-trips the writer,
+  follows the requested order, ignores unrequested nodes, survives
+  multi-index names, and raises on a missing node/variable.
+  `_try_file_xhat` `.csv` path via the existing `test_xhat_from_file.py`
+  stubs (happy path, model-order wins, extra nodes ignored, missing var
+  raises).
+- **Gather (no MPI):** `gather_nonant_tree_to_rank0` returns the
+  node-keyed, deduped local dict under the serial path;
+  `_assert_nonant_node_agreement` passes within tolerance and raises on
+  disagreement.
+- **End-to-end smoke (manual, this PR):** farmer (2-stage) and hydro
+  (3-stage) write→read round trips through `generic_cylinders`, EF and
+  cylinders.
 
 ## Resolved
 

--- a/doc/designs/multistage_xhat_write_design.md
+++ b/doc/designs/multistage_xhat_write_design.md
@@ -46,14 +46,21 @@ Two observations drive the design:
   canonical format ("support what we already write"). Its only defects
   for round-trip use are EF-qualified variable names and no comment
   convention.
-- **A cylinders run has no whole-tree, single-rank nonant cache.**
-  `Hub.send_nonants` packs only each rank's *local* scenarios into a
-  per-rank buffer; cross-cylinder exchange is rank-to-rank.
-  `write_tree_solution` sidesteps assembly by having every rank write
-  its own scenarios into a shared directory. A *single file* cannot be
-  sharded that way, and one representative scenario only knows the nodes
-  on its own root-to-leaf path. So a single-file multi-stage writer for
-  cylinders needs the nonant tree **assembled on one rank**.
+- **A cylinders run already gathers nonant values to rank 0 — but
+  scenario-keyed, not node-keyed.** `SPBase.gather_var_values_to_rank0`
+  walks every local scenario's node list, builds
+  `{(scenario_name, var_name): value}` (bundle prefix stripped, zero-prob
+  aware), `mpicomm.gather`s to rank 0 and merges — so the whole tree's
+  nonant values *do* land on one rank today (used by
+  `report_var_values_at_rank0`). What it does **not** do is key by
+  *node*: it carries per-scenario redundancy for shared nodes and drops
+  the node association. `WheelSpinner.local_nonant_cache` is the
+  complementary piece — node-keyed and deduped, but *local* (per-rank,
+  values only). So the writer needs **no novel gather**: it needs a
+  node-keyed rank-0 assembly reusing these two existing patterns.
+  (`write_tree_solution` itself still sidesteps assembly by having every
+  rank write its own scenarios into a directory — which is why a *single*
+  file needs the node-keyed rank-0 form.)
 
 ## Decisions taken (the two we discussed)
 
@@ -130,25 +137,36 @@ this. A single `_node_local_name(name)` helper centralizes the
 prefix-strip rule already used by `first_stage_nonant_writer`'s bundling
 branch.
 
-### 2. Whole-tree assembly for cylinders (the genuinely new code)
+### 2. Whole-tree assembly for cylinders (reuse, not new code)
+
+This is **not** a novel gather. `SPBase.gather_var_values_to_rank0`
+already does the intra-cylinder `mpicomm.gather` of nonant values to
+rank 0, and `WheelSpinner.local_nonant_cache` already builds the
+node-keyed, deduped *local* dict. The assembler is the node-keyed analog
+of the former, reusing the latter's per-node dedup:
 
 ```python
-def gather_nonant_tree(opt):
-    # On each rank: local {node -> [(local_name, value)]} from opt.local_scenarios,
-    #   one entry per node (first local scenario through the node wins; NAC
-    #   guarantees the rest agree).
-    # opt.mpicomm.gather(local, root=0); on rank 0 merge (first wins) and return;
+def gather_nonant_tree_to_rank0(opt):
+    # local: {node_name: [(local_var_name, value), ...]}, one entry per node
+    #   (first local scenario through the node wins -- mirrors
+    #   local_nonant_cache's dedup; adds the var name + bundle-prefix strip
+    #   from gather_var_values_to_rank0).
+    # opt.mpicomm.gather(local, root=0); merge on rank 0 (first wins);
     #   non-root ranks return None.
 ```
 
-~25 lines around `mpicomm.gather`. In the no-MPI mock (`mpisppy/MPI.py`)
-the gather is trivially the single local dict. The merge takes
-first-rank-wins, but guards it: if two ranks report different values for
-the same node beyond a small tolerance, **raise**. A genuine
-disagreement means the incumbent is not nonanticipative, so the file
-would be ill-defined (which rank's value would we write?) — failing
-loudly beats silently writing a wrong xhat. Integer/binary nonants must
-match exactly; the tolerance only absorbs floating-point residue.
+Whether this lands as a new sibling or as a `by_node=True` option on
+`gather_var_values_to_rank0` is an implementation call; either way it
+reuses the tested gather/strip logic rather than re-deriving it. In the
+no-MPI mock (`mpisppy/MPI.py`) the gather is trivially the single local
+dict. The merge takes first-rank-wins but guards it: if two ranks report
+different values for the same node beyond a small tolerance, **raise** —
+a genuine disagreement means the incumbent is not nonanticipative, so the
+file would be ill-defined (which rank's value would we write?) and
+failing loudly beats silently writing a wrong xhat. Integer/binary
+nonants must match exactly; the tolerance only absorbs floating-point
+residue. Zero-prob nonants follow `gather_var_values_to_rank0`'s handling
+(request their values explicitly when writing an xhat).
 
 ### 3. The new method
 
@@ -191,7 +209,9 @@ reader decision into the writer.
 
 1. `write_nonant_tree_csv` serializer + `_node_local_name` helper.
 2. `ef_nonants_csv` refactored onto the serializer (node-local names).
-3. `gather_nonant_tree(opt)` assembler.
+3. `gather_nonant_tree_to_rank0(opt)` — node-keyed analog of the existing
+   `gather_var_values_to_rank0`, reusing `local_nonant_cache`'s per-node
+   dedup (not a new gather mechanism).
 4. `SPBase.write_tree_nonants` + `WheelSpinner.write_tree_nonants`.
 5. `cfg.write_xhat_file_args()` (`--write-xhat-file`), wired into the
    generic parsing and into both `generic/decomp.py::_write_solutions`

--- a/doc/designs/multistage_xhat_write_design.md
+++ b/doc/designs/multistage_xhat_write_design.md
@@ -115,7 +115,13 @@ ROOT_1, ProductionAdjust[CORN], 48.0
   distinguishes nodes. Answers the "file vs directory" question for the
   multi-stage case.
 - **Node-local names** so the same file reads back into any single
-  scenario model regardless of EF-vs-cylinders origin.
+  scenario model regardless of EF-vs-cylinders origin. Localizing is
+  prefix-aware (`sputils._node_local_nonant_name`): a leading bundle
+  segment, or a `<scenario_name>.` prefix that some spokes introduce
+  (the multistage xhatshuffle stage-2 EF rebinds nonants into a
+  scenario-named sub-block), is stripped on both write and read so the
+  names stay scenario-independent and round-trip. (aircond surfaced
+  this; without it the file carried per-node scenario prefixes.)
 - **Nodes written are the non-leaf nodes** in each scenario's
   `_mpisppy_node_list` — exactly the set `_fix_nonants` requires. Leaf
   recourse is scenario-specific and not part of an xhat.
@@ -256,6 +262,12 @@ unchanged `self.opt.evaluate(...)` / `update_if_improving(...)` path.
   node-keyed, deduped local dict under the serial path;
   `_assert_nonant_node_agreement` passes within tolerance and raises on
   disagreement.
+- **End-to-end MPI round trip (automated):**
+  `test_xhat_file_multistage.py` (mpiexec -np 4) runs a multistage
+  aircond cylinder system, writes the incumbent tree, and reads it back
+  by name. At np 4 the writing cylinder spans two ranks, so it exercises
+  the cross-rank gather/merge (a single rank holds only some subtrees).
+  Wired into `run_coverage.bash` and `test_pr_and_main.yml`.
 - **End-to-end smoke (manual, this PR):** farmer (2-stage) and hydro
   (3-stage) write→read round trips through `generic_cylinders`, EF and
   cylinders.

--- a/doc/designs/multistage_xhat_write_design.md
+++ b/doc/designs/multistage_xhat_write_design.md
@@ -1,0 +1,249 @@
+# Design: Writing a multi-stage xhat (nonant tree) to a file
+
+**Status:** Draft — up for discussion. Nothing implemented yet.
+**Author:** dlw (captured with Claude Code assistance)
+**Last updated:** 2026-06-14
+**Branch:** `feasible-xhat-multistage-file`
+
+## Where this fits
+
+The larger goal is two-fold: (1) a **multi-stage** `feasible_xhat_creator`
+contract, and (2) the ability to **read an xhat from a file** for any
+number of stages. The runtime fixing path
+(`SPOpt._fix_nonants` / `Xhat_Eval.fix_nonants_upto_stage`) already
+consumes a full `{node_name: array}` cache across every tree node, and
+`--xhat-from-file` already exists for the two-stage case
+(`cylinders/xhatbase.py::_try_file_xhat`, reading via
+`ciutils.read_xhat`). So the missing pieces are narrower than the docs
+imply.
+
+This note covers **only the write side**, as a first, self-contained,
+green-on-its-own PR. We establish *and produce* the canonical on-disk
+format that the later reader will consume. Reading, the `ciutils`
+generalization, the multi-stage `feasible_xhat_creator` contract, and
+any new CLI surface are explicitly **out of scope here** (see below).
+
+Rationale for writing first: the reader must consume a concrete format,
+and the most useful producer of that format — a real multi-stage
+cylinders run's incumbent — does not exist today. Settling the format
+by *writing* it first lets the reader phase be pure consumption.
+
+## What mpi-sppy writes today
+
+| Writer | Format | Names | Scope |
+|---|---|---|---|
+| `ciutils.write_xhat` / `writetxt_xhat` | `.npy` / `.txt`, bare ROOT vector | positional | 2-stage only; MMW round-trips it |
+| `sputils.first_stage_nonant_writer` | CSV `var,value` | by name | ROOT only; cylinders `--solution-base-name.csv` |
+| `sputils.first_stage_nonant_npy_serializer` | `.npy`, ROOT vector | positional | ROOT only; `--solution-base-name.npy` |
+| `sputils.ef_nonants_csv` | CSV `Node, EF_VarName, Value` | by name (**EF-qualified**) | **whole tree**; EF `--solution-base-name.csv` (`generic/ef.py`) |
+| `sputils.scenario_tree_solution_writer` | directory of per-scenario CSVs `var,value` | by name | whole tree, but **all** Vars+Expressions; `--solution-base-name_soldir` |
+
+Two observations drive the design:
+
+- **`ef_nonants_csv` is already a single-file, by-name, multi-stage
+  nonant dump** — the only one in the tree. Its rows are deduped to one
+  per `(node, var)` (it walks `ef.ref_vars`). It is the natural
+  canonical format ("support what we already write"). Its only defects
+  for round-trip use are EF-qualified variable names and no comment
+  convention.
+- **A cylinders run has no whole-tree, single-rank nonant cache.**
+  `Hub.send_nonants` packs only each rank's *local* scenarios into a
+  per-rank buffer; cross-cylinder exchange is rank-to-rank.
+  `write_tree_solution` sidesteps assembly by having every rank write
+  its own scenarios into a shared directory. A *single file* cannot be
+  sharded that way, and one representative scenario only knows the nodes
+  on its own root-to-leaf path. So a single-file multi-stage writer for
+  cylinders needs the nonant tree **assembled on one rank**.
+
+## Decisions taken (the two we discussed)
+
+**(a) Reuse, via a shared serializer core.** Factor one serializer that
+turns `{node -> [(local_name, value)]}` into the canonical CSV, and make
+`ef_nonants_csv` a thin adapter onto it (rather than grow a second,
+drifting CSV writer). This unifies a latent inconsistency: today EF
+`--solution-base-name.csv` emits a whole-tree file while *cylinders*
+`--solution-base-name.csv` emits ROOT-only.
+
+  *Accepted cost:* `ef_nonants_csv`'s on-disk bytes change — EF-qualified
+  names (`Scenario1.DevotedAcres[CORN]`) become **node-local**
+  (`DevotedAcres[CORN]`), plus a `#`-comment header. One format-pinning
+  test (`test_sputils.py::test_ef_nonants_csv_creates_file`) is updated;
+  `generic/ef.py`'s EF `.csv` output changes shape. For nonants
+  node-local names are strictly better (the scenario prefix is noise on
+  shared vars and blocks reading the file back into a single scenario).
+
+**(b) A new method, not a mode on `write_tree_solution`.** A single-file
+nonant writer differs on three axes at once — parallelism
+(rank-0-after-gather vs every-rank-writes), content (nonants vs all
+Vars+Expressions), and shape (one file vs a directory). It gets its own
+method, `write_tree_nonants`, sitting between `write_first_stage_solution`
+(ROOT, one file, rank 0) and `write_tree_solution` (all vars, directory,
+sharded). `write_tree_solution` is untouched, so the heavily-used
+`_soldir` path carries no regression risk.
+
+## Canonical format
+
+A single CSV. Comment lines start with `#`; data lines are
+`node_name, variable_name, value` with **node-local** variable names.
+Readers strip surrounding whitespace from each field and skip blank /
+`#` lines.
+
+```
+# mpi-sppy xhat: nonant tree, node-local variable names
+# node_name, variable_name, value
+ROOT, DevotedAcres[CORN], 80.0
+ROOT, DevotedAcres[SUGAR_BEETS], 250.0
+ROOT, DevotedAcres[WHEAT], 170.0
+ROOT_0, ProductionAdjust[CORN], 0.0
+ROOT_1, ProductionAdjust[CORN], 48.0
+```
+
+- **By name, not positional.** Robust to variable-ordering changes
+  between the writing run and any future reading run, human-readable,
+  hand-editable. Matches `first_stage_nonant_writer` and the wxbar CSV
+  reader. (The positional `.npy` ROOT vector stays for the existing
+  2-stage MMW path; it is not touched here.)
+- **Single file** for the whole tree; the `node_name` column
+  distinguishes nodes. Answers the "file vs directory" question for the
+  multi-stage case.
+- **Node-local names** so the same file reads back into any single
+  scenario model regardless of EF-vs-cylinders origin.
+- **Nodes written are the non-leaf nodes** in each scenario's
+  `_mpisppy_node_list` — exactly the set `_fix_nonants` requires. Leaf
+  recourse is scenario-specific and not part of an xhat.
+
+## Architecture
+
+Three small pieces in `mpisppy/utils/sputils.py`, plus method hooks.
+
+### 1. Shared serializer (format, no extraction)
+
+```python
+def write_nonant_tree_csv(file_name, node_to_rows):
+    # node_to_rows: {node_name: [(local_var_name, value), ...]}
+    # writes the canonical CSV (header + node-local rows), deterministic order
+```
+
+`ef_nonants_csv` is reimplemented to build `node_to_rows` from
+`ef.ref_vars` (stripping the EF block prefix to node-local) and call
+this. A single `_node_local_name(name)` helper centralizes the
+prefix-strip rule already used by `first_stage_nonant_writer`'s bundling
+branch.
+
+### 2. Whole-tree assembly for cylinders (the genuinely new code)
+
+```python
+def gather_nonant_tree(opt):
+    # On each rank: local {node -> [(local_name, value)]} from opt.local_scenarios,
+    #   one entry per node (first local scenario through the node wins; NAC
+    #   guarantees the rest agree).
+    # opt.mpicomm.gather(local, root=0); on rank 0 merge (first wins) and return;
+    #   non-root ranks return None.
+```
+
+~25 lines around `mpicomm.gather`. In the no-MPI mock (`mpisppy/MPI.py`)
+the gather is trivially the single local dict. The merge takes
+first-rank-wins, but guards it: if two ranks report different values for
+the same node beyond a small tolerance, **raise**. A genuine
+disagreement means the incumbent is not nonanticipative, so the file
+would be ill-defined (which rank's value would we write?) — failing
+loudly beats silently writing a wrong xhat. Integer/binary nonants must
+match exactly; the tolerance only absorbs floating-point residue.
+
+### 3. The new method
+
+`SPBase.write_tree_nonants(file_name)` (mirrors
+`write_first_stage_solution`): ensure `tree_solution_available`
+(`load_best_solution()` if needed), `gather_nonant_tree(self)`, and on
+rank 0 `os.makedirs` the parent dir if any and
+`write_nonant_tree_csv`. `WheelSpinner.write_tree_nonants` delegates to
+`self.spcomm.opt.write_tree_nonants`, mirroring the existing two
+delegators. EF parity comes free: `ef_nonants_csv` already produces the
+same format via the shared serializer.
+
+## Explicitly out of scope (deferred to the reader phase)
+
+- **The reader** (`{node: array}` from the CSV) and any change to
+  `--xhat-from-file` / `xhatbase._try_file_xhat`.
+- **`ciutils.write_xhat`/`read_xhat` generalization.** Deliberately not
+  touched here: `write_xhat` receives a bare `{node: array}` cache with
+  **no variable names**, so it cannot emit the by-name CSV without a
+  model. Whether the multi-stage `ciutils` path becomes model-aware
+  (by-name) or stays model-free (a positional `.npz`/`node,index,value`)
+  is a reader-phase decision about round-trip semantics, made where the
+  consumers (MMW, zhat4xhat) and their model access are in view. The
+  by-name CSV format chosen here is the input to that decision, not a
+  prejudgment of it.
+- The multi-stage `feasible_xhat_creator` contract and docs.
+
+This boundary keeps the writing PR small and avoids baking half of a
+reader decision into the writer.
+
+## Backward compatibility
+
+- `ef_nonants_csv` output changes (names node-local; `#` header). Update
+  its one format test; note the EF `--solution-base-name.csv` change in
+  the PR description and user docs.
+- `write_tree_solution`, `first_stage_nonant_writer`, the `.npy` ROOT
+  serializers, and the `ciutils` 2-stage path are **unchanged**.
+
+## PR scope checklist
+
+1. `write_nonant_tree_csv` serializer + `_node_local_name` helper.
+2. `ef_nonants_csv` refactored onto the serializer (node-local names).
+3. `gather_nonant_tree(opt)` assembler.
+4. `SPBase.write_tree_nonants` + `WheelSpinner.write_tree_nonants`.
+5. `cfg.write_xhat_file_args()` (`--write-xhat-file`), wired into the
+   generic parsing and into both `generic/decomp.py::_write_solutions`
+   (cylinders) and `generic/ef.py` (EF).
+6. Tests (below), wired into `run_coverage.bash` **and**
+   `test_pr_and_main.yml` in the same commit.
+7. Doc: short note in `doc/src/` on the format + `--write-xhat-file`;
+   mention the EF `.csv` format change.
+
+## Tests
+
+- **Serial / EF:** `ef_nonants_csv` (now node-local) writes the expected
+  rows for a small multi-stage example (e.g. `hydro`); reload the values
+  into a fresh scenario by name and assert they match. Update
+  `test_ef_nonants_csv_creates_file`.
+- **Cylinders gather (needs MPI):** a 2-rank multi-stage run; assert
+  rank 0's `write_tree_nonants` file contains every node exactly once and
+  values match the incumbent. Add to the mpiexec test list.
+- **No-MPI path:** `gather_nonant_tree` returns the single local dict
+  under the `MPI.py` mock.
+- Coverage-harness wiring as in (5) above.
+
+## Resolved
+
+- **Node ordering.** Sort by the node-name *path tuple*: split the name
+  on `_` and read trailing segments as ints (`ROOT`, `ROOT_0`,
+  `ROOT_0_1`, ...). Stage is implied by the name (depth = segment count),
+  so no `node.stage` lookup is needed; integer-izing the segments makes
+  `ROOT_10` sort after `ROOT_2`.
+- **Shared-node disagreement is an error, not a warning** (see the
+  assembler section). The tolerance only forgives floating-point residue;
+  integer/binary nonants must match exactly.
+
+## How the file gets produced: a dedicated `--write-xhat-file` flag
+
+**Decided:** a dedicated `--write-xhat-file <path>` flag, *not* a
+piggyback on `--solution-base-name` and not method-only. Rationale: it is
+turnkey, behaves identically for EF and cylinders (both route through the
+shared serializer, so the file is byte-identical regardless of how the
+xhat was produced), and it stays clear of the EF-vs-cylinders
+`--solution-base-name.csv` asymmetry. `write_tree_nonants` remains a
+public method too, for driver scripts and `custom_writer` hooks.
+
+Wiring:
+
+- A new `cfg.write_xhat_file_args()` registering `--write-xhat-file`
+  (`domain=str`, default `None` = off), added to the generic parsing
+  alongside the other solution-output options.
+- Cylinders: when set, `generic/decomp.py::_write_solutions` calls
+  `wheel.write_tree_nonants(cfg.write_xhat_file)`.
+- EF: when set, `generic/ef.py` writes the same format to the same path
+  via the shared serializer (the node-local `ef_nonants_csv` adapter).
+
+This is write-only: the flag produces a file. The matching
+`--xhat-from-file` *read* of a multi-stage file is the next phase.

--- a/doc/src/xhat_from_file.rst
+++ b/doc/src/xhat_from_file.rst
@@ -4,10 +4,15 @@ Supplying an Initial Xhat from a File
 =====================================
 
 Every xhat spoke (``xhatlooper``, ``xhatshufflelooper``,
-``xhatspecific``, ``xhatxbar``) will optionally read a first-stage
-solution ``xhat`` from a ``.npy`` file, evaluate it across all
-scenarios once, and report the resulting inner bound — **before** its
-normal exploration loop starts.
+``xhatspecific``, ``xhatxbar``) will optionally read an ``xhat`` from a
+file, evaluate it across all scenarios once, and report the resulting
+inner bound — **before** its normal exploration loop starts. Two file
+formats are accepted:
+
+- a ``.csv`` nonant tree (``node_name, variable_name, value``), matched
+  to the model **by variable name**, for **any number of stages**; and
+- a ``.npy`` holding a bare root-node vector, matched **by position**,
+  for **two-stage** problems only.
 
 When This is Useful
 -------------------
@@ -38,33 +43,53 @@ Enabling the Feature
 
    --xhat-from-file <path>
 
-where ``<path>`` points at a ``.npy`` file whose contents is a
-one-dimensional numpy array holding the first-stage values **in the
-same order as the problem's root-node nonant list**. Order-sensitive
-— the ordinary pyomo iteration order over
-``scenario._mpisppy_node_list[0].nonant_vardata_list`` for any local
-scenario. (If you generated the file from a previous mpi-sppy run,
-the order matches automatically.)
+The format is chosen by the file extension: ``.csv`` for the by-name
+nonant tree, anything else (``.npy``) for the positional root vector.
+The flag is off by default; the feature is only active when supplied.
 
-The flag is off by default; the feature is only active when the flag
-is supplied.
+File Formats
+------------
 
-File Format
------------
+**CSV nonant tree (any number of stages).** Lines are
+``node_name, variable_name, value`` with **node-local** variable names;
+lines beginning with ``#`` are comments. This is matched to the model
+by name, so it is **not** order-sensitive, and a file may carry more
+nodes than a given run needs (extras are ignored). Produce one directly
+from a run with ``--write-xhat-file`` (below), or by hand:
 
-``.npy`` only, via the existing ``mpisppy.confidence_intervals.ciutils.read_xhat``
-helper. That is the canonical mpi-sppy xhat on-disk format: the
-MMW confidence-interval code already uses it
-(``--mmw-xhat-input-file-name``), and several examples write xhats
-this way (``ciutils.write_xhat``).
+.. code-block:: text
 
-To produce a compatible file from a script:
+   # node_name, variable_name, value
+   ROOT, DevotedAcreage[CORN0], 80.0
+   ROOT, DevotedAcreage[SUGAR_BEETS0], 250.0
+   ROOT, DevotedAcreage[WHEAT0], 170.0
+
+**Positional ``.npy`` (two-stage only).** A one-dimensional numpy array
+of the root-node values **in nonant order** — the pyomo iteration order
+over ``scenario._mpisppy_node_list[0].nonant_vardata_list`` for any
+local scenario. This is the format the MMW confidence-interval code uses
+(``--mmw-xhat-input-file-name``, via ``ciutils.read_xhat``):
 
 .. code-block:: python
 
    import numpy as np
    xhat_values = [1.0, 0.0, 1.0]   # in nonant order
    np.save("my_xhat.npy", np.array(xhat_values, dtype=float))
+
+Producing a file with ``--write-xhat-file``
+-------------------------------------------
+
+A run writes its incumbent xhat as the canonical CSV nonant tree with:
+
+.. code-block:: bash
+
+   --write-xhat-file <path>
+
+It works for any number of stages and identically for EF and cylinders
+runs (both route through ``sputils.write_nonant_tree_csv``), so the file
+from one run is directly readable by ``--xhat-from-file`` in another.
+Programmatically, ``WheelSpinner.write_tree_nonants(path)`` and
+``sputils.ef_nonants_csv(ef, path)`` write the same format.
 
 Example
 -------
@@ -87,18 +112,15 @@ spoke starts its normal shuffle loop.
 Scope and Limitations
 ---------------------
 
-**Two-stage only.** V1 supports two-stage problems only, matching
-``ciutils.read_xhat``. Multi-stage is planned as a follow-up; for
-now, enabling the flag on a multi-stage run raises
+**Multi-stage needs the CSV.** The ``.csv`` nonant tree supports any
+number of stages. The positional ``.npy`` is two-stage only; pointing
+``--xhat-from-file`` at a ``.npy`` on a multi-stage run raises, naming
+the ``.csv`` format as the multi-stage path.
 
-.. code-block:: text
-
-   RuntimeError: --xhat-from-file is two-stage only; multi-stage
-   support is planned as a follow-up.
-
-**Length must match.** The file's vector length must equal the
-problem's root-node nonant count. A mismatch raises at spoke startup
-with an error naming both counts — no silent truncation or padding.
+**Names / lengths must match.** For a ``.csv``, every node and variable
+the run needs must be present, by node-local name, or startup raises
+naming the missing item. For a ``.npy``, the vector length must equal
+the root-node nonant count — no silent truncation or padding.
 
 **Missing file is a hard error.** The path must exist when the spoke
 starts; a missing file is not silently treated as "feature off".
@@ -126,16 +148,13 @@ recommended way to exercise feasibility cuts in an end-to-end test:
 hand in a known-infeasible binary vector via ``--xhat-from-file``
 with ``--xhat-feasibility-cuts-count=1`` and watch the cut land.
 
-Follow-up Milestones
---------------------
-
-- Multi-stage support (per-node xhat file or a multi-node format).
-- Additional file formats (CSV, JSON) if a concrete use case appears.
-
 See Also
 --------
 
 - :ref:`Spokes` — overview of the xhat spokes.
 - the xhat feasibility-cuts feature (PR #671) — the companion feature for
   non-complete-recourse problems.
-- ``doc/designs/xhat_from_file_design.md`` — the design document.
+- ``doc/designs/multistage_xhat_write_design.md`` — the design document
+  for the multi-stage CSV nonant tree (read and write).
+- ``doc/designs/xhat_from_file_design.md`` — the original two-stage
+  design document.

--- a/mpisppy/cylinders/xhatbase.py
+++ b/mpisppy/cylinders/xhatbase.py
@@ -131,17 +131,12 @@ class XhatInnerBoundBase(spoke.InnerBoundNonantSpoke):
         from mpisppy.utils import sputils
         bundling = getattr(self.opt, "bundling", False)
         node_varname_order = dict()
-        for s in self.opt.local_scenarios.values():
+        for sname, s in self.opt.local_scenarios.items():
             for node in s._mpisppy_node_list:
                 if node.name in node_varname_order:
                     continue
-                names = []
-                for var in node.nonant_vardata_list:
-                    var_name = var.name
-                    if bundling:
-                        dot_index = var_name.find('.')
-                        assert dot_index >= 0
-                        var_name = var_name[(dot_index + 1):]
-                    names.append(var_name)
-                node_varname_order[node.name] = names
+                node_varname_order[node.name] = [
+                    sputils._node_local_nonant_name(var.name, sname, bundling)
+                    for var in node.nonant_vardata_list
+                ]
         return sputils.read_nonant_tree_csv(path, node_varname_order)

--- a/mpisppy/cylinders/xhatbase.py
+++ b/mpisppy/cylinders/xhatbase.py
@@ -59,45 +59,55 @@ class XhatInnerBoundBase(spoke.InnerBoundNonantSpoke):
     def _try_file_xhat(self):
         """Evaluate a file-supplied xhat once, before the main loop.
 
-        Gated on ``options['xhat_from_file']`` being a path. Two-stage
-        only for V1 (matches ``ciutils.read_xhat``). Hard-fails on
-        missing file, length mismatch, or multi-stage. Restores
-        nonants afterwards so the spoke's main loop sees clean state.
+        Gated on ``options['xhat_from_file']`` being a path. The file may be
+
+        * a ``.csv`` written by ``sputils.write_nonant_tree_csv``
+          (``node_name, variable_name, value``; node-local names) -- any
+          number of stages, matched to the model by variable name, or
+        * a ``.npy`` holding a bare ROOT vector (``ciutils.read_xhat``) --
+          two-stage only, matched by position.
+
+        Hard-fails on a missing file, a length/coverage mismatch, or a
+        multi-stage ``.npy``. Restores nonants afterwards so the spoke's
+        main loop sees clean state.
         """
         path = self.opt.options.get("xhat_from_file", None)
         if not path:
             return
-        # Lazy import to avoid any startup-time coupling and to keep
-        # numpy out of the non-feature path.
-        from mpisppy.confidence_intervals import ciutils
-
-        if self.opt.multistage:
-            raise RuntimeError(
-                "--xhat-from-file is two-stage only; multi-stage support "
-                "is planned as a follow-up. See "
-                "doc/designs/xhat_from_file_design.md."
-            )
         if not os.path.exists(path):
             raise RuntimeError(
                 f"--xhat-from-file={path!r} does not exist."
             )
 
-        nonant_cache = ciutils.read_xhat(path, num_stages=2)
-        # Length check against the root-node nonant count of an
-        # arbitrary local scenario (all local scenarios share the
-        # same nonant count by PH invariant).
-        any_s = next(iter(self.opt.local_scenarios.values()))
-        expected = len(any_s._mpisppy_data.nonant_indices)
-        got = len(nonant_cache["ROOT"])
-        if got != expected:
-            raise RuntimeError(
-                f"--xhat-from-file vector length {got} does not match the "
-                f"problem's root-node nonant count {expected} (file={path!r})."
-            )
+        if path.endswith(".csv"):
+            nonant_cache = self._read_xhat_csv(path)
+        else:
+            # Lazy import to keep numpy out of the non-feature path.
+            from mpisppy.confidence_intervals import ciutils
+            if self.opt.multistage:
+                raise RuntimeError(
+                    "--xhat-from-file with a .npy file is two-stage only; "
+                    "use the .csv format (node_name, variable_name, value) "
+                    "for multi-stage. See "
+                    "doc/designs/multistage_xhat_write_design.md."
+                )
+            nonant_cache = ciutils.read_xhat(path, num_stages=2)
+            # Length check against the root-node nonant count of an
+            # arbitrary local scenario (all local scenarios share the
+            # same nonant count by PH invariant).
+            any_s = next(iter(self.opt.local_scenarios.values()))
+            expected = len(any_s._mpisppy_data.nonant_indices)
+            got = len(nonant_cache["ROOT"])
+            if got != expected:
+                raise RuntimeError(
+                    f"--xhat-from-file vector length {got} does not match the "
+                    f"problem's root-node nonant count {expected} (file={path!r})."
+                )
 
+        n_nonants = sum(len(v) for v in nonant_cache.values())
         if self.cylinder_rank == 0:
             print(f"[xhat-from-file] evaluating {path!r} "
-                  f"({expected} nonants)")
+                  f"({n_nonants} nonants)")
         Eobj = self.opt.evaluate(nonant_cache)
         # Restore nonants so the main loop starts from clean state.
         self.opt._restore_nonants()
@@ -106,3 +116,32 @@ class XhatInnerBoundBase(spoke.InnerBoundNonantSpoke):
         elif self.cylinder_rank == 0:
             print(f"[xhat-from-file] candidate gave Eobj={Eobj!r}; not "
                   f"updating inner bound")
+
+    def _read_xhat_csv(self, path):
+        """Read a canonical by-name xhat CSV into a ``{node: ndarray}``
+        cache for this spoke's local scenarios (any number of stages).
+
+        The CSV is keyed by node-local variable name, so the per-node
+        order is resolved from the local scenarios' ``nonant_vardata_list``
+        (matching the writer's name-localization), then
+        ``sputils.read_nonant_tree_csv`` orders the values. The file may
+        carry more nodes than this rank needs; only the local nodes are
+        read.
+        """
+        from mpisppy.utils import sputils
+        bundling = getattr(self.opt, "bundling", False)
+        node_varname_order = dict()
+        for s in self.opt.local_scenarios.values():
+            for node in s._mpisppy_node_list:
+                if node.name in node_varname_order:
+                    continue
+                names = []
+                for var in node.nonant_vardata_list:
+                    var_name = var.name
+                    if bundling:
+                        dot_index = var_name.find('.')
+                        assert dot_index >= 0
+                        var_name = var_name[(dot_index + 1):]
+                    names.append(var_name)
+                node_varname_order[node.name] = names
+        return sputils.read_nonant_tree_csv(path, node_varname_order)

--- a/mpisppy/generic/decomp.py
+++ b/mpisppy/generic/decomp.py
@@ -137,5 +137,9 @@ def _write_solutions(wheel, module, cfg):
             wheel.write_tree_solution(f'{cfg.solution_base_name}_soldir')
         global_toc("Wrote solution data.")
 
+    if cfg.get("write_xhat_file", None) is not None:
+        wheel.write_tree_nonants(cfg.write_xhat_file)
+        global_toc("Wrote xhat tree file.")
+
     if hasattr(module, "custom_writer"):
         module.custom_writer(wheel, cfg)

--- a/mpisppy/generic/ef.py
+++ b/mpisppy/generic/ef.py
@@ -88,6 +88,10 @@ def do_EF(module, cfg, scenario_creator, scenario_creator_kwargs,
             ef.write_tree_solution(f'{cfg.solution_base_name}_soldir')
         global_toc("Wrote EF solution data.")
 
+    if cfg.get("write_xhat_file", None) is not None:
+        sputils.ef_nonants_csv(ef.ef, cfg.write_xhat_file)
+        global_toc("Wrote xhat tree file.")
+
     if hasattr(module, "custom_writer"):
         module.custom_writer(ef, cfg)
 

--- a/mpisppy/generic/parsing.py
+++ b/mpisppy/generic/parsing.py
@@ -145,6 +145,7 @@ def parse_args(m):
     cfg.xhatshuffle_args()
     cfg.xhatxbar_args()
     cfg.xhat_from_file_args()
+    cfg.write_xhat_file_args()
     cfg.norm_rho_args()
     cfg.primal_dual_rho_args()
     cfg.converger_args()

--- a/mpisppy/spbase.py
+++ b/mpisppy/spbase.py
@@ -690,6 +690,77 @@ class SPBase:
             return result
 
 
+    def gather_nonant_tree_to_rank0(self, get_zero_prob_values=True):
+        """ Gather the whole nonant tree to the root of the cylinder's
+        ``mpicomm``, keyed by node name.
+
+        Node-keyed analog of ``gather_var_values_to_rank0``: builds, per
+        node, the list of ``(node-local variable name, value)`` pairs --
+        one entry per node, deduped across local scenarios that share it
+        -- gathers to rank 0 and merges.
+
+        Returns:
+            dict or None:
+                On rank 0, ``{node_name: [(local_var_name, value), ...]}``.
+                On other ranks, ``None``.
+
+        Raises:
+            RuntimeError: if two ranks report different values for a
+                shared node beyond tolerance (the incumbent is then not
+                nonanticipative and the tree would be ill-defined).
+        """
+        local = dict()
+        for (sname, model) in self.local_scenarios.items():
+            for node in model._mpisppy_node_list:
+                ndn = node.name
+                if ndn in local:
+                    continue
+                rows = []
+                for var in node.nonant_vardata_list:
+                    var_name = var.name
+                    if self.bundling:
+                        dot_index = var_name.find('.')
+                        assert dot_index >= 0
+                        var_name = var_name[(dot_index + 1):]
+                    if self.is_zero_prob(model, var) and not get_zero_prob_values:
+                        rows.append((var_name, None))
+                    else:
+                        rows.append((var_name, pyo.value(var)))
+                local[ndn] = rows
+
+        if self.n_proc == 1:
+            return local
+
+        gathered = self.mpicomm.gather(local, root=0)
+        if self.cylinder_rank != 0:
+            return None
+        merged = dict()
+        for d in gathered:
+            for ndn, rows in d.items():
+                if ndn in merged:
+                    self._assert_nonant_node_agreement(ndn, merged[ndn], rows)
+                else:
+                    merged[ndn] = rows
+        return merged
+
+    @staticmethod
+    def _assert_nonant_node_agreement(ndn, rows_a, rows_b, tol=1e-6):
+        """ Raise if two ranks disagree on a shared node's nonant values.
+
+        Integer/binary nonants must match exactly; the tolerance only
+        absorbs floating-point residue. ``None`` (a masked zero-prob
+        value) is skipped.
+        """
+        for (name_a, val_a), (name_b, val_b) in zip(rows_a, rows_b):
+            if val_a is None or val_b is None:
+                continue
+            if abs(val_a - val_b) > tol:
+                raise RuntimeError(
+                    f"Inconsistent nonant value for node {ndn}, variable "
+                    f"{name_a}: {val_a} vs {val_b}. The incumbent is not "
+                    "nonanticipative; cannot write a well-defined xhat tree."
+                )
+
     def report_var_values_at_rank0(self, header="", print_zero_prob_values=False, fixed_vars=True):
         """ Pretty-print the values and associated statistics for
         non-anticipative variables across all scenarios. """
@@ -767,6 +838,27 @@ class SPBase:
         self.mpicomm.Barrier()
         for scenario_name, scenario in self.local_scenarios.items():
             scenario_tree_solution_writer(directory_name, scenario_name, scenario, self.bundling)
+
+    def write_tree_nonants(self, file_name):
+        """ Write the whole nonant tree (the xhat) to one by-name CSV.
+
+        Single-file, node-local-name companion to ``write_tree_solution``
+        (which writes a directory of per-scenario, all-variable files).
+        Only rank 0 of the cylinder writes; the tree is assembled there by
+        ``gather_nonant_tree_to_rank0``.
+
+            Args:
+                file_name: path of the CSV file to write the xhat tree to
+        """
+        if not self.tree_solution_available:
+            if not self.load_best_solution():
+                raise RuntimeError("No tree solution available")
+        node_to_rows = self.gather_nonant_tree_to_rank0(get_zero_prob_values=True)
+        if self.cylinder_rank == 0:
+            dirname = os.path.dirname(file_name)
+            if dirname != '':
+                os.makedirs(dirname, exist_ok=True)
+            sputils.write_nonant_tree_csv(file_name, node_to_rows)
 
 
 def _put_var_vals_in_component_map_dict(sn_cache_dict, var_iter):

--- a/mpisppy/spbase.py
+++ b/mpisppy/spbase.py
@@ -717,11 +717,8 @@ class SPBase:
                     continue
                 rows = []
                 for var in node.nonant_vardata_list:
-                    var_name = var.name
-                    if self.bundling:
-                        dot_index = var_name.find('.')
-                        assert dot_index >= 0
-                        var_name = var_name[(dot_index + 1):]
+                    var_name = sputils._node_local_nonant_name(
+                        var.name, sname, self.bundling)
                     if self.is_zero_prob(model, var) and not get_zero_prob_values:
                         rows.append((var_name, None))
                     else:

--- a/mpisppy/spin_the_wheel.py
+++ b/mpisppy/spin_the_wheel.py
@@ -240,6 +240,19 @@ class WheelSpinner:
         if winner:
             self.spcomm.opt.write_tree_solution(solution_directory_name,scenario_tree_solution_writer)
 
+    def write_tree_nonants(self, solution_file_name):
+        """ Write the whole nonant tree (the xhat) to one by-name CSV, if a
+        solution is available. Single-file, nonant-only companion to
+        write_tree_solution.
+        Args:
+            solution_file_name : path of the CSV file to write the xhat tree to
+        """
+        if not self._ran:
+            raise RuntimeError("Need to call WheelSpinner.run() before querying solutions.")
+        winner = self._determine_innerbound_winner()
+        if winner:
+            self.spcomm.opt.write_tree_nonants(solution_file_name)
+
     def local_nonant_cache(self):
         """ Returns a dict with non-anticipative values at each local node
             We assume that the optimization has been done before calling this

--- a/mpisppy/tests/test_ef_ph.py
+++ b/mpisppy/tests/test_ef_ph.py
@@ -701,9 +701,14 @@ class Test_hydro(unittest.TestCase):
         pyo.assert_optimal_termination(results)
         mpisppy.utils.sputils.ef_nonants_csv(ef, "delme.csv")
 
-        df = pd.read_csv("delme.csv", index_col=1)
-        val2 = round_pos_sig(df.loc[" Scen7.Pgt[2]"].at[" Value"])
-        self.assertEqual(val2, 60)
+        # ef_nonants_csv writes the canonical xhat CSV: '#'-comment header,
+        # columns node_name, variable_name, value, with node-local variable
+        # names (the scenario-block prefix is stripped, so the second-stage
+        # Pgt[2] is shared across its node by non-anticipativity).
+        df = pd.read_csv("delme.csv", comment="#", header=None,
+                         names=["node", "var", "value"], skipinitialspace=True)
+        pgt2_vals = [round_pos_sig(v) for v in df[df["var"] == "Pgt[2]"]["value"]]
+        self.assertIn(60, pgt2_vals)
         os.remove("delme.csv")
 
         

--- a/mpisppy/tests/test_sputils.py
+++ b/mpisppy/tests/test_sputils.py
@@ -957,6 +957,27 @@ class TestNonantTreeCsv(unittest.TestCase):
             "stage_model_1.RegularProd",
         )
 
+    def test_node_local_nonant_name_strips_scenario_prefix(self):
+        # non-bundled: a leading "<scenario_name>." (e.g. a multistage
+        # stage-2 EF sub-block rebind) is stripped to stay node-local...
+        self.assertEqual(
+            sputils._node_local_nonant_name(
+                "scen0.stage_model_1.RegularProd", "scen0", bundling=False),
+            "stage_model_1.RegularProd",
+        )
+        # ...while an unprefixed name is left alone
+        self.assertEqual(
+            sputils._node_local_nonant_name(
+                "DevotedAcreage[CORN0]", "scen0", bundling=False),
+            "DevotedAcreage[CORN0]",
+        )
+        # bundled: strip the first segment (the inner scenario name)
+        self.assertEqual(
+            sputils._node_local_nonant_name(
+                "scen3.stage_model_1.RegularProd", "Bundle0", bundling=True),
+            "stage_model_1.RegularProd",
+        )
+
     def test_write_nonant_tree_csv_format_and_order(self):
         import os
         import tempfile

--- a/mpisppy/tests/test_sputils.py
+++ b/mpisppy/tests/test_sputils.py
@@ -877,7 +877,11 @@ class TestEFIterators(unittest.TestCase):
             self.assertTrue(os.path.exists(fname))
             with open(fname) as fh:
                 content = fh.read()
-            self.assertIn("Node", content)
+            # canonical format: '#'-comment header, node-local var names
+            self.assertIn("# node_name, variable_name, value", content)
+            self.assertIn("ROOT, x[1], 1.0", content)
+            # node-local: the EF scenario-block prefix must be stripped
+            self.assertNotIn("Scenario1.x[", content)
         finally:
             os.unlink(fname)
 
@@ -913,6 +917,233 @@ class TestDeprecatedSpinTheWheelWriters(unittest.TestCase):
     def test_local_nonant_cache_raises(self):
         with self.assertRaises(RuntimeError):
             sputils.local_nonant_cache(None)
+
+
+# ---------------------------------------------------------------------------
+# Canonical multi-stage xhat CSV: write_nonant_tree_csv, _node_sort_key,
+# _node_local_name
+# ---------------------------------------------------------------------------
+
+class TestNonantTreeCsv(unittest.TestCase):
+    """The single-file, by-name, multi-stage xhat writer."""
+
+    def _read(self, fname):
+        with open(fname) as fh:
+            return fh.read()
+
+    def test_node_sort_key_orders_numerically(self):
+        names = ["ROOT_10", "ROOT", "ROOT_2", "ROOT_0_1", "ROOT_0"]
+        ordered = sorted(names, key=sputils._node_sort_key)
+        self.assertEqual(
+            ordered, ["ROOT", "ROOT_0", "ROOT_0_1", "ROOT_2", "ROOT_10"]
+        )
+
+    def test_node_local_name_strips_one_prefix(self):
+        self.assertEqual(
+            sputils._node_local_name("Scenario1.x[1]", strip_prefix=True), "x[1]"
+        )
+        self.assertEqual(
+            sputils._node_local_name("x[1]", strip_prefix=True), "x[1]"
+        )
+        self.assertEqual(
+            sputils._node_local_name("Scenario1.x[1]", strip_prefix=False),
+            "Scenario1.x[1]",
+        )
+
+    def test_write_nonant_tree_csv_format_and_order(self):
+        import os
+        import tempfile
+        node_to_rows = {
+            "ROOT_1": [("z", 7.0)],
+            "ROOT": [("x[1]", 80.0), ("x[2]", 250.0)],
+            "ROOT_0": [("z", 0.0)],
+        }
+        fd, fname = tempfile.mkstemp(suffix=".csv")
+        os.close(fd)
+        try:
+            sputils.write_nonant_tree_csv(fname, node_to_rows)
+            content = self._read(fname)
+        finally:
+            os.unlink(fname)
+        lines = [ln for ln in content.splitlines() if not ln.startswith("#")]
+        self.assertEqual(
+            lines,
+            ["ROOT, x[1], 80.0", "ROOT, x[2], 250.0",
+             "ROOT_0, z, 0.0", "ROOT_1, z, 7.0"],
+        )
+        self.assertTrue(content.startswith("# mpi-sppy xhat"))
+
+    def test_round_trip_by_name_from_ef(self):
+        # Write an EF's nonant tree, parse it back by (node, name), and
+        # confirm it matches nonant_cache_from_ef position-for-position.
+        import os
+        import tempfile
+        names = [f"Scenario{i + 1}" for i in range(3)]
+        ef = sputils.create_EF(names, _make_two_stage_scenario)
+        fd, fname = tempfile.mkstemp(suffix=".csv")
+        os.close(fd)
+        try:
+            sputils.ef_nonants_csv(ef, fname)
+            content = self._read(fname)
+        finally:
+            os.unlink(fname)
+        parsed = {}
+        for ln in content.splitlines():
+            if ln.startswith("#") or not ln.strip():
+                continue
+            ndn, name, val = [t.strip() for t in ln.split(",")]
+            parsed.setdefault(ndn, []).append(float(val))
+        cache = sputils.nonant_cache_from_ef(ef)
+        self.assertEqual(set(parsed), set(cache))
+        for ndn in cache:
+            self.assertEqual(parsed[ndn], list(cache[ndn]))
+
+    def test_read_round_trips_write_multistage(self):
+        # write -> read back, ordered to a caller-supplied per-node order
+        import os
+        import tempfile
+        node_to_rows = {
+            "ROOT": [("x[1]", 80.0), ("x[2]", 250.0)],
+            "ROOT_0": [("z", 0.0)],
+            "ROOT_1": [("z", 7.0)],
+        }
+        order = {ndn: [n for n, _ in rows] for ndn, rows in node_to_rows.items()}
+        fd, fname = tempfile.mkstemp(suffix=".csv")
+        os.close(fd)
+        try:
+            sputils.write_nonant_tree_csv(fname, node_to_rows)
+            cache = sputils.read_nonant_tree_csv(fname, order)
+        finally:
+            os.unlink(fname)
+        self.assertEqual(set(cache), {"ROOT", "ROOT_0", "ROOT_1"})
+        self.assertEqual(list(cache["ROOT"]), [80.0, 250.0])
+        self.assertEqual(list(cache["ROOT_1"]), [7.0])
+
+    def test_read_respects_requested_order(self):
+        # the array follows node_varname_order, not file order
+        import os
+        import tempfile
+        fd, fname = tempfile.mkstemp(suffix=".csv")
+        os.close(fd)
+        try:
+            sputils.write_nonant_tree_csv(
+                fname, {"ROOT": [("a", 1.0), ("b", 2.0)]})
+            cache = sputils.read_nonant_tree_csv(fname, {"ROOT": ["b", "a"]})
+        finally:
+            os.unlink(fname)
+        self.assertEqual(list(cache["ROOT"]), [2.0, 1.0])
+
+    def test_read_ignores_unrequested_nodes(self):
+        import os
+        import tempfile
+        fd, fname = tempfile.mkstemp(suffix=".csv")
+        os.close(fd)
+        try:
+            sputils.write_nonant_tree_csv(
+                fname, {"ROOT": [("a", 1.0)], "ROOT_0": [("z", 9.0)]})
+            cache = sputils.read_nonant_tree_csv(fname, {"ROOT": ["a"]})
+        finally:
+            os.unlink(fname)
+        self.assertEqual(set(cache), {"ROOT"})
+
+    def test_read_survives_multi_index_var_names(self):
+        # commas inside a Var name (x[a,b]) must round-trip
+        import os
+        import tempfile
+        fd, fname = tempfile.mkstemp(suffix=".csv")
+        os.close(fd)
+        try:
+            sputils.write_nonant_tree_csv(
+                fname, {"ROOT": [("x[CORN,2024]", 3.5)]})
+            cache = sputils.read_nonant_tree_csv(
+                fname, {"ROOT": ["x[CORN,2024]"]})
+        finally:
+            os.unlink(fname)
+        self.assertEqual(list(cache["ROOT"]), [3.5])
+
+    def test_read_missing_node_raises(self):
+        import os
+        import tempfile
+        fd, fname = tempfile.mkstemp(suffix=".csv")
+        os.close(fd)
+        try:
+            sputils.write_nonant_tree_csv(fname, {"ROOT": [("a", 1.0)]})
+            with self.assertRaises(RuntimeError) as ctx:
+                sputils.read_nonant_tree_csv(fname, {"ROOT_9": ["a"]})
+        finally:
+            os.unlink(fname)
+        self.assertIn("ROOT_9", str(ctx.exception))
+
+    def test_read_missing_variable_raises(self):
+        import os
+        import tempfile
+        fd, fname = tempfile.mkstemp(suffix=".csv")
+        os.close(fd)
+        try:
+            sputils.write_nonant_tree_csv(fname, {"ROOT": [("a", 1.0)]})
+            with self.assertRaises(RuntimeError) as ctx:
+                sputils.read_nonant_tree_csv(fname, {"ROOT": ["a", "missing"]})
+        finally:
+            os.unlink(fname)
+        self.assertIn("missing", str(ctx.exception))
+
+
+# ---------------------------------------------------------------------------
+# SPBase node-keyed nonant gather + agreement check
+# ---------------------------------------------------------------------------
+
+class _Node:
+    def __init__(self, name, vardatas):
+        self.name = name
+        self.nonant_vardata_list = vardatas
+
+
+class _StubScen:
+    def __init__(self, node_list):
+        self._mpisppy_node_list = node_list
+
+
+class _StubOpt:
+    """Minimal stand-in exposing what gather_nonant_tree_to_rank0 reads on
+    the serial (n_proc == 1) path."""
+    bundling = False
+    n_proc = 1
+    cylinder_rank = 0
+
+    def __init__(self, local_scenarios):
+        self.local_scenarios = local_scenarios
+
+    def is_zero_prob(self, model, var):
+        return False
+
+
+class TestGatherNonantTree(unittest.TestCase):
+    from mpisppy.spbase import SPBase
+
+    def test_serial_gather_is_node_keyed_and_deduped(self):
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var([1, 2], initialize=3.0)
+        root = _Node("ROOT", [m.x[1], m.x[2]])
+        # two scenarios share ROOT -> exactly one ROOT entry in the result
+        scens = {"S1": _StubScen([root]), "S2": _StubScen([root])}
+        opt = _StubOpt(scens)
+        result = self.SPBase.gather_nonant_tree_to_rank0(opt)
+        self.assertEqual(set(result), {"ROOT"})
+        self.assertEqual(result["ROOT"], [("x[1]", 3.0), ("x[2]", 3.0)])
+
+    def test_agreement_check_passes_within_tol(self):
+        # exact ints and near-equal floats are fine
+        self.SPBase._assert_nonant_node_agreement(
+            "ROOT", [("a", 1.0), ("b", 2.0)], [("a", 1.0), ("b", 2.0 + 1e-9)]
+        )
+
+    def test_agreement_check_raises_on_disagreement(self):
+        with self.assertRaises(RuntimeError) as ctx:
+            self.SPBase._assert_nonant_node_agreement(
+                "ROOT_0", [("a", 1.0)], [("a", 5.0)]
+            )
+        self.assertIn("Inconsistent", str(ctx.exception))
+        self.assertIn("ROOT_0", str(ctx.exception))
 
 
 if __name__ == "__main__":

--- a/mpisppy/tests/test_sputils.py
+++ b/mpisppy/tests/test_sputils.py
@@ -949,6 +949,13 @@ class TestNonantTreeCsv(unittest.TestCase):
             sputils._node_local_name("Scenario1.x[1]", strip_prefix=False),
             "Scenario1.x[1]",
         )
+        # only the FIRST segment (scenario/bundle block) is stripped, so a
+        # variable inside a per-stage sub-block (e.g. aircond) keeps its dot
+        self.assertEqual(
+            sputils._node_local_name(
+                "Scenario1.stage_model_1.RegularProd", strip_prefix=True),
+            "stage_model_1.RegularProd",
+        )
 
     def test_write_nonant_tree_csv_format_and_order(self):
         import os

--- a/mpisppy/tests/test_xhat_file_multistage.py
+++ b/mpisppy/tests/test_xhat_file_multistage.py
@@ -1,0 +1,142 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+"""End-to-end MPI round trip for the multi-stage xhat file.
+
+Runs a real multistage aircond cylinder system, writes the incumbent's
+whole nonant tree to one CSV via ``WheelSpinner.write_tree_nonants``, then
+reads it back *by name* with ``sputils.read_nonant_tree_csv`` and asserts
+the entire tree round-trips.
+
+The point of running under MPI -- versus the serial unit tests in
+``test_sputils.py`` / ``test_xhat_from_file.py`` -- is to exercise
+``SPBase.gather_nonant_tree_to_rank0``'s cross-rank merge. At ``-np 4``
+the two cylinders (PH hub, xhatshuffle spoke) get two ranks each, so the
+writing cylinder's scenarios are split across ranks and a single rank
+holds only some second-stage subtrees. The assembled file containing
+*every* non-leaf node therefore proves the gather stitched the subtrees
+together across ranks, and that the per-node agreement check accepted the
+shared ROOT (a disagreement would have raised inside the write).
+
+mpiexec -np 4 python -m mpi4py -m pytest mpisppy/tests/test_xhat_file_multistage.py
+"""
+
+import os
+import tempfile
+import unittest
+
+import numpy as np
+from mpi4py import MPI
+
+from mpisppy.utils import config
+import mpisppy.utils.cfg_vanilla as vanilla
+import mpisppy.utils.sputils as sputils
+import mpisppy.tests.examples.aircond as aircond
+from mpisppy.spin_the_wheel import WheelSpinner
+from mpisppy.tests.utils import get_solver
+
+comm = MPI.COMM_WORLD
+
+solver_available, solver_name, _, _ = get_solver()
+# The xhatshuffle stage-2 EF needs a non-persistent solver.
+_, np_solver_name, _, _ = get_solver(persistent_OK=False)
+
+# 3-stage tree: ROOT plus 4 second-stage (non-leaf) nodes; the stage-3
+# leaves carry no nonants. At -np 4 the writing cylinder has 2 ranks, so
+# each holds two whole subtrees -- the cross-rank-merge case we want.
+BRANCHING_FACTORS = [4, 4]
+
+
+def _cfg():
+    cfg = config.Config()
+    cfg.multistage()
+    cfg.popular_args()
+    cfg.two_sided_args()
+    cfg.ph_args()
+    cfg.xhatshuffle_args()
+    aircond.inparser_adder(cfg)
+    cfg.solver_name = np_solver_name
+    cfg.default_rho = 1.0
+    cfg.max_iterations = 10
+    cfg.branching_factors = BRANCHING_FACTORS
+    cfg.max_solver_threads = 2
+    return cfg
+
+
+def _build_dicts(cfg):
+    num_scens = int(np.prod(BRANCHING_FACTORS))
+    all_scenario_names = aircond.scenario_names_creator(num_scens)
+    all_nodenames = sputils.create_nodenames_from_branching_factors(
+        BRANCHING_FACTORS)
+    kwargs = aircond.kw_creator(cfg)
+    beans = (cfg, aircond.scenario_creator, aircond.scenario_denouement,
+             all_scenario_names)
+
+    hub_dict = vanilla.ph_hub(
+        *beans, scenario_creator_kwargs=kwargs, all_nodenames=all_nodenames)
+    spoke = vanilla.xhatshuffle_spoke(
+        *beans, scenario_creator_kwargs=kwargs, all_nodenames=all_nodenames)
+    spoke["opt_kwargs"]["options"]["stage2_ef_solver_name"] = np_solver_name
+    spoke["opt_kwargs"]["options"]["branching_factors"] = BRANCHING_FACTORS
+    return hub_dict, [spoke], kwargs
+
+
+@unittest.skipUnless(comm.size == 4, "needs exactly 4 MPI ranks")
+@unittest.skipUnless(solver_available, "no solver is available")
+class TestXhatFileMultistageRoundTrip(unittest.TestCase):
+
+    def test_write_then_read_round_trip(self):
+        cfg = _cfg()
+        hub_dict, spoke_list, kwargs = _build_dicts(cfg)
+        wheel = WheelSpinner(hub_dict, spoke_list)
+        wheel.spin()
+
+        # A path all ranks agree on (only the winner's rank 0 actually writes).
+        if comm.rank == 0:
+            path = os.path.join(tempfile.gettempdir(),
+                                f"xhat_ms_roundtrip_{os.getpid()}.csv")
+        else:
+            path = None
+        path = comm.bcast(path, root=0)
+
+        wheel.write_tree_nonants(path)
+        comm.Barrier()
+
+        # Rank 0 reads it back by name and checks the whole tree is present.
+        if comm.rank == 0:
+            try:
+                self.assertTrue(os.path.exists(path),
+                                "write_tree_nonants produced no file")
+                # Build every scenario to recover, per node, the node-local
+                # nonant variable names (the order read_nonant_tree_csv wants).
+                order = {}
+                for sname in aircond.scenario_names_creator(
+                        int(np.prod(BRANCHING_FACTORS))):
+                    s = aircond.scenario_creator(sname, **kwargs)
+                    for node in s._mpisppy_node_list:
+                        order.setdefault(
+                            node.name,
+                            [v.name for v in node.nonant_vardata_list])
+
+                cache = sputils.read_nonant_tree_csv(path, order)
+
+                # Every non-leaf node (ROOT + the 4 second-stage nodes) must be
+                # present, even though any single writing rank held only some
+                # subtrees -- this is the cross-rank-merge assertion.
+                self.assertEqual(set(cache), set(order))
+                self.assertEqual(len(cache), 1 + BRANCHING_FACTORS[0])
+                for ndn, arr in cache.items():
+                    self.assertTrue(np.all(np.isfinite(arr)),
+                                    f"non-finite values for node {ndn}")
+            finally:
+                if os.path.exists(path):
+                    os.remove(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mpisppy/tests/test_xhat_from_file.py
+++ b/mpisppy/tests/test_xhat_from_file.py
@@ -92,6 +92,13 @@ def _write_npy(values):
     return path
 
 
+def _write_csv(node_to_rows):
+    fd, path = tempfile.mkstemp(suffix=".csv")
+    os.close(fd)
+    sputils.write_nonant_tree_csv(path, node_to_rows)
+    return path
+
+
 class TestFileXhatDisabled(unittest.TestCase):
 
     def test_off_by_default_is_noop(self):
@@ -141,6 +148,65 @@ class TestFileXhatHardFails(unittest.TestCase):
             with self.assertRaises(RuntimeError) as cm:
                 helper._try_file_xhat()
             self.assertIn("two-stage", str(cm.exception))
+        finally:
+            os.remove(path)
+
+
+class TestFileXhatCsv(unittest.TestCase):
+    """The by-name .csv path (works for any number of stages)."""
+
+    def test_csv_happy_path_evaluates_by_name(self):
+        # node-local names for _binary_scenario's ROOT node are x[0..2]
+        path = _write_csv(
+            {"ROOT": [("x[0]", 1.0), ("x[1]", 0.0), ("x[2]", 1.0)]})
+        try:
+            sp = _make_sp(options={"xhat_from_file": path})
+            helper = _make_helper(sp, evaluate_result=42.0)
+            helper._try_file_xhat()
+            self.assertEqual(len(helper.opt.evaluate_calls), 1)
+            np.testing.assert_array_equal(
+                helper.opt.evaluate_calls[0]["ROOT"], [1.0, 0.0, 1.0])
+            self.assertEqual(helper.updates, [42.0])
+            self.assertEqual(helper.opt.restore_calls, 1)
+        finally:
+            os.remove(path)
+
+    def test_csv_order_follows_model_not_file(self):
+        # file lists the vars in a different order; result must follow the
+        # model's nonant_vardata_list order (x[0], x[1], x[2])
+        path = _write_csv(
+            {"ROOT": [("x[2]", 1.0), ("x[0]", 1.0), ("x[1]", 0.0)]})
+        try:
+            sp = _make_sp(options={"xhat_from_file": path})
+            helper = _make_helper(sp, evaluate_result=1.0)
+            helper._try_file_xhat()
+            np.testing.assert_array_equal(
+                helper.opt.evaluate_calls[0]["ROOT"], [1.0, 0.0, 1.0])
+        finally:
+            os.remove(path)
+
+    def test_csv_extra_nodes_ignored(self):
+        # a deeper node in the file is ignored for this two-stage model
+        path = _write_csv({
+            "ROOT": [("x[0]", 1.0), ("x[1]", 1.0), ("x[2]", 0.0)],
+            "ROOT_0": [("y", 5.0)],
+        })
+        try:
+            sp = _make_sp(options={"xhat_from_file": path})
+            helper = _make_helper(sp, evaluate_result=2.0)
+            helper._try_file_xhat()
+            self.assertEqual(set(helper.opt.evaluate_calls[0]), {"ROOT"})
+        finally:
+            os.remove(path)
+
+    def test_csv_missing_variable_raises(self):
+        path = _write_csv({"ROOT": [("x[0]", 1.0), ("x[1]", 0.0)]})  # no x[2]
+        try:
+            sp = _make_sp(options={"xhat_from_file": path})
+            helper = _make_helper(sp, evaluate_result=1.0)
+            with self.assertRaises(RuntimeError) as cm:
+                helper._try_file_xhat()
+            self.assertIn("x[2]", str(cm.exception))
         finally:
             os.remove(path)
 

--- a/mpisppy/utils/config.py
+++ b/mpisppy/utils/config.py
@@ -1167,17 +1167,35 @@ class Config(pyofig.ConfigDict):
                               default=False)
 
     def xhat_from_file_args(self):
-        # Supply an initial xhat candidate from a .npy file. Every xhat
-        # spoke (xhatlooper, xhatshufflelooper, xhatspecific, xhatxbar)
-        # that descends from XhatInnerBoundBase will evaluate it once,
-        # before its normal exploration loop. Two-stage only today
-        # (matches ciutils.read_xhat). See
-        # doc/src/xhat_from_file.rst.
+        # Supply an initial xhat candidate from a file. Every xhat spoke
+        # (xhatlooper, xhatshufflelooper, xhatspecific, xhatxbar) that
+        # descends from XhatInnerBoundBase will evaluate it once, before
+        # its normal exploration loop. A .csv (node_name, variable_name,
+        # value; see sputils.write_nonant_tree_csv) works for any number
+        # of stages and is matched by name; a .npy holds a bare ROOT
+        # vector and is two-stage only. See doc/src/xhat_from_file.rst.
         self.add_to_config("xhat_from_file",
-                           description="Path to a .npy file holding an initial "
-                                       "first-stage xhat vector to evaluate "
-                                       "before normal xhatter exploration. "
-                                       "Two-stage only. Default None (off).",
+                           description="Path to a file holding an initial xhat "
+                                       "to evaluate before normal xhatter "
+                                       "exploration. A .csv nonant tree "
+                                       "(node_name, variable_name, value) works "
+                                       "for any number of stages; a .npy ROOT "
+                                       "vector is two-stage only. "
+                                       "Default None (off).",
+                           domain=str,
+                           default=None)
+
+    def write_xhat_file_args(self):
+        # Write the incumbent xhat (the whole nonant tree) to a single
+        # by-name CSV. Works for any number of stages and identically for
+        # EF and cylinders runs (both route through
+        # sputils.write_nonant_tree_csv). Default None (off).
+        self.add_to_config("write_xhat_file",
+                           description="Path to write the incumbent xhat (the "
+                                       "whole nonant tree) as a single by-name "
+                                       "CSV: 'node_name, variable_name, value', "
+                                       "node-local names. All stages; EF and "
+                                       "cylinders. Default None (off).",
                            domain=str,
                            default=None)
 

--- a/mpisppy/utils/sputils.py
+++ b/mpisppy/utils/sputils.py
@@ -538,16 +538,133 @@ def ef_nonants(ef):
         yield (ndn, var, pyo.value(var))
 
         
+def _node_local_name(var_name, strip_prefix):
+    """Return a variable name local to a single scenario model.
+
+    EF and loosely-bundled models qualify a nonant Var with a leading
+    ``<block>.`` (scenario or bundle name). Strip it so the same name can
+    be matched against any scenario's node-local Vars. Mirrors the
+    bundling branch in ``first_stage_nonant_writer`` and
+    ``SPBase.gather_var_values_to_rank0``.
+    """
+    if strip_prefix:
+        dot_index = var_name.find('.')
+        if dot_index >= 0:
+            var_name = var_name[(dot_index + 1):]
+    return var_name
+
+
+def _node_sort_key(node_name):
+    """Deterministic tree order for a node name like ``ROOT_0_10``.
+
+    Stage is implied by the name's depth, so no node object is needed.
+    Numeric path segments sort numerically (``ROOT_2`` before
+    ``ROOT_10``); the leading ``ROOT`` sorts before its children. Each
+    segment maps to a same-typed triple so mixed names never raise.
+    """
+    key = []
+    for seg in node_name.split('_'):
+        if seg.isdigit():
+            key.append((1, int(seg), ""))
+        else:
+            key.append((0, 0, seg))
+    return key
+
+
+def write_nonant_tree_csv(file_name, node_to_rows):
+    """Write a whole nonant tree (an xhat) to one by-name CSV.
+
+    Args:
+        file_name (str): output path.
+        node_to_rows (dict): ``{node_name: [(local_var_name, value), ...]}``
+            with node-local variable names (see ``_node_local_name``).
+
+    The format is the canonical mpi-sppy xhat interchange file: comment
+    lines start with ``#``; data lines are ``node_name, variable_name,
+    value``. Nodes are written in tree order (``_node_sort_key``). This
+    is the single-file, nonant-only companion to the per-scenario
+    ``scenario_tree_solution_writer`` directory format.
+    """
+    with open(file_name, "w") as outfile:
+        outfile.write("# mpi-sppy xhat: nonant tree, node-local variable names\n")
+        outfile.write("# node_name, variable_name, value\n")
+        for ndn in sorted(node_to_rows, key=_node_sort_key):
+            for (var_name, value) in node_to_rows[ndn]:
+                outfile.write(f"{ndn}, {var_name}, {value}\n")
+
+
+def read_nonant_tree_csv(file_name, node_varname_order):
+    """Read a canonical xhat CSV into a ``{node_name: np.ndarray}`` cache.
+
+    Inverse of ``write_nonant_tree_csv``. The file is keyed by (node,
+    node-local variable name), so the caller supplies the variable order
+    to return for each node it needs -- typically the node-local names of
+    each ``node.nonant_vardata_list`` from its own scenarios.
+
+    Args:
+        file_name (str): a CSV written by ``write_nonant_tree_csv``.
+        node_varname_order (dict): ``{node_name: [local_var_name, ...]}``.
+            Only these nodes are returned; nodes present in the file but
+            not requested are ignored (so each rank can read just the
+            nodes its local scenarios traverse).
+
+    Returns:
+        dict: ``{node_name: np.ndarray}`` for exactly the requested nodes,
+        each array ordered to match ``node_varname_order[node]``.
+
+    Raises:
+        RuntimeError: a requested node or variable is missing from the
+            file, or a data line is malformed.
+    """
+    parsed = dict()
+    with open(file_name) as infile:
+        for line in infile:
+            s = line.strip()
+            if not s or s.startswith("#"):
+                continue
+            # Split on the FIRST comma (node) and the LAST comma (value)
+            # so variable names with internal commas (multi-index Vars
+            # such as x[a,b]) survive the round trip.
+            try:
+                ndn, rest = s.split(",", 1)
+                name, val = rest.rsplit(",", 1)
+            except ValueError:
+                raise RuntimeError(
+                    f"{file_name}: malformed data line: {line!r}")
+            parsed.setdefault(ndn.strip(), dict())[name.strip()] = float(val)
+
+    cache = dict()
+    for ndn, names in node_varname_order.items():
+        if ndn not in parsed:
+            raise RuntimeError(f"{file_name}: node {ndn} not found in file")
+        node_vals = parsed[ndn]
+        arr = np.empty(len(names), dtype="d")
+        for i, nm in enumerate(names):
+            if nm not in node_vals:
+                raise RuntimeError(
+                    f"{file_name}: variable {nm!r} for node {ndn} not found "
+                    "in file")
+            arr[i] = node_vals[nm]
+        cache[ndn] = arr
+    return cache
+
+
 def ef_nonants_csv(ef, filename):
-    """ Dump the nonant vars from an ef to a csv file; truly a dump...
+    """Write the EF's nonant tree to the canonical xhat CSV.
+
+    Variable names are made node-local (the scenario-block prefix is
+    stripped) so the file reads back into any single scenario model. See
+    ``write_nonant_tree_csv`` for the format.
+
     Args:
         ef (ConcreteModel): the full extensive form model
         filename (str): the full name of the csv output file
     """
-    with open(filename, "w") as outfile:
-        outfile.write("Node, EF_VarName, Value\n")
-        for (ndname, varname, varval) in ef_nonants(ef):
-            outfile.write("{}, {}, {}\n".format(ndname, varname, varval))
+    node_to_rows = dict()
+    for (ndname, var, varval) in ef_nonants(ef):
+        node_to_rows.setdefault(ndname, []).append(
+            (_node_local_name(var.name, strip_prefix=True), varval))
+    write_nonant_tree_csv(filename, node_to_rows)
 
             
 def nonant_cache_from_ef(ef,verbose=False):

--- a/mpisppy/utils/sputils.py
+++ b/mpisppy/utils/sputils.py
@@ -554,6 +554,29 @@ def _node_local_name(var_name, strip_prefix):
     return var_name
 
 
+def _node_local_nonant_name(var_name, scenario_name, bundling):
+    """Strip a scenario/bundle block prefix from a nonant Var's name so it
+    is local to a single scenario model and consistent across scenarios.
+
+    - Bundled: the leading segment is the inner scenario name; strip it
+      (matches the existing bundling writers).
+    - Non-bundled: some spokes (e.g. the multistage xhatshuffle stage-2
+      EF) rebind nonants into a sub-block named for the owning scenario;
+      strip a leading ``<scenario_name>.`` when present. Plain scenarios
+      have no prefix and are returned unchanged.
+
+    Writer and reader both go through this so the by-name file round-trips
+    regardless of how the run happens to qualify its Var names.
+    """
+    if bundling:
+        dot_index = var_name.find('.')
+        if dot_index >= 0:
+            var_name = var_name[(dot_index + 1):]
+    elif var_name.startswith(scenario_name + "."):
+        var_name = var_name[(len(scenario_name) + 1):]
+    return var_name
+
+
 def _node_sort_key(node_name):
     """Deterministic tree order for a node name like ``ROOT_0_10``.
 

--- a/run_coverage.bash
+++ b/run_coverage.bash
@@ -214,6 +214,11 @@ run_phase "test_cg_with_cylinders (mpiexec -np 2)" \
 run_phase "test_cg_multirank_hub (mpiexec -np 4)" \
     mpiexec -np 4 $OVERSUBSCRIBE coverage run --rcfile="$PROJ_DIR/.coveragerc" -m mpi4py mpisppy/tests/test_cg_multirank_hub.py
 
+# Multi-stage xhat-file round trip: at np=4 the writing cylinder spans two
+# ranks, so gather_nonant_tree_to_rank0 must merge subtrees across ranks.
+run_phase "test_xhat_file_multistage (mpiexec -np 4)" \
+    mpiexec -np 4 $OVERSUBSCRIBE coverage run --rcfile="$PROJ_DIR/.coveragerc" -m mpi4py mpisppy/tests/test_xhat_file_multistage.py
+
 run_phase "test_dualcg_main (serial)" \
     coverage run --rcfile=.coveragerc mpisppy/tests/test_dualcg_main.py
 


### PR DESCRIPTION
## What

Adds a canonical single-file, **by-name** CSV "nonant tree" for an xhat of **any number of stages**, with both a writer and a reader. Until now mpi-sppy could only round-trip a two-stage xhat as a positional `.npy` ROOT vector (`ciutils.read_xhat`, used by MMW and `--xhat-from-file`); multi-stage had no on-disk format.

Format — one file, `#`-comment header, node-local variable names:

```
# mpi-sppy xhat: nonant tree, node-local variable names
# node_name, variable_name, value
ROOT, DevotedAcreage[CORN0], 80.0
ROOT_0, stage_model_2.RegularProd, 187.2
```

## Writer

- `sputils.write_nonant_tree_csv` serializer (+ `_node_sort_key`, `_node_local_name`, `_node_local_nonant_name`).
- `ef_nonants_csv` refactored onto the serializer — now emits **node-local** names (see backward-compat note).
- `SPBase.gather_nonant_tree_to_rank0` — node-keyed analog of the existing `gather_var_values_to_rank0`, assembling the whole tree on rank 0; `_assert_nonant_node_agreement` errors if two ranks disagree on a shared node (the incumbent would not be non-anticipative).
- `SPBase.write_tree_nonants` / `WheelSpinner.write_tree_nonants`.
- New `--write-xhat-file <path>` flag, wired into both the EF and cylinders generic drivers. Identical format from either path.

## Reader

- `sputils.read_nonant_tree_csv` — matched by name; splits on the first/last comma so multi-index Var names (`x[a,b]`) survive.
- `cylinders/xhatbase._try_file_xhat` now dispatches `.csv` (any number of stages) vs `.npy` (two-stage, unchanged). `--xhat-from-file` is therefore now multi-stage. The `ciutils` `.npy` / MMW path is untouched.

## Backward compatibility

`ef_nonants_csv` output changes: EF-qualified names (`Scenario1.DevotedAcreage[...]`) become node-local (`DevotedAcreage[...]`) with a `#`-comment header. This affects the EF `--solution-base-name.csv` output. `write_tree_solution`, `first_stage_nonant_writer`, the `.npy` ROOT serializers, and the `ciutils` two-stage path are unchanged.

## Tests

- Serializer/reader unit tests, EF round-trip, and the gather/agreement logic (`test_sputils.py`); the `.csv` reader path (`test_xhat_from_file.py`); updated the hydro EF check (`test_ef_ph.py`).
- New `test_xhat_file_multistage.py` (`mpiexec -np 4`): a multistage aircond cylinder system writes its incumbent tree and reads it back by name. At np 4 the writing cylinder spans two ranks, exercising `gather_nonant_tree_to_rank0`'s cross-rank merge. Wired into `run_coverage.bash` and `test_pr_and_main.yml`.
- Verified end-to-end on farmer (2-stage), hydro (3-stage), and aircond (4-stage), EF and cylinders.

Design: `doc/designs/multistage_xhat_write_design.md`. User docs: `doc/src/xhat_from_file.rst`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
