### PR TITLE
Fix PrimalDualRho for multistage: gather xbars from all local scenarios

### DIFF
--- a/mpisppy/extensions/primal_dual_rho.py
+++ b/mpisppy/extensions/primal_dual_rho.py
@@ -40,10 +40,13 @@ class PrimalDualRho(mpisppy.extensions.extension.Extension):
                           (decision node name, index)
         """
         xbars = {}
+        # Accumulate over all local scenarios: in a multistage tree a single
+        # scenario only traverses its own path's nodes, so one scenario's
+        # xbars miss sibling subtrees. xbar is the node consensus, so
+        # scenarios sharing a node agree and the overwrite is harmless.
         for s in self._ph.local_scenarios.values():
             for ndn_i, xbar in s._mpisppy_model.xbars.items():
                 xbars[ndn_i] = xbar.value
-            break
         return xbars
 
     def _compute_primal_convergence(self):


### PR DESCRIPTION
## Problem

`PrimalDualRho._get_xbars()` iterates the local scenarios but `break`s after
the first one, assuming a single scenario's `xbars` cover every tree node.
That holds only for **two-stage** problems, where every scenario passes
through `ROOT`. On a **multistage** tree a scenario only traverses its own
path, so `prev_xbars` misses sibling subtrees and `_compute_dual_residual`
raises `KeyError: ('ROOT_1', 0)` on the first update step.

### Reproduce
Enable `--use-primal-dual-rho-updater` on any multistage instance (e.g.
`examples/hydro` with `--branching-factors "3 3"`, or `aircond` with
`--branching-factors "3 2"`); PH dies in `miditer` on iteration 1.

## Fix

Drop the `break` so `xbars` accumulate over all local scenarios. `xbar` is
the node consensus, so scenarios sharing a node agree and the overwrite is
harmless. **Two-stage behavior is unchanged** — the union is still `{ROOT}`.

One-line change (plus a comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)