### PR TITLE
docs: clear all Sphinx user-doc build warnings/errors

### DIFF
--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -60,7 +60,6 @@ extensions = [
 copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
 copybutton_prompt_is_regexp = True
 
-viewcode_import = True
 #napoleon_include_private_with_doc = True
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/src/uc_cleanup.rst
+++ b/doc/src/uc_cleanup.rst
@@ -1,4 +1,0 @@
-examples/uc cleanup
-===================
-
-Design notes for cleaning up ``examples/uc``. TBD.

--- a/mpisppy/cylinders/spcommunicator.py
+++ b/mpisppy/cylinders/spcommunicator.py
@@ -144,9 +144,11 @@ class FieldArray:
     The intention here is that these are passive data holding classes. That is, other classes are
     expected to update the internal fields. The lone exception to this is the read/write id field.
     See the `SendArray` and `RecvArray` classes for how that field is updated.
+
     Wrapper around an MPI-allocated numpy buffer with:
-      - a padded "window" array used for MPI RMA
-      - a logical view used by mpi-sppy code (data + id)
+
+    - a padded "window" array used for MPI RMA
+    - a logical view used by mpi-sppy code (data + id)
     """
 
     def __init__(self, length: int):


### PR DESCRIPTION
## What

Clears all warnings/errors from the user-doc Sphinx build. `make html` in `doc/` now finishes with **zero** warnings (previously 3).

## Fixes

| Issue | Fix |
|-------|-----|
| `WARNING: config value 'viewcode_import' has type 'bool'; expected 'NoneType'` | Removed the long-deprecated `viewcode_import = True` from `doc/src/conf.py`. Its modern replacement `viewcode_follow_imported_members` already defaults to `True`, so effective behavior is unchanged. |
| `ERROR: Unexpected indentation [docutils]` in the `FieldArray` docstring | Fixed the docstring in `mpisppy/cylinders/spcommunicator.py` to valid reStructuredText — blank line before the bullet list and dedented bullets. |
| `WARNING: doc/src/uc_cleanup.rst isn't included in any toctree` | Deleted `doc/src/uc_cleanup.rst` — a "TBD" design-note stub with no real content. Rather than publish an empty placeholder, it's removed. |

## Verification

```
cd doc && make html
# build succeeded.  (empty stderr, 0 warnings)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
