### PR TITLE
Slamming: preference-driven in-hub variable fixing

### DIFF
--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -1174,7 +1174,8 @@ jobs:
             mpisppy/tests/test_ciutils.py \
             mpisppy/tests/test_prox_approx.py \
             mpisppy/tests/test_sep_rho.py \
-            mpisppy/tests/test_reduced_costs_fixer.py
+            mpisppy/tests/test_reduced_costs_fixer.py \
+            mpisppy/tests/test_slammer.py
 
       - name: Upload coverage data
         if: always()

--- a/doc/designs/slamming_design.md
+++ b/doc/designs/slamming_design.md
@@ -1,7 +1,9 @@
 # Slamming — design
 
-**Status:** Draft — up for discussion. Nothing is implemented yet.
-Intended branch: `slamming` (off Pyomo/mpi-sppy `main`).
+**Status:** The mechanism described here is implemented on branch `slamming`
+(off Pyomo/mpi-sppy `main`). This document describes the slamming *mechanism*;
+the work that decides *when* to invoke it (stall/cycle detection) is a separate
+future project that uses slamming as a consumer — not a later phase of this one.
 **Author:** dlw (captured with Claude Code assistance)
 **Last updated:** 2026-06-17
 
@@ -30,12 +32,13 @@ family of in-PH fixers).
    the way PySP did.
 3. Support wildcards in the file so a single rule can cover a family of
    indexed variables.
-4. Decouple the slamming **mechanism** (this design) from slam
-   **triggering**, so that:
-   - Phase 1 ships a simple iteration-count trigger (PySP's
+4. Keep the slamming **mechanism** (this design) cleanly separable from the
+   decision of *when* to slam, so that:
+   - this design ships a simple iteration-count trigger (PySP's
      "slam-after-iter" plus an iters-between cadence), and
-   - a later phase can drop a genuine **stall detector** into the same
-     seam without touching the mechanism.
+   - a separate future project that detects stalls/cycles can invoke the
+     slamming mechanism on demand (the action layer, §7) rather than relying
+     on the iteration trigger.
 5. **Total backward compatibility.** A run that uses none of the new
    slamming options behaves byte-for-byte as it does today.
 6. Multistage-capable from the start (the existing slam *spokes* are
@@ -43,20 +46,21 @@ family of in-PH fixers).
 
 ### Non-goals
 
-- **Stall detection.** Phase 1's trigger is iteration counting. Real
-  stall/cycle detection is a named follow-up (§11, Phase 2). The point
-  of this design is to build the slamming machinery *first*, with a
-  pluggable trigger, so stall detection slots in later.
-- **Automatic un-slamming / backtracking.** Phase 1 slams are sticky.
-  We reserve an `unslam` hook (§7.5) for a later phase but do not
-  implement release logic now.
+- **Stall detection.** This design's trigger is iteration counting. Real
+  stall/cycle detection is out of scope; it is expected to live in a
+  *separate* project that invokes this slamming mechanism when it decides one
+  is warranted. The point here is to build the slamming machinery *first*, so
+  such a consumer has something to call.
+- **Automatic un-slamming / backtracking.** Slams here are sticky. The
+  `_slammed` record (§7.5) is kept so a future consumer could add release
+  logic, but no release logic is implemented now.
 - **Replacing the existing fixers.** `fixer.py`, `reduced_costs_fixer.py`,
   `relaxed_ph_fixer.py`, and `integer_relax_then_enforce.py` are
   untouched; the slammer coexists with them (§9).
 - **Replacing the `SlamMin` / `SlamMax` spokes.** Those remain (§1); this
   is a different, complementary mechanism.
 - **PySP config-file syntax compatibility.** We use a modern by-name file
-  (§5). A WW-syntax importer is an optional later phase if there is
+  (§5). A WW-syntax importer is an optional future enhancement if there is
   demand to bring old files verbatim.
 
 ---
@@ -110,7 +114,7 @@ in spirit:
   integer).
 - A slam **priority** per variable.
 - `PH_Iters_Between_Slamming` and a "slam after iteration K" start point —
-  the iteration-count trigger this design adopts for Phase 1.
+  the iteration-count trigger this design adopts.
 
 When triggered (PySP triggered on detected cycling / stall), PySP slammed
 variables according to these preferences to break the cycle.
@@ -161,9 +165,10 @@ organized as three independent layers so each can evolve separately:
   iteration_for_slam()      directive map from file        slam(ndn_i, dir)
 ```
 
-**Trigger (`when`)** — a predicate `iteration_for_slam(phiter) -> bool`. Phase 1:
-iteration counting (§6). Phase 2: a stall detector implementing the same
-predicate. The rest of the extension never changes.
+**Trigger (`when`)** — a predicate `iteration_for_slam(phiter) -> bool`,
+implemented here as iteration counting (§6). The action layer (below) is the
+reusable mechanism; a separate future project that decides slams are needed can
+drive it directly, so the trigger is just one (the built-in) caller.
 
 **Preferences (`who`/`where`)** — a directive map built once from the file
 (§5): for each nonant, `{can_slam, directions, priority}`. Only nonants
@@ -180,9 +185,9 @@ driven from `PHBase`, so the Slammer runs under any `PHBase`-derived hub:
 `_mpisppy_model.xbars` (for `nearest` / `anywhere`) and the per-node
 communicators `comms[ndn]` (for `min` / `max`), both of which the whole
 `PHBase` family maintains. **L-shaped** (`SPBase`, no extension hooks) is
-out. One caveat: the Phase-1 trigger counts iterations, and APH's
+out. One caveat: the built-in trigger counts iterations, and APH's
 asynchronous notion of an "iteration" makes that cadence less meaningful
-there — APH is a more natural fit for the Phase-2 stall trigger.
+there — APH is a more natural fit for an external, stall-driven caller.
 
 ---
 
@@ -245,9 +250,9 @@ identical on every rank, so all ranks raise together.
 
 ---
 
-## 6. Trigger layer — Phase 1
+## 6. Trigger layer
 
-Two options drive the iteration-count trigger:
+Two options drive the built-in iteration-count trigger:
 
 - `--slam-start-iter K` — do not slam before hub iteration `K` (PySP's
   "slam after iter").
@@ -264,10 +269,11 @@ def iteration_for_slam(self, phiter):
 Purely a function of the iteration counter, so it is identical on every
 rank with no communication.
 
-**Phase 2 seam.** The stall detector will implement the same
-`iteration_for_slam(phiter)` signature (reading the convergence history the hub
-already tracks). Swapping it in is a one-line change in `Slammer`; nothing
-else moves.
+**External callers.** This predicate is just the built-in trigger. A separate
+project that detects stalls/cycles is not expected to rewrite it; the natural
+integration is for that project to invoke the slammer's action layer (§7) when
+it decides a slam is warranted, leaving this iteration trigger in place (or
+disabled) alongside it.
 
 ---
 
@@ -286,8 +292,8 @@ There is deliberately **no convergence gate**: an eligible nonant is
 slammed strictly by priority whether or not the scenarios already agree on
 it. The user has already expressed intent by listing the variable with a
 priority; second-guessing that with a dynamic "skip already-converged"
-test adds a subtle behavior whose natural home is the Phase-2 stall
-detector (which is, by definition, the layer that knows what is stuck).
+test adds a subtle behavior whose natural home is a stall detector (a
+separate project, which is by definition the layer that knows what is stuck).
 Slamming an already-converged variable is harmless — it pins the variable
 where it was settling and reduces the live problem, which is exactly what
 `fixer.py` would have done. If a fixer is also active, no work is
@@ -297,9 +303,10 @@ a fixer-fixed variable fails eligibility test 2 here.
 ### 7.2 Selection
 
 Among eligible nonants, pick the one with the **largest** `priority`
-(ties → name order). Phase 1 slams **one nonant per event** — conservative,
+(ties → name order). This design slams **one nonant per event** — conservative,
 PySP-faithful, and the trigger cadence (`--iters-between-slams`) controls
-aggressiveness. A batched / fraction-based variant is a later option.
+aggressiveness. A batched / fraction-based variant is a possible future
+enhancement.
 
 ### 7.3 Determinism across ranks
 
@@ -310,7 +317,8 @@ picks the *same* nonant with no communication:
   all scenarios on all ranks.
 
 If any future input to selection could differ across ranks, the selection
-result is reduced to agreement before acting; in Phase 1 none can.
+result is reduced to agreement before acting; with the inputs used here none
+can.
 
 ### 7.4 `min` / `max` direction — on-demand reduction
 
@@ -331,9 +339,10 @@ For the chosen `(ndn, i)` and value `v`, in every local scenario:
 `xvar.fix(v)`; if the solver is persistent, `solver.update_var(xvar)`.
 Record `self._slammed[(ndn, i)] = v`.
 
-`_slammed` exists for reporting and for the **`unslam` hook** reserved for
-Phase 2 (releasing a bad slam). Phase 1 never calls it; the seam is left
-so the stall/backtracking phase need not refactor the action layer.
+`_slammed` exists for reporting and as the record an eventual **`unslam`**
+(releasing a bad slam) would need. This design never releases a slam; keeping
+the record means a future consumer that wants backtracking need not refactor
+the action layer.
 
 ### 7.6 Reporting
 
@@ -400,19 +409,22 @@ update`). Not required for correctness.
 
 ---
 
-## 11. Phasing (each its own review-sized PR)
+## 11. Scope and future work
 
-**Phase 1 (this design):** the slammer mechanism — directives file
+**This design (one review-sized PR):** the slammer mechanism — directives file
 (by-name + wildcards), the five+`nearest` directions, one-slam-per-event
-selection, iteration-count trigger, sticky slams, multistage, full
+selection, the built-in iteration-count trigger, sticky slams, multistage, full
 backward compatibility. Plus example + docs + tests.
 
-**Phase 2:** a real **stall/cycle detector** implementing
-`iteration_for_slam(phiter)`, dropped into the trigger seam; and the **`unslam`**
-release logic the Phase 1 hook anticipates.
+**Separate future project (not a phase of this one):** stall/cycle detection.
+That project decides *when* slamming is warranted and **invokes this mechanism
+as a consumer** (the action layer, §7); it may also add `unslam` / backtracking,
+for which the `_slammed` record (§7.5) is already kept. It is deliberately not
+built here — this design exists so that project has a slamming mechanism to call.
 
-**Phase 3 (optional):** batched / fraction-based slamming; PySP WW-syntax
-file importer; JSON file format.
+**Optional independent enhancements:** batched / fraction-based slamming; a PySP
+WW-syntax file importer; a JSON file format. Each stands alone if there is
+demand.
 
 ---
 
@@ -445,8 +457,8 @@ Settled in review (DLW, 2026-06-17); recorded here for provenance.
 2. **`nearest` token** — kept as a convenience for "either bound, pick the
    closer." *Confirmed.*
 3. **Convergence gate** — the proposed `--slam-only-unconverged` option is
-   **dropped**. Phase 1 slams strictly by priority with no convergence
-   test (§7.1); convergence-aware targeting, if wanted, belongs in the
-   Phase-2 stall detector.
-4. **One slam per event** in Phase 1; batched / priority-band slamming is a
-   later option (§7.2).
+   **dropped**. The mechanism slams strictly by priority with no convergence
+   test (§7.1); convergence-aware targeting, if wanted, belongs in the separate
+   stall-detection project.
+4. **One slam per event**; batched / priority-band slamming is a possible
+   future enhancement (§7.2).

--- a/doc/designs/slamming_design.md
+++ b/doc/designs/slamming_design.md
@@ -197,7 +197,7 @@ Columns:
 
 | Column | Meaning |
 |---|---|
-| `name` | nonant name pattern, matched with `fnmatch` against `xvar.name` (e.g. `DoBuild[*]`, `Reservoir*.spill[*]`). |
+| `name` | nonant name pattern matched against `xvar.name` (e.g. `DoBuild[*]`, `Reservoir*.spill[*]`). Shell-style `*`/`?` wildcards; `[` and `]` are **literal**, not character classes (so `DoBuild[*]` matches every `DoBuild[...]`). This is deliberately *not* `fnmatch`, whose bracket semantics would make `DoBuild[*]` fail to match an indexed Pyomo name. |
 | `can_slam` | `1`/`0`. Optional; defaults to `1` when the row is present. `0` carves out an exception. |
 | `directions` | `\|`-separated ordered list from `{lb, ub, nearest, anywhere, min, max}`. First *applicable* direction wins. |
 | `priority` | float; the eligible nonant with the **largest** priority is slammed first. Ties broken by name (deterministic across ranks). |
@@ -211,6 +211,15 @@ NumUnits[*],1,nearest,50
 NumUnits[7],0,,0
 Reservoir*.spill[*],1,min,10
 ```
+
+A worked example translated from PySP's historical `wwph.suffixes` ships at
+`examples/sizes/config/slamming_directives.csv`.
+
+**Comments and quoting.** Blank lines and whole-line `#` comments are ignored
+anywhere, including before the header. A multi-index name contains a comma
+(e.g. `NumUnitsCutFirstStage[*,*]`), so it must be **quoted**
+(`"NumUnitsCutFirstStage[*,*]"`) to survive the CSV split — standard CSV
+quoting.
 
 **Matching against scenario variables.** Each scenario is its own Pyomo
 model, but the *same* nonant has the *same* `xvar.name` in every scenario

--- a/doc/designs/slamming_design.md
+++ b/doc/designs/slamming_design.md
@@ -1,0 +1,439 @@
+# Slamming — design
+
+**Status:** Draft — up for discussion. Nothing is implemented yet.
+Intended branch: `slamming` (off Pyomo/mpi-sppy `main`).
+**Author:** dlw (captured with Claude Code assistance)
+**Last updated:** 2026-06-17
+
+Related: PySP's Watson–Woodruff (WW) PH extension, which let the user
+specify slamming preferences in a configuration file. This design brings
+a similar capability to mpi-sppy, modernized to the library's current
+idioms (by-name nonant files, the `Config` system, the `Extension`
+family of in-PH fixers).
+
+---
+
+## 0. Goals
+
+1. Add **slamming** to mpi-sppy: forcing (fixing) selected nonanticipative
+   variables to a chosen value *while a decomposition hub is running*, to
+   drive toward a feasible / converged incumbent when ordinary convergence
+   is slow. Slamming is an `Extension`, not a PH feature: it works with any
+   hub that runs the extension hooks and maintains x-bar — the `PHBase`
+   family (PH, APH, Subgradient, FWPH). See §4 for the applicability
+   conditions. (L-shaped derives from `SPBase`, runs no extensions, and is
+   out of scope.)
+
+2. Let the user specify, per variable, **whether** it may be slammed,
+   **which direction(s)** it may be slammed in, and in **what order**
+   (priority) — supplied through a file (`--slamming-directives-file`),
+   the way PySP did.
+3. Support wildcards in the file so a single rule can cover a family of
+   indexed variables.
+4. Decouple the slamming **mechanism** (this design) from slam
+   **triggering**, so that:
+   - Phase 1 ships a simple iteration-count trigger (PySP's
+     "slam-after-iter" plus an iters-between cadence), and
+   - a later phase can drop a genuine **stall detector** into the same
+     seam without touching the mechanism.
+5. **Total backward compatibility.** A run that uses none of the new
+   slamming options behaves byte-for-byte as it does today.
+6. Multistage-capable from the start (the existing slam *spokes* are
+   two-stage only — see §1).
+
+### Non-goals
+
+- **Stall detection.** Phase 1's trigger is iteration counting. Real
+  stall/cycle detection is a named follow-up (§11, Phase 2). The point
+  of this design is to build the slamming machinery *first*, with a
+  pluggable trigger, so stall detection slots in later.
+- **Automatic un-slamming / backtracking.** Phase 1 slams are sticky.
+  We reserve an `unslam` hook (§7.5) for a later phase but do not
+  implement release logic now.
+- **Replacing the existing fixers.** `fixer.py`, `reduced_costs_fixer.py`,
+  `relaxed_ph_fixer.py`, and `integer_relax_then_enforce.py` are
+  untouched; the slammer coexists with them (§9).
+- **Replacing the `SlamMin` / `SlamMax` spokes.** Those remain (§1); this
+  is a different, complementary mechanism.
+- **PySP config-file syntax compatibility.** We use a modern by-name file
+  (§5). A WW-syntax importer is an optional later phase if there is
+  demand to bring old files verbatim.
+
+---
+
+## 1. Current state in mpi-sppy — two senses of "slam"
+
+The word "slam" is already used in the tree, so we are careful to keep
+the two senses distinct.
+
+**(a) The `SlamMin` / `SlamMax` *spokes*** (`mpisppy/cylinders/slam_heuristic.py`).
+These are `InnerBoundNonantSpoke`s — *non-destructive incumbent finders*.
+Each builds a candidate equal to the per-variable **min** (or **max**) of
+the current nonant values across all scenarios, fixes *all* nonants to
+that candidate, and evaluates the objective to report an inner bound.
+They never perturb the hub. Limitations: globally all-to-min or
+all-to-max (no per-variable control), **two-stage only** (explicit
+`RuntimeError` on multistage), `rounding_bias` for integers. Wired via
+`cfg_vanilla.slammin_spoke` / `slammax_spoke` and `config.slammin_args` /
+`slammax_args`.
+
+**(b) In-PH heuristic *fixing* extensions.** mpi-sppy already fixes
+variables inside the PH loop:
+
+| Extension | Fires on | Direction from | Per-var user spec? |
+|---|---|---|---|
+| `fixer.py` | converged within `th` for N iters | nearest / lb / ub (tuple) | yes — `id_fix_list_fct` callback |
+| `reduced_costs_fixer.py` | \|rc\| ≥ quantile target, at bound | sign of reduced cost + sense | no (automatic) |
+| `relaxed_ph_fixer.py` | relaxed-PH soln agrees with xbar at a bound | the relaxed value | no (automatic) |
+| `integer_relax_then_enforce.py` | time / iters / near-convergence | n/a (re-enforces integrality) | no |
+
+**Why none of these is slamming.** They all fix on *agreement /
+convergence* — a variable is pinned because the evidence says it is
+already settling there — and so they can derive direction
+**automatically**. Slamming is the opposite regime: it forces
+*non-converged* variables precisely *because* PH is not settling, and so
+there is no signal to read direction from. That is exactly why slamming
+needs **user-supplied** direction preferences. This design adds the
+missing member of the in-PH-fixing family: a *stall-regime, user-directed*
+fixer.
+
+---
+
+## 2. How PySP did it
+
+PySP's WW PH extension read a configuration file with global directives
+and per-variable override blocks. The slamming-relevant directives were,
+in spirit:
+
+- `CanSlamToLB`, `CanSlamToUB`, `CanSlamToAnywhere` — which directions a
+  variable may be slammed in (`Anywhere` = round x-bar to the nearest
+  integer).
+- A slam **priority** per variable.
+- `PH_Iters_Between_Slamming` and a "slam after iteration K" start point —
+  the iteration-count trigger this design adopts for Phase 1.
+
+When triggered (PySP triggered on detected cycling / stall), PySP slammed
+variables according to these preferences to break the cycle.
+
+We keep the *concepts* (per-variable can-slam, directions, priority; a
+file; an iteration trigger) and modernize the *encoding* (§5) and the
+*architecture* (§4).
+
+---
+
+## 3. The slam action — semantics
+
+To **slam** a nonant `(ndn, i)` is to `fix()` its `Var` to a chosen value
+**in every local scenario, on every rank**, and push the change to the
+persistent solver. The chosen value depends on the variable's allowed
+**direction**:
+
+| Direction | Value the variable is fixed to |
+|---|---|
+| `lb` | `xvar.lb` |
+| `ub` | `xvar.ub` |
+| `nearest` | `lb` or `ub`, whichever the current x-bar is closer to |
+| `anywhere` | x-bar, rounded to the nearest integer if the var is integer/binary (reusing the existing `rounding_bias`); plain x-bar otherwise |
+| `min` | the **minimum** of the variable's value across all scenarios at this node |
+| `max` | the **maximum** of the variable's value across all scenarios at this node |
+
+`lb`, `ub`, `nearest`, `anywhere` use only data that is already identical
+on every rank (the variable's own bounds; the globally-reduced x-bar), so
+they are **coherent for free** — no communication. `min` and `max` need a
+cross-scenario reduction (§7.4).
+
+A direction is **applicable** only if it yields a finite value (e.g. `lb`
+is skipped if the variable has no lower bound). The file may list an
+ordered set of directions; the slammer uses the first applicable one
+(§5).
+
+---
+
+## 4. Architecture — three decoupled layers
+
+A single new extension, `mpisppy/extensions/slammer.py`, class `Slammer`,
+in the in-PH-fixing family. It fires in `miditer` (like `fixer.py`). It is
+organized as three independent layers so each can evolve separately:
+
+```
+   Trigger          Selection + preferences          Action
+  (WHEN)      →        (WHO / WHERE)           →      (WHAT)
+  should_slam()      directive map from file        slam(ndn_i, dir)
+```
+
+**Trigger (`when`)** — a predicate `should_slam(phiter) -> bool`. Phase 1:
+iteration counting (§6). Phase 2: a stall detector implementing the same
+predicate. The rest of the extension never changes.
+
+**Preferences (`who`/`where`)** — a directive map built once from the file
+(§5): for each nonant, `{can_slam, directions, priority}`. Only nonants
+**present** in the file (matched by a `can_slam` rule) are eligible;
+everything else is never slammed (the safe default that gives backward
+compatibility).
+
+**Action (`what`)** — when the trigger fires, choose the eligible nonant
+of highest priority and slam it per §3 (§7).
+
+**Applicable hubs.** The extension hooks (`pre_iter0`, `miditer`, …) are
+driven from `PHBase`, so the Slammer runs under any `PHBase`-derived hub:
+**PH, APH, Subgradient, FWPH**. The action layer additionally reads
+`_mpisppy_model.xbars` (for `nearest` / `anywhere`) and the per-node
+communicators `comms[ndn]` (for `min` / `max`), both of which the whole
+`PHBase` family maintains. **L-shaped** (`SPBase`, no extension hooks) is
+out. One caveat: the Phase-1 trigger counts iterations, and APH's
+asynchronous notion of an "iteration" makes that cadence less meaningful
+there — APH is a more natural fit for the Phase-2 stall trigger.
+
+---
+
+## 5. The directives file
+
+`--slamming-directives-file PATH`. **CSV**, keyed **by nonant name**, with
+wildcards. Chosen over JSON to match mpi-sppy's existing by-name nonant
+CSVs (e.g. the multistage xhat file); JSON is trivial to add later if
+wanted.
+
+Columns:
+
+| Column | Meaning |
+|---|---|
+| `name` | nonant name pattern, matched with `fnmatch` against `xvar.name` (e.g. `DoBuild[*]`, `Reservoir*.spill[*]`). |
+| `can_slam` | `1`/`0`. Optional; defaults to `1` when the row is present. `0` carves out an exception. |
+| `directions` | `\|`-separated ordered list from `{lb, ub, nearest, anywhere, min, max}`. First *applicable* direction wins. |
+| `priority` | float; the eligible nonant with the **largest** priority is slammed first. Ties broken by name (deterministic across ranks). |
+
+Example:
+
+```csv
+name,can_slam,directions,priority
+DoBuild[*],1,ub|lb,100
+NumUnits[*],1,nearest,50
+NumUnits[7],0,,0
+Reservoir*.spill[*],1,min,10
+```
+
+**Matching against scenario variables.** Each scenario is its own Pyomo
+model, but the *same* nonant has the *same* `xvar.name` in every scenario
+(e.g. `DoBuild[Seattle]`), so patterns are matched against `xvar.name` and
+are scenario-independent and multistage-clean (one rule can span nodes).
+
+**Precedence:** **last matching row wins** (gitignore-style). Write broad
+defaults first and exceptions after. In the example, `NumUnits[7]` is
+excluded even though `NumUnits[*]` would slam it.
+
+**Coverage:** *not all nonants must appear.* A nonant matched by **no**
+row — or whose last matching row has `can_slam=0` — is **never slammed**.
+This is the requirement that only explicitly-specified variables can be
+slammed, and it is what makes the feature backward compatible.
+
+The file is parsed once and validated at startup: unknown direction
+tokens, unparseable priorities, and patterns that match **zero** nonants
+are reported (the last as a warning, gated on rank 0).
+
+---
+
+## 6. Trigger layer — Phase 1
+
+Two options drive the iteration-count trigger:
+
+- `--slam-start-iter K` — do not slam before hub iteration `K` (PySP's
+  "slam after iter").
+- `--iters-between-slams M` — once started, slam at most once every `M`
+  iterations.
+
+```python
+def should_slam(self, phiter):
+    if phiter < self.slam_start_iter:
+        return False
+    return (phiter - self.slam_start_iter) % self.iters_between_slams == 0
+```
+
+Purely a function of the iteration counter, so it is identical on every
+rank with no communication.
+
+**Phase 2 seam.** The stall detector will implement the same
+`should_slam(phiter)` signature (reading the convergence history the hub
+already tracks). Swapping it in is a one-line change in `Slammer`; nothing
+else moves.
+
+---
+
+## 7. Action layer
+
+### 7.1 Eligibility
+
+A nonant is eligible to be slammed this event iff:
+1. it is **present** in the directive map with `can_slam` true,
+2. it is **not already fixed** (by the modeler, a fixer, or a prior slam),
+   and
+3. it is **not a surrogate nonant** (`all_surrogate_nonants`) — consistent
+   with every other fixer.
+
+There is deliberately **no convergence gate**: an eligible nonant is
+slammed strictly by priority whether or not the scenarios already agree on
+it. The user has already expressed intent by listing the variable with a
+priority; second-guessing that with a dynamic "skip already-converged"
+test adds a subtle behavior whose natural home is the Phase-2 stall
+detector (which is, by definition, the layer that knows what is stuck).
+Slamming an already-converged variable is harmless — it pins the variable
+where it was settling and reduces the live problem, which is exactly what
+`fixer.py` would have done. If a fixer is also active, no work is
+duplicated: a slammed variable is `is_fixed()`, so the fixers skip it, and
+a fixer-fixed variable fails eligibility test 2 here.
+
+### 7.2 Selection
+
+Among eligible nonants, pick the one with the **largest** `priority`
+(ties → name order). Phase 1 slams **one nonant per event** — conservative,
+PySP-faithful, and the trigger cadence (`--iters-between-slams`) controls
+aggressiveness. A batched / fraction-based variant is a later option.
+
+### 7.3 Determinism across ranks
+
+Selection must use only globally-consistent inputs so that every rank
+picks the *same* nonant with no communication:
+- `priority` / `can_slam` come from the file (rank-identical), and
+- the fixed mask is coherent because slamming/fixing is always applied to
+  all scenarios on all ranks.
+
+If any future input to selection could differ across ranks, the selection
+result is reduced to agreement before acting; in Phase 1 none can.
+
+### 7.4 `min` / `max` direction — on-demand reduction
+
+`min` / `max` need the extremum of the selected variable's value across
+all scenarios at its node. Because the selected `(ndn, i)` is identical on
+every rank (§7.3), all ranks symmetrically:
+1. take the local min/max of `xvar.value` over local scenarios at node
+   `ndn`, then
+2. `self.opt.comms[ndn].Allreduce(..., op=MPI.MIN / MPI.MAX)`
+
+reusing the same per-node communicators x-bar uses. The cost (one small
+collective) is paid **only** when a `min`/`max`-directed slam actually
+fires — never on other iterations, never for other directions.
+
+### 7.5 Applying and recording the slam
+
+For the chosen `(ndn, i)` and value `v`, in every local scenario:
+`xvar.fix(v)`; if the solver is persistent, `solver.update_var(xvar)`.
+Record `self._slammed[(ndn, i)] = v`.
+
+`_slammed` exists for reporting and for the **`unslam` hook** reserved for
+Phase 2 (releasing a bad slam). Phase 1 never calls it; the seam is left
+so the stall/backtracking phase need not refactor the action layer.
+
+### 7.6 Reporting
+
+On rank 0 (gated), log each slam (`name → value`, direction, priority) and
+a running count, mirroring the fixers' progress output.
+
+---
+
+## 8. Config / CLI surface and backward compatibility
+
+New options (added in `config.py`, exposed in `generic_cylinders.py`):
+
+| Option | Meaning |
+|---|---|
+| `--slamming-directives-file PATH` | the file (§5); **its presence activates the Slammer** |
+| `--slam-start-iter K` | first iteration at which slamming may occur |
+| `--iters-between-slams M` | cadence once started |
+
+**Activation & compatibility contract:**
+- The `Slammer` extension is added **iff `--slamming-directives-file` is
+  given.**
+- Supplying any *other* new slam option **without** the file is a **hard
+  error** ("slamming options require `--slamming-directives-file`").
+- With no slamming options, the extension is never constructed and
+  behavior is identical to today.
+- The existing `--slammin` / `--slammax` spoke flags are **untouched** and
+  independent; the new options are named so they cannot collide.
+
+---
+
+## 9. Plumbing
+
+- **`config.py`:** a `slamming_args()` method adding the options above
+  (following the pattern of the other `*_args` methods); reuse the
+  existing `rounding_bias` option for `anywhere` integer rounding.
+- **`cfg_vanilla.py`:** in the hub builder, when
+  `cfg.slamming_directives_file` is set, append `Slammer` to the hub's
+  extension list (via the existing `MultiExtension` mechanism, alongside
+  any other extensions).
+- **`generic_cylinders.py`:** register `slamming_args`; wire activation.
+- A small farmer/sizes example directives file under `examples/` plus a
+  doc page so the feature is discoverable.
+
+The directional-fix-and-update inner loop overlaps with
+`reduced_costs_fixer` / `relaxed_ph_fixer`; if it is clean to do so, factor
+a tiny shared helper (`fix nonant to value across all scenarios + persistent
+update`). Not required for correctness.
+
+---
+
+## 10. Interaction with existing features
+
+- **`fixer.py` and the other fixers:** coexist. A slammed variable is
+  `is_fixed()`, so every fixer's `is_fixed()` guard skips it; conversely a
+  fixer-fixed variable fails the slammer's eligibility test (§7.1). No
+  double-fixing.
+- **Modeler-fixed and surrogate nonants:** never slammed (§7.1), matching
+  the variable-probability surrogate-nonant contract.
+- **`SlamMin`/`SlamMax` spokes:** orthogonal. The spokes propose
+  incumbents; the slammer alters the hub search. A run may use both.
+- **Bundling:** the slammer operates on nonant indices, which bundling
+  preserves; reporting counts may need the same per-bundle care the
+  fixers take.
+
+---
+
+## 11. Phasing (each its own review-sized PR)
+
+**Phase 1 (this design):** the slammer mechanism — directives file
+(by-name + wildcards), the five+`nearest` directions, one-slam-per-event
+selection, iteration-count trigger, sticky slams, multistage, full
+backward compatibility. Plus example + docs + tests.
+
+**Phase 2:** a real **stall/cycle detector** implementing
+`should_slam(phiter)`, dropped into the trigger seam; and the **`unslam`**
+release logic the Phase 1 hook anticipates.
+
+**Phase 3 (optional):** batched / fraction-based slamming; PySP WW-syntax
+file importer; JSON file format.
+
+---
+
+## 12. Testing
+
+- **Parser/unit:** wildcard matching, last-match-wins precedence,
+  `can_slam=0` exceptions, unmatched ⇒ not slammable, bad-token /
+  zero-match validation.
+- **Action/unit:** each direction (`lb`/`ub`/`nearest`/`anywhere`/`min`/
+  `max`) fixes to the expected value; `anywhere` rounding honors
+  `rounding_bias`; infinite-bound directions are skipped.
+- **Determinism:** same nonant selected on every rank (run under
+  `mpiexec`).
+- **Backward compatibility:** an existing test invocation with no slamming
+  options produces identical results; supplying a slam option without the
+  file errors.
+- **Integration:** a small MIP (sizes / a netdes-like model) where
+  slamming demonstrably forces convergence the plain run does not reach in
+  the iteration budget.
+- Wire the new `mpisppy/tests/test_slammer.py` into `run_coverage.bash`
+  **and** `test_pr_and_main.yml` in the same commit.
+
+---
+
+## 13. Resolved decisions
+
+Settled in review (DLW, 2026-06-17); recorded here for provenance.
+
+1. **`priority` direction** — larger priority is slammed first. *Confirmed.*
+2. **`nearest` token** — kept as a convenience for "either bound, pick the
+   closer." *Confirmed.*
+3. **Convergence gate** — the proposed `--slam-only-unconverged` option is
+   **dropped**. Phase 1 slams strictly by priority with no convergence
+   test (§7.1); convergence-aware targeting, if wanted, belongs in the
+   Phase-2 stall detector.
+4. **One slam per event** in Phase 1; batched / priority-band slamming is a
+   later option (§7.2).

--- a/doc/designs/slamming_design.md
+++ b/doc/designs/slamming_design.md
@@ -158,10 +158,10 @@ organized as three independent layers so each can evolve separately:
 ```
    Trigger          Selection + preferences          Action
   (WHEN)      →        (WHO / WHERE)           →      (WHAT)
-  should_slam()      directive map from file        slam(ndn_i, dir)
+  iteration_for_slam()      directive map from file        slam(ndn_i, dir)
 ```
 
-**Trigger (`when`)** — a predicate `should_slam(phiter) -> bool`. Phase 1:
+**Trigger (`when`)** — a predicate `iteration_for_slam(phiter) -> bool`. Phase 1:
 iteration counting (§6). Phase 2: a stall detector implementing the same
 predicate. The rest of the extension never changes.
 
@@ -236,8 +236,12 @@ This is the requirement that only explicitly-specified variables can be
 slammed, and it is what makes the feature backward compatible.
 
 The file is parsed once and validated at startup: unknown direction
-tokens, unparseable priorities, and patterns that match **zero** nonants
-are reported (the last as a warning, gated on rank 0).
+tokens and unparseable priorities are errors at parse time, and a pattern
+that matches **zero** nonanticipative variables is a hard error naming the
+file (almost always a typo). Because each rank owns only some nodes, the
+per-pattern match is reduced across the hub before the check, so a pattern
+matched on another rank is not falsely flagged; the reduced result is
+identical on every rank, so all ranks raise together.
 
 ---
 
@@ -251,7 +255,7 @@ Two options drive the iteration-count trigger:
   iterations.
 
 ```python
-def should_slam(self, phiter):
+def iteration_for_slam(self, phiter):
     if phiter < self.slam_start_iter:
         return False
     return (phiter - self.slam_start_iter) % self.iters_between_slams == 0
@@ -261,7 +265,7 @@ Purely a function of the iteration counter, so it is identical on every
 rank with no communication.
 
 **Phase 2 seam.** The stall detector will implement the same
-`should_slam(phiter)` signature (reading the convergence history the hub
+`iteration_for_slam(phiter)` signature (reading the convergence history the hub
 already tracks). Swapping it in is a one-line change in `Slammer`; nothing
 else moves.
 
@@ -404,7 +408,7 @@ selection, iteration-count trigger, sticky slams, multistage, full
 backward compatibility. Plus example + docs + tests.
 
 **Phase 2:** a real **stall/cycle detector** implementing
-`should_slam(phiter)`, dropped into the trigger seam; and the **`unslam`**
+`iteration_for_slam(phiter)`, dropped into the trigger seam; and the **`unslam`**
 release logic the Phase 1 hook anticipates.
 
 **Phase 3 (optional):** batched / fraction-based slamming; PySP WW-syntax

--- a/doc/src/extensions.rst
+++ b/doc/src/extensions.rst
@@ -166,14 +166,16 @@ slammer
 ^^^^^^^
 
 This extension does preference-driven *slamming*: it forces (fixes) a
-non-converged nonanticipative variable according to pre-specified user
-preferences while the hub is running, to break a stall or cycle. Unlike the
-other fixers above -- which fix on *agreement* and so can infer a direction
-automatically -- slamming forces variables precisely *because* they are not
-settling, so the directions are supplied by the user in a directives file.
-(This is distinct from the
-``SlamMin`` / ``SlamMax`` *spokes*, which are non-destructive incumbent finders
-that never perturb the hub.)
+nonanticipative variable according to pre-specified user preferences while the
+hub is running, to break a stall or cycle. Unlike the other fixers above --
+which fix on *agreement* and so can infer a direction automatically -- slamming
+is meant for variables that are *not* settling, where there is no agreement to
+read a direction from, so the directions are supplied by the user in a
+directives file. This is the intended use rather than an enforced precondition:
+slamming does not test convergence per variable; any variable matched by a
+``can_slam`` rule is eligible (see the eligibility rules below). (Slamming is
+distinct from the ``SlamMin`` / ``SlamMax`` *spokes*, which are non-destructive
+incumbent finders that never perturb the hub.)
 
 From ``generic_cylinders.py`` the extension is activated **only** when a
 directives file is supplied, so a run with no slamming options behaves exactly

--- a/doc/src/extensions.rst
+++ b/doc/src/extensions.rst
@@ -166,11 +166,12 @@ slammer
 ^^^^^^^
 
 This extension does preference-driven *slamming*: it forces (fixes) a
-non-converged nonanticipative variable to a user-chosen value while the hub is
-running, to break a stall or cycle. Unlike the other fixers above -- which fix
-on *agreement* and so can infer a direction automatically -- slamming forces
-variables precisely *because* they are not settling, so the directions are
-supplied by the user in a directives file. (This is distinct from the
+non-converged nonanticipative variable according to pre-specified user
+preferences while the hub is running, to break a stall or cycle. Unlike the
+other fixers above -- which fix on *agreement* and so can infer a direction
+automatically -- slamming forces variables precisely *because* they are not
+settling, so the directions are supplied by the user in a directives file.
+(This is distinct from the
 ``SlamMin`` / ``SlamMax`` *spokes*, which are non-destructive incumbent finders
 that never perturb the hub.)
 
@@ -200,10 +201,50 @@ slammed. A multi-index name contains a comma and so must be quoted. A worked
 example translated from PySP ships at
 ``examples/sizes/config/slamming_directives.csv``.
 
-Phase 1 uses an iteration-count trigger and slams one variable per event;
-slams are sticky. See ``doc/designs/slamming_design.md`` for the full design,
-including the directions, the directives-file semantics, and the planned stall
-detector.
+The available ``directions``, and the value each fixes the variable to, are:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 15 85
+
+   * - Direction
+     - Value the variable is fixed to
+   * - ``lb``
+     - the variable's lower bound
+   * - ``ub``
+     - the variable's upper bound
+   * - ``nearest``
+     - whichever bound (``lb`` or ``ub``) the current consensus value ``xbar``
+       is closer to
+   * - ``anywhere``
+     - ``xbar`` itself, rounded to the nearest integer for integer and binary
+       variables (using ``--rounding-bias``)
+   * - ``min``
+     - the minimum of the variable's value across all scenarios that share its
+       scenario-tree node
+   * - ``max``
+     - the maximum of the variable's value across all scenarios that share its
+       scenario-tree node
+
+A direction is *applicable* only when it produces a finite value (for example,
+``lb`` is skipped for a variable that has no lower bound). The directions in a
+row are tried in order and the first applicable one is used; if none applies,
+that variable is not slammed at this event.
+
+Slamming is triggered by iteration count: no variable is slammed before
+``--slam-start-iter``, and from then on at most one variable is slammed every
+``--iters-between-slams`` iterations. At each such event the single eligible
+variable with the largest ``priority`` is slammed (ties are broken by name, so
+the choice is the same on every rank). A variable is eligible only if it is
+matched by a ``can_slam`` rule, is not already fixed (by the modeler or another
+fixer), and is not a surrogate variable. Once a variable is slammed it stays
+fixed for the remainder of the run.
+
+The directions ``lb``, ``ub``, ``nearest``, and ``anywhere`` use only data that
+is already identical on every rank, so they need no communication; ``min`` and
+``max`` perform a single small reduction across scenarios, and only when such a
+slam actually occurs. See ``doc/designs/slamming_design.md`` for design details
+and rationale.
 
 WXBarWriter and WXBarReader
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/src/extensions.rst
+++ b/doc/src/extensions.rst
@@ -199,9 +199,10 @@ out an exception), an ordered ``|``-separated list of ``directions`` from
 and a ``priority`` (the eligible nonant with the largest priority is slammed
 first). Matching is last-match-wins, so write broad defaults first and
 exceptions after; only variables matched by a ``can_slam`` rule are ever
-slammed. A multi-index name contains a comma and so must be quoted. A worked
-example translated from PySP ships at
-``examples/sizes/config/slamming_directives.csv``.
+slammed. A multi-index name contains a comma and so must be quoted. A pattern
+that matches no variable in the model is a hard error (it is almost always a
+typo) and the message names the file. A worked example translated from PySP
+ships at ``examples/sizes/config/slamming_directives.csv``.
 
 The available ``directions``, and the value each fixes the variable to, are:
 

--- a/doc/src/extensions.rst
+++ b/doc/src/extensions.rst
@@ -23,6 +23,7 @@ Many extensions are supported in :ref:`generic_cylinders` via
 command-line flags:
 
 - ``--fixer`` -- activates the fixer extension
+- ``--slamming-directives-file <file>`` -- activates the slammer extension
 - ``--mipgaps-json <file>`` -- activates the mipgapper extension
 - ``--user-defined-extensions <module>`` -- loads a custom extension
 - ``--grad-rho`` -- activates gradient-based rho (see :ref:`rho_setting`)
@@ -158,6 +159,51 @@ threshold is within 10\%  of the convergence tolerance.
 This extension can be especially effective if (1) solving the relaxation
 is much easier than solving the problem with integrality constraints or (2) the
 relaxation is reasonably "tight".
+
+.. _slammer:
+
+slammer
+^^^^^^^
+
+This extension does preference-driven *slamming*: it forces (fixes) a
+non-converged nonanticipative variable to a user-chosen value while the hub is
+running, to break a stall or cycle. Unlike the other fixers above -- which fix
+on *agreement* and so can infer a direction automatically -- slamming forces
+variables precisely *because* they are not settling, so the directions are
+supplied by the user in a directives file. (This is distinct from the
+``SlamMin`` / ``SlamMax`` *spokes*, which are non-destructive incumbent finders
+that never perturb the hub.)
+
+From ``generic_cylinders.py`` the extension is activated **only** when a
+directives file is supplied, so a run with no slamming options behaves exactly
+as it does today:
+
+- ``--slamming-directives-file <file>`` -- the directives file (its presence
+  activates the extension)
+- ``--slam-start-iter <K>`` -- first hub iteration at which slamming may occur
+  (default 1)
+- ``--iters-between-slams <M>`` -- once started, slam at most once every ``M``
+  iterations (default 1)
+
+Supplying ``--slam-start-iter`` or ``--iters-between-slams`` without the file is
+an error.
+
+The directives file is a CSV keyed by nonant name with shell-style wildcards
+(``*``/``?``; the index brackets ``[`` ``]`` are matched literally). Each row
+gives a name pattern, an optional ``can_slam`` flag (``1``/``0``; ``0`` carves
+out an exception), an ordered ``|``-separated list of ``directions`` from
+``{lb, ub, nearest, anywhere, min, max}`` (the first applicable one is used),
+and a ``priority`` (the eligible nonant with the largest priority is slammed
+first). Matching is last-match-wins, so write broad defaults first and
+exceptions after; only variables matched by a ``can_slam`` rule are ever
+slammed. A multi-index name contains a comma and so must be quoted. A worked
+example translated from PySP ships at
+``examples/sizes/config/slamming_directives.csv``.
+
+Phase 1 uses an iteration-count trigger and slams one variable per event;
+slams are sticky. See ``doc/designs/slamming_design.md`` for the full design,
+including the directions, the directives-file semantics, and the planned stall
+detector.
 
 WXBarWriter and WXBarReader
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/examples/sizes/config/slamming_directives.csv
+++ b/examples/sizes/config/slamming_directives.csv
@@ -1,0 +1,30 @@
+# Slamming directives for the sizes model.
+#
+# Modernized from the historical PySP WWPH suffix file (wwph.suffixes in this
+# directory): the production / cut variables are slow to converge, so when the
+# hub stalls we force them to their per-scenario maximum to break the cycle.
+#
+# Used by generic_cylinders.py via:
+#   --slamming-directives-file examples/sizes/config/slamming_directives.csv
+#   --slam-start-iter 100 --iters-between-slams 5
+# (matching PySP's SlamAfterIter=100, PH_Iters_Between_Cycle_Slams=5).
+#
+# Columns: name (wildcard pattern), can_slam (1/0), directions (|-separated),
+# priority (larger is slammed first).  Matching is last-match-wins, so the
+# broad rules come first and the per-index priorities override them.
+#
+# NOTE: a multi-index name like NumUnitsCutFirstStage[*,*] contains a comma, so
+# it must be quoted to keep the CSV from splitting it (standard CSV quoting).
+name,can_slam,directions,priority
+NumProducedFirstStage[*],1,max,5
+"NumUnitsCutFirstStage[*,*]",1,max,10
+NumProducedFirstStage[1],1,max,1
+NumProducedFirstStage[2],1,max,2
+NumProducedFirstStage[3],1,max,3
+NumProducedFirstStage[4],1,max,4
+NumProducedFirstStage[5],1,max,5
+NumProducedFirstStage[6],1,max,6
+NumProducedFirstStage[7],1,max,7
+NumProducedFirstStage[8],1,max,8
+NumProducedFirstStage[9],1,max,9
+NumProducedFirstStage[10],1,max,10

--- a/mpisppy/extensions/slammer.py
+++ b/mpisppy/extensions/slammer.py
@@ -40,6 +40,7 @@ import csv
 import math
 import re
 
+import numpy as np
 import pyomo.environ as pyo
 
 import mpisppy.MPI as MPI
@@ -226,6 +227,8 @@ class Slammer(Extension):
     def __init__(self, spobj):
         super().__init__(spobj)
         opts = spobj.options.get("slammer_options", {})
+        # Kept for error messages; None when directives are passed in directly.
+        self._directives_file = opts.get("directives_file")
         if "directives" in opts:
             self.directives = opts["directives"]
         else:
@@ -248,7 +251,7 @@ class Slammer(Extension):
     # ------------------------------------------------------------------ #
     # Trigger layer (WHEN)
     # ------------------------------------------------------------------ #
-    def should_slam(self, phiter):
+    def iteration_for_slam(self, phiter):
         """Whether to slam at hub iteration ``phiter``: at or after
         ``slam_start_iter``, then once every ``iters_between_slams`` iterations.
         A pure function of the iteration counter, so it is identical on every
@@ -264,7 +267,8 @@ class Slammer(Extension):
         """Build the eligibility map by matching each nonant's name against the
         directives.  The same nonant has the same ``xvar.name`` in every
         scenario, so one representative scenario suffices and the map is
-        scenario-independent and multistage-clean."""
+        scenario-independent and multistage-clean.  Raises ``ValueError`` (on
+        every rank) if any directive pattern matches no nonant anywhere."""
         rep = self.opt.local_scenarios[self.opt.local_scenario_names[0]]
         local_names = []
         for ndn_i, xvar in rep._mpisppy_data.nonant_indices.items():
@@ -278,24 +282,35 @@ class Slammer(Extension):
             if d is not None and d.can_slam:
                 self._directive_of[ndn_i] = d
 
-        # Warn (rank 0) about patterns that match no local nonant; usually a
-        # typo.  Gated on rank 0 per the design; in a multi-rank multistage run
-        # rank 0 may not own every node, so this is advisory only.
-        if self.opt.cylinder_rank == 0:
-            import warnings
-            for d in self.directives:
-                if not any(d.matches(nm) for nm in local_names):
-                    warnings.warn(
-                        f"slamming directive pattern {d.pattern!r} matched no "
-                        "nonanticipative variable",
-                        UserWarning, stacklevel=2)
+        # A directive pattern that matches no nonanticipative variable anywhere
+        # is almost always a typo, so it is a hard error.  Each rank sees only
+        # the nonants of the nodes it owns, so reduce the per-directive match
+        # flags across the hub (ROOT spans every hub rank); a pattern matched on
+        # some other rank is then not falsely flagged (this matters for
+        # multistage).  The reduced result is identical on every rank, so all
+        # ranks raise together.
+        local_match = np.array(
+            [1 if any(d.matches(nm) for nm in local_names) else 0
+             for d in self.directives], 'i')
+        global_match = np.zeros(len(self.directives), 'i')
+        self.opt.comms["ROOT"].Allreduce(
+            [local_match, MPI.INT], [global_match, MPI.INT], op=MPI.MAX)
+        unmatched = [d.pattern for d, hit in zip(self.directives, global_match)
+                     if not hit]
+        if unmatched:
+            where = f" in {self._directives_file}" if self._directives_file \
+                    else ""
+            raise ValueError(
+                f"slamming directives{where}: pattern(s) matched no "
+                "nonanticipative variable: "
+                f"{', '.join(repr(p) for p in unmatched)}")
 
     # ------------------------------------------------------------------ #
     # Action layer (WHAT)
     # ------------------------------------------------------------------ #
     def miditer(self):
         phiter = self.opt._PHIter
-        if not self.should_slam(phiter):
+        if not self.iteration_for_slam(phiter):
             return
         self._slam_one()
 
@@ -397,7 +412,6 @@ class Slammer(Extension):
                 local = v
             else:
                 local = min(local, v) if direction == "min" else max(local, v)
-        import numpy as np
         local_arr = np.array([local], dtype="d")
         global_arr = np.empty(1, dtype="d")
         self.opt.comms[ndn].Allreduce(

--- a/mpisppy/extensions/slammer.py
+++ b/mpisppy/extensions/slammer.py
@@ -1,0 +1,416 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+"""Preference-driven in-hub slamming.
+
+Slamming forces (fixes) a non-converged nonanticipative variable to a
+user-chosen value while a decomposition hub is running, to drive toward a
+feasible / converged incumbent when ordinary convergence is slow.  Unlike the
+other in-hub fixers (``fixer.py``, ``reduced_costs_fixer.py``,
+``relaxed_ph_fixer.py``), which fix on *agreement* and so can infer a direction
+automatically, slamming forces *non-converged* variables and therefore needs
+*user-supplied* direction preferences.  Those preferences come from a directives
+file (see :func:`parse_directives_file`).
+
+See ``doc/designs/slamming_design.md`` for the full design.  This is the
+Phase-1 mechanism: an iteration-count trigger, one slam per event, sticky
+slams, full backward compatibility.  The ``Slammer`` is added to a hub only
+when ``--slamming-directives-file`` is supplied; with no slamming options a run
+behaves exactly as it does today.
+
+The ``Slammer`` is distinct from the ``SlamMin`` / ``SlamMax`` *spokes* in
+``mpisppy/cylinders/slam_heuristic.py``: those are non-destructive incumbent
+finders that fix *all* nonants to a per-variable extremum and never perturb the
+hub; the ``Slammer`` alters the hub search per user preference.
+"""
+
+import csv
+import math
+import re
+
+import pyomo.environ as pyo
+
+import mpisppy.MPI as MPI
+from mpisppy.extensions.extension import Extension
+from mpisppy.utils.sputils import is_persistent
+
+
+# Ordered set of legal direction tokens (see the design, §3).
+VALID_DIRECTIONS = ("lb", "ub", "nearest", "anywhere", "min", "max")
+
+
+def _compile_glob(pattern):
+    """Compile a shell-style name pattern into a regex.
+
+    ``*`` matches any run of characters and ``?`` matches exactly one; every
+    other character -- crucially including ``[`` and ``]`` -- is literal.  This
+    is deliberately *not* :mod:`fnmatch`: nonant names are indexed Pyomo names
+    such as ``DoBuild[Seattle]``, and ``fnmatch`` would read the brackets as a
+    character class, so ``DoBuild[*]`` would fail to match.  Here the brackets
+    are literal, so ``DoBuild[*]`` matches every ``DoBuild[...]`` as intended.
+    """
+    out = []
+    for ch in pattern:
+        if ch == "*":
+            out.append(".*")
+        elif ch == "?":
+            out.append(".")
+        else:
+            out.append(re.escape(ch))
+    return re.compile("".join(out), re.DOTALL)
+
+
+class SlamDirective:
+    """One parsed row of a directives file.
+
+    Attributes:
+        pattern (str): a shell-style name pattern (``*``/``?`` wildcards, with
+            ``[``/``]`` literal) matched against ``xvar.name`` (see
+            :func:`_compile_glob`).
+        can_slam (bool): whether matched variables may be slammed.
+        directions (tuple): ordered direction tokens; the first *applicable*
+            one is used (see :data:`VALID_DIRECTIONS`).
+        priority (float): larger priority is slammed first; ties broken by name.
+    """
+    __slots__ = ("pattern", "can_slam", "directions", "priority", "_regex")
+
+    def __init__(self, pattern, can_slam, directions, priority):
+        self.pattern = pattern
+        self.can_slam = can_slam
+        self.directions = tuple(directions)
+        self.priority = priority
+        self._regex = _compile_glob(pattern)
+
+    def matches(self, name):
+        """True if ``name`` matches this directive's pattern in full."""
+        return self._regex.fullmatch(name) is not None
+
+    def __repr__(self):
+        return (f"SlamDirective(pattern={self.pattern!r}, "
+                f"can_slam={self.can_slam}, directions={self.directions}, "
+                f"priority={self.priority})")
+
+
+def _parse_can_slam(raw):
+    token = raw.strip().lower()
+    if token in ("", "1", "true", "yes"):
+        return True
+    if token in ("0", "false", "no"):
+        return False
+    raise ValueError(f"slamming directives: cannot parse can_slam value {raw!r} "
+                     "(expected 0/1)")
+
+
+def _parse_directions(raw):
+    tokens = [t.strip().lower() for t in raw.split("|") if t.strip() != ""]
+    for t in tokens:
+        if t not in VALID_DIRECTIONS:
+            raise ValueError(
+                f"slamming directives: unknown direction token {t!r} "
+                f"(legal tokens: {', '.join(VALID_DIRECTIONS)})")
+    return tuple(tokens)
+
+
+def parse_directives_file(path):
+    """Parse a slamming directives CSV into a list of :class:`SlamDirective`.
+
+    The file is keyed by nonant name with wildcards.  Columns:
+
+    ``name`` (required)
+        shell-style pattern (``*``/``?`` wildcards; ``[``/``]`` literal) matched
+        against ``xvar.name`` (e.g. ``DoBuild[*]``); see :func:`_compile_glob`.
+        A multi-index name contains a comma (e.g. ``Cut[*,*]``) and so must be
+        quoted to survive the CSV split (standard CSV quoting).
+    ``can_slam`` (optional; default ``1``)
+        ``1``/``0``; ``0`` carves out an exception so matched variables are
+        never slammed.
+    ``directions`` (required unless ``can_slam`` is ``0``)
+        ``|``-separated ordered list drawn from :data:`VALID_DIRECTIONS`.
+    ``priority`` (optional; default ``0``)
+        float; the eligible nonant with the largest priority is slammed first.
+
+    Rows are returned in file order; matching is **last-match-wins** so write
+    broad defaults first and exceptions after.  Blank lines and whole-line
+    comments (starting with ``#``) are ignored anywhere, including before the
+    header.
+
+    Raises:
+        ValueError: on a missing ``name`` column, an unknown direction token,
+            an unparseable ``can_slam``/``priority``, or a ``can_slam=1`` row
+            with no directions.
+    """
+    with open(path, "r", newline="") as f:
+        raw_lines = f.readlines()
+
+    # Drop blank lines and whole-line '#' comments, but remember each kept
+    # line's original 1-based number for error messages.
+    kept = [(i, line) for i, line in enumerate(raw_lines, start=1)
+            if line.strip() != "" and not line.strip().startswith("#")]
+    if not kept:
+        raise ValueError(
+            f"slamming directives file {path!r} has no header row")
+
+    reader = csv.DictReader([line for _, line in kept])
+    if reader.fieldnames is None or "name" not in reader.fieldnames:
+        raise ValueError(
+            f"slamming directives file {path!r} must have a 'name' column")
+
+    directives = []
+    # DictReader consumes kept[0] as the header, so kept[1:] aligns with rows.
+    for (lineno, _), row in zip(kept[1:], reader):
+        pattern = (row.get("name") or "").strip()
+        if pattern == "":
+            continue  # tolerate a stray empty name field
+        try:
+            can_slam = _parse_can_slam(row.get("can_slam") or "")
+            directions = _parse_directions(row.get("directions") or "")
+            priority_raw = (row.get("priority") or "").strip()
+            priority = float(priority_raw) if priority_raw != "" else 0.0
+        except ValueError as e:
+            raise ValueError(f"{path}:{lineno}: {e}") from None
+        if can_slam and len(directions) == 0:
+            raise ValueError(
+                f"{path}:{lineno}: row for {pattern!r} has can_slam=1 but "
+                "no directions")
+        directives.append(
+            SlamDirective(pattern, can_slam, directions, priority))
+    return directives
+
+
+def resolve_directive(directives, name):
+    """Return the last :class:`SlamDirective` matching ``name``, else ``None``.
+
+    Last-match-wins (gitignore-style): a later row overrides an earlier one.
+    """
+    match = None
+    for d in directives:
+        if d.matches(name):
+            match = d
+    return match
+
+
+def _finite(x):
+    return x is not None and math.isfinite(x)
+
+
+class Slammer(Extension):
+    """Preference-driven in-hub slammer (Phase 1).
+
+    Constructed from ``opt.options["slammer_options"]``, a dict with keys:
+
+    ``directives`` or ``directives_file``
+        a pre-parsed list of :class:`SlamDirective` (used directly) or a path
+        to a CSV parsed with :func:`parse_directives_file`.
+    ``slam_start_iter`` (int, default 1)
+        first hub iteration at which slamming may occur.
+    ``iters_between_slams`` (int, default 1)
+        cadence once started; slam at most once every this many iterations.
+    ``rounding_bias`` (float, default 0.0)
+        added before rounding integer variables (matches the slam spokes).
+    ``verbose`` (bool, default False)
+        report each slam on rank 0.
+    """
+
+    def __init__(self, spobj):
+        super().__init__(spobj)
+        opts = spobj.options.get("slammer_options", {})
+        if "directives" in opts:
+            self.directives = opts["directives"]
+        else:
+            self.directives = parse_directives_file(opts["directives_file"])
+        self.slam_start_iter = opts.get("slam_start_iter", 1)
+        self.iters_between_slams = opts.get("iters_between_slams", 1)
+        if self.iters_between_slams < 1:
+            raise ValueError("iters_between_slams must be a positive integer")
+        self.rounding_bias = opts.get("rounding_bias", 0.0)
+        self.verbose = opts.get("verbose", False)
+
+        # (ndn, i) -> value, for every slam done so far (sticky in Phase 1).
+        # Also the seam for the Phase-2 unslam hook.
+        self._slammed = {}
+        # Built in pre_iter0(): the eligibility map and bookkeeping.
+        self._directive_of = {}   # (ndn, i) -> SlamDirective (can_slam only)
+        self._name_of = {}        # (ndn, i) -> xvar.name
+        self._modeler_fixed = set()
+
+    # ------------------------------------------------------------------ #
+    # Trigger layer (WHEN)
+    # ------------------------------------------------------------------ #
+    def should_slam(self, phiter):
+        """Phase-1 trigger: a pure function of the iteration counter, so it is
+        identical on every rank with no communication.  Phase 2 will drop a
+        stall detector into this same predicate."""
+        if phiter < self.slam_start_iter:
+            return False
+        return (phiter - self.slam_start_iter) % self.iters_between_slams == 0
+
+    # ------------------------------------------------------------------ #
+    # Preferences layer (WHO / WHERE)
+    # ------------------------------------------------------------------ #
+    def pre_iter0(self):
+        """Build the eligibility map by matching each nonant's name against the
+        directives.  The same nonant has the same ``xvar.name`` in every
+        scenario, so one representative scenario suffices and the map is
+        scenario-independent and multistage-clean."""
+        rep = self.opt.local_scenarios[self.opt.local_scenario_names[0]]
+        local_names = []
+        for ndn_i, xvar in rep._mpisppy_data.nonant_indices.items():
+            name = xvar.name
+            self._name_of[ndn_i] = name
+            local_names.append(name)
+            if xvar.fixed:
+                self._modeler_fixed.add(ndn_i)
+                continue  # modeler-fixed nonants are never slammed
+            d = resolve_directive(self.directives, name)
+            if d is not None and d.can_slam:
+                self._directive_of[ndn_i] = d
+
+        # Warn (rank 0) about patterns that match no local nonant; usually a
+        # typo.  Gated on rank 0 per the design; in a multi-rank multistage run
+        # rank 0 may not own every node, so this is advisory only.
+        if self.opt.cylinder_rank == 0:
+            import warnings
+            for d in self.directives:
+                if not any(d.matches(nm) for nm in local_names):
+                    warnings.warn(
+                        f"slamming directive pattern {d.pattern!r} matched no "
+                        "nonanticipative variable",
+                        UserWarning, stacklevel=2)
+
+    # ------------------------------------------------------------------ #
+    # Action layer (WHAT)
+    # ------------------------------------------------------------------ #
+    def miditer(self):
+        phiter = self.opt._PHIter
+        if not self.should_slam(phiter):
+            return
+        self._slam_one()
+
+    def _slam_one(self):
+        """Select the highest-priority eligible nonant and slam it.
+
+        Selection uses only globally-consistent inputs (file-supplied priority
+        and name; the fixed mask, which is coherent because slamming/fixing is
+        applied to all scenarios on all ranks), so every rank picks the same
+        nonant with no communication.  This holds when the nonant catalog is
+        rank-coherent (two-stage, or single-rank multistage).  A cross-rank
+        selection reduction for node-split multistage is a Phase-2 seam.
+        """
+        rep = self.opt.local_scenarios[self.opt.local_scenario_names[0]]
+        surrogates = rep._mpisppy_data.all_surrogate_nonants
+
+        best = None        # (ndn_i, direction, value)
+        best_key = None    # (priority, name) for max-priority, name-tiebreak
+        for ndn_i, d in self._directive_of.items():
+            if ndn_i in self._slammed:
+                continue
+            xvar = rep._mpisppy_data.nonant_indices[ndn_i]
+            if xvar.fixed:
+                continue
+            if xvar in surrogates:
+                continue
+            choice = self._first_applicable_direction(rep, ndn_i, d.directions)
+            if choice is None:
+                continue  # no applicable direction -> not eligible this event
+            name = self._name_of[ndn_i]
+            # Largest priority wins; ties broken by name (ascending) so the
+            # choice is deterministic and identical across ranks.
+            key = (d.priority, name)
+            if best_key is None or key[0] > best_key[0] \
+               or (key[0] == best_key[0] and key[1] < best_key[1]):
+                best = (ndn_i, choice[0], choice[1])
+                best_key = key
+
+        if best is None:
+            return  # nothing eligible this event
+
+        ndn_i, direction, value = best
+        if direction in ("min", "max"):
+            value = self._node_extremum(ndn_i, direction)
+            xvar = rep._mpisppy_data.nonant_indices[ndn_i]
+            if xvar.is_binary() or xvar.is_integer():
+                value = round(value + self.rounding_bias)
+
+        self._fix_everywhere(ndn_i, value)
+        self._slammed[ndn_i] = value
+        self._report(self._name_of[ndn_i], value, direction, best_key[0])
+
+    def _first_applicable_direction(self, scenario, ndn_i, directions):
+        """Return ``(direction, value)`` for the first applicable direction, or
+        ``None`` if none applies.  For ``min``/``max`` the value is deferred
+        (returned as ``None``) and computed by a reduction only if this nonant
+        is the one actually slammed (see :meth:`_node_extremum`)."""
+        xvar = scenario._mpisppy_data.nonant_indices[ndn_i]
+        is_int = xvar.is_binary() or xvar.is_integer()
+        for direction in directions:
+            if direction == "lb":
+                if _finite(xvar.lb):
+                    return ("lb", xvar.lb)
+            elif direction == "ub":
+                if _finite(xvar.ub):
+                    return ("ub", xvar.ub)
+            elif direction == "nearest":
+                lb_ok, ub_ok = _finite(xvar.lb), _finite(xvar.ub)
+                if lb_ok or ub_ok:
+                    xb = pyo.value(scenario._mpisppy_model.xbars[ndn_i])
+                    if lb_ok and ub_ok:
+                        val = xvar.lb if abs(xb - xvar.lb) <= abs(xvar.ub - xb) \
+                              else xvar.ub
+                    else:
+                        val = xvar.lb if lb_ok else xvar.ub
+                    return ("nearest", val)
+            elif direction == "anywhere":
+                xb = pyo.value(scenario._mpisppy_model.xbars[ndn_i])
+                if _finite(xb):
+                    val = round(xb + self.rounding_bias) if is_int else xb
+                    return ("anywhere", val)
+            elif direction in ("min", "max"):
+                # A solved variable's value is always finite, so min/max is
+                # always applicable; the actual extremum is reduced later.
+                return (direction, None)
+        return None
+
+    def _node_extremum(self, ndn_i, direction):
+        """min/max of the selected variable's value across all scenarios at its
+        node, reduced over the per-node communicator the hub already uses for
+        x-bar.  Paid only when a min/max slam actually fires."""
+        ndn = ndn_i[0]
+        op = MPI.MIN if direction == "min" else MPI.MAX
+        local = None
+        for s in self.opt.local_scenarios.values():
+            v = pyo.value(s._mpisppy_data.nonant_indices[ndn_i])
+            if local is None:
+                local = v
+            else:
+                local = min(local, v) if direction == "min" else max(local, v)
+        import numpy as np
+        local_arr = np.array([local], dtype="d")
+        global_arr = np.empty(1, dtype="d")
+        self.opt.comms[ndn].Allreduce(
+            [local_arr, MPI.DOUBLE], [global_arr, MPI.DOUBLE], op=op)
+        return float(global_arr[0])
+
+    def _fix_everywhere(self, ndn_i, value):
+        """Fix the nonant to ``value`` in every local scenario and push the
+        change to any persistent solver."""
+        for s in self.opt.local_scenarios.values():
+            xvar = s._mpisppy_data.nonant_indices[ndn_i]
+            xvar.fix(value)
+            if is_persistent(s._solver_plugin):
+                s._solver_plugin.update_var(xvar)
+
+    def _report(self, name, value, direction, priority):
+        if self.verbose and self.opt.cylinder_rank == 0:
+            print(f"(rank0) Slammer: slammed {name} to {value} via "
+                  f"'{direction}' (priority {priority}); "
+                  f"total slammed = {len(self._slammed)}")
+
+    def post_everything(self):
+        if self.verbose and self.opt.cylinder_rank == 0:
+            print(f"(rank0) Slammer: final count of nonants slammed = "
+                  f"{len(self._slammed)}")

--- a/mpisppy/extensions/slammer.py
+++ b/mpisppy/extensions/slammer.py
@@ -249,9 +249,10 @@ class Slammer(Extension):
     # Trigger layer (WHEN)
     # ------------------------------------------------------------------ #
     def should_slam(self, phiter):
-        """Iteration-count trigger: a pure function of the iteration counter, so
-        it is identical on every rank with no communication.  A future stall
-        detector can replace this predicate without touching the rest."""
+        """Whether to slam at hub iteration ``phiter``: at or after
+        ``slam_start_iter``, then once every ``iters_between_slams`` iterations.
+        A pure function of the iteration counter, so it is identical on every
+        rank with no communication."""
         if phiter < self.slam_start_iter:
             return False
         return (phiter - self.slam_start_iter) % self.iters_between_slams == 0

--- a/mpisppy/extensions/slammer.py
+++ b/mpisppy/extensions/slammer.py
@@ -8,20 +8,21 @@
 ###############################################################################
 """Preference-driven in-hub slamming.
 
-Slamming forces (fixes) a non-converged nonanticipative variable to a
-user-chosen value while a decomposition hub is running, to drive toward a
-feasible / converged incumbent when ordinary convergence is slow.  Unlike the
+Slamming forces (fixes) a non-converged nonanticipative variable according to
+pre-specified user preferences while a decomposition hub is running, to drive
+toward a feasible / converged incumbent when ordinary convergence is slow.  Unlike the
 other in-hub fixers (``fixer.py``, ``reduced_costs_fixer.py``,
 ``relaxed_ph_fixer.py``), which fix on *agreement* and so can infer a direction
 automatically, slamming forces *non-converged* variables and therefore needs
 *user-supplied* direction preferences.  Those preferences come from a directives
 file (see :func:`parse_directives_file`).
 
-See ``doc/designs/slamming_design.md`` for the full design.  This is the
-Phase-1 mechanism: an iteration-count trigger, one slam per event, sticky
-slams, full backward compatibility.  The ``Slammer`` is added to a hub only
-when ``--slamming-directives-file`` is supplied; with no slamming options a run
-behaves exactly as it does today.
+The trigger is an iteration count (slam after a start iteration, then once
+every so many iterations); one variable is slammed per event and the slam is
+sticky.  The ``Slammer`` is added to a hub only when
+``--slamming-directives-file`` is supplied; with no slamming options a run
+behaves exactly as it does today.  See ``doc/designs/slamming_design.md`` for
+design details and rationale.
 
 The ``Slammer`` is distinct from the ``SlamMin`` / ``SlamMax`` *spokes* in
 ``mpisppy/cylinders/slam_heuristic.py``: those are non-destructive incumbent
@@ -199,7 +200,7 @@ def _finite(x):
 
 
 class Slammer(Extension):
-    """Preference-driven in-hub slammer (Phase 1).
+    """Preference-driven in-hub slammer.
 
     Constructed from ``opt.options["slammer_options"]``, a dict with keys:
 
@@ -230,8 +231,8 @@ class Slammer(Extension):
         self.rounding_bias = opts.get("rounding_bias", 0.0)
         self.verbose = opts.get("verbose", False)
 
-        # (ndn, i) -> value, for every slam done so far (sticky in Phase 1).
-        # Also the seam for the Phase-2 unslam hook.
+        # (ndn, i) -> value, for every slam done so far.  Slams are sticky:
+        # this also records what would have to be released to ever un-slam.
         self._slammed = {}
         # Built in pre_iter0(): the eligibility map and bookkeeping.
         self._directive_of = {}   # (ndn, i) -> SlamDirective (can_slam only)
@@ -242,9 +243,9 @@ class Slammer(Extension):
     # Trigger layer (WHEN)
     # ------------------------------------------------------------------ #
     def should_slam(self, phiter):
-        """Phase-1 trigger: a pure function of the iteration counter, so it is
-        identical on every rank with no communication.  Phase 2 will drop a
-        stall detector into this same predicate."""
+        """Iteration-count trigger: a pure function of the iteration counter, so
+        it is identical on every rank with no communication.  A future stall
+        detector can replace this predicate without touching the rest."""
         if phiter < self.slam_start_iter:
             return False
         return (phiter - self.slam_start_iter) % self.iters_between_slams == 0
@@ -298,8 +299,9 @@ class Slammer(Extension):
         and name; the fixed mask, which is coherent because slamming/fixing is
         applied to all scenarios on all ranks), so every rank picks the same
         nonant with no communication.  This holds when the nonant catalog is
-        rank-coherent (two-stage, or single-rank multistage).  A cross-rank
-        selection reduction for node-split multistage is a Phase-2 seam.
+        rank-coherent (two-stage, or single-rank multistage); node-split
+        multistage would need a cross-rank reduction to agree on the selection,
+        which is not done here.
         """
         rep = self.opt.local_scenarios[self.opt.local_scenario_names[0]]
         surrogates = rep._mpisppy_data.all_surrogate_nonants

--- a/mpisppy/extensions/slammer.py
+++ b/mpisppy/extensions/slammer.py
@@ -8,14 +8,20 @@
 ###############################################################################
 """Preference-driven in-hub slamming.
 
-Slamming forces (fixes) a non-converged nonanticipative variable according to
-pre-specified user preferences while a decomposition hub is running, to drive
-toward a feasible / converged incumbent when ordinary convergence is slow.  Unlike the
+Slamming forces (fixes) a nonanticipative variable according to pre-specified
+user preferences while a decomposition hub is running, to drive toward a
+feasible / converged incumbent when ordinary convergence is slow.  Unlike the
 other in-hub fixers (``fixer.py``, ``reduced_costs_fixer.py``,
-``relaxed_ph_fixer.py``), which fix on *agreement* and so can infer a direction
-automatically, slamming forces *non-converged* variables and therefore needs
-*user-supplied* direction preferences.  Those preferences come from a directives
-file (see :func:`parse_directives_file`).
+``relaxed_ph_fixer.py``), which fix a variable once its scenarios *agree* and so
+can infer a direction automatically, slamming is meant for variables that are
+*not* settling -- where there is no agreement to read a direction from -- which
+is why it needs *user-supplied* direction preferences.  Those preferences come
+from a directives file (see :func:`parse_directives_file`).
+
+This "not settling" framing is the intended use, not an enforced precondition:
+slamming does not test convergence per variable.  Any variable matched by a
+``can_slam`` rule is eligible whether or not its scenarios already agree --
+slamming an already-settled variable simply pins it where it was heading.
 
 The trigger is an iteration count (slam after a start iteration, then once
 every so many iterations); one variable is slammed per event and the slam is

--- a/mpisppy/generic/extensions.py
+++ b/mpisppy/generic/extensions.py
@@ -42,6 +42,9 @@ def configure_extensions(hub_dict, module, cfg):
     if cfg.integer_relax_then_enforce:
         vanilla.add_integer_relax_then_enforce(hub_dict, cfg)
 
+    if cfg.slamming_directives_file is not None:
+        vanilla.add_slammer(hub_dict, cfg)
+
     if cfg.grad_rho:
         from mpisppy.extensions.grad_rho import GradRho
         ext_classes.append(GradRho)

--- a/mpisppy/generic/parsing.py
+++ b/mpisppy/generic/parsing.py
@@ -134,6 +134,7 @@ def parse_args(m):
     cfg.fixer_args()
     cfg.relaxed_ph_fixer_args()
     cfg.integer_relax_then_enforce_args()
+    cfg.slamming_args()
     cfg.gapper_args()
     cfg.gapper_args(name="lagrangian")
     cfg.ph_primal_args()

--- a/mpisppy/tests/test_slammer.py
+++ b/mpisppy/tests/test_slammer.py
@@ -27,7 +27,6 @@ import os
 import tempfile
 import types
 import unittest
-import warnings
 
 import pyomo.environ as pyo
 from pyomo.common.collections import ComponentSet
@@ -105,8 +104,21 @@ class _FakeComm:
         recvbuf[0][:] = sendbuf[0]
 
 
+def _make_opt(scenarios, slammer_options):
+    """A fake opt carrying the given scenarios and slammer options."""
+    opt = types.SimpleNamespace(
+        cylinder_rank=0,
+        _PHIter=1,
+        comms={NDN: _FakeComm()},
+        local_scenarios={f"Scen{i+1}": s for i, s in enumerate(scenarios)},
+        options={"slammer_options": slammer_options},
+    )
+    opt.local_scenario_names = list(opt.local_scenarios.keys())
+    return opt
+
+
 def _build(directives, scenario_specs, slam_start_iter=1, iters_between_slams=1,
-           rounding_bias=0.0, suppress_warnings=True):
+           rounding_bias=0.0):
     """Build (ext, opt, models) from directives and a list of scenarios, each a
     list of var specs.  pre_iter0() is called so the eligibility map is ready."""
     models, scenarios = [], []
@@ -115,28 +127,16 @@ def _build(directives, scenario_specs, slam_start_iter=1, iters_between_slams=1,
         models.append(m)
         scenarios.append(sc)
 
-    opt = types.SimpleNamespace(
-        cylinder_rank=0,
-        _PHIter=1,
-        comms={NDN: _FakeComm()},
-        local_scenarios={f"Scen{i+1}": s for i, s in enumerate(scenarios)},
-        options={"slammer_options": {
-            "directives": directives,
-            "slam_start_iter": slam_start_iter,
-            "iters_between_slams": iters_between_slams,
-            "rounding_bias": rounding_bias,
-            "verbose": False,
-        }},
-    )
-    opt.local_scenario_names = list(opt.local_scenarios.keys())
+    opt = _make_opt(scenarios, {
+        "directives": directives,
+        "slam_start_iter": slam_start_iter,
+        "iters_between_slams": iters_between_slams,
+        "rounding_bias": rounding_bias,
+        "verbose": False,
+    })
 
     ext = Slammer(opt)
-    if suppress_warnings:
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            ext.pre_iter0()
-    else:
-        ext.pre_iter0()
+    ext.pre_iter0()
     return ext, opt, models
 
 
@@ -459,35 +459,63 @@ class Test_selection(unittest.TestCase):
         self.assertEqual(_var(models, 0, 0).value, 7.0)  # left alone
 
     def test_unmatched_nonant_never_slammed(self):
-        ds = [SlamDirective("other[*]", True, ("lb",), 1.0)]
-        ext, _, models = _build(ds, [[{"lb": 1.0, "ub": 9.0, "value": 5.0}]])
+        # v[1] is matched by no rule -> never slammed (the coverage default)
+        ds = [SlamDirective("v[0]", True, ("lb",), 1.0)]
+        ext, _, models = _build(ds, [[
+            {"lb": 1.0, "ub": 9.0, "value": 5.0},
+            {"lb": 2.0, "ub": 9.0, "value": 5.0},
+        ]])
         ext._slam_one()
-        self.assertFalse(_var(models, 0, 0).fixed)
+        self.assertTrue(_var(models, 0, 0).fixed)    # v[0] matched -> slammed
+        self.assertFalse(_var(models, 0, 1).fixed)   # v[1] unmatched -> never
 
-    def test_zero_match_pattern_warns(self):
-        # a pattern matching no nonant is almost always a typo -> warn (rank 0)
+
+class Test_zero_match(unittest.TestCase):
+    def test_zero_match_pattern_errors(self):
+        # a pattern matching no nonant is almost always a typo -> hard error
         ds = [SlamDirective("typo[*]", True, ("lb",), 1.0)]
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            _build(ds, [[{"lb": 1.0, "ub": 9.0, "value": 5.0}]],
-                   suppress_warnings=False)
-        self.assertTrue(any(issubclass(w.category, UserWarning) and
-                            "typo[*]" in str(w.message) for w in caught))
+        with self.assertRaises(ValueError):
+            _build(ds, [[{"lb": 1.0, "ub": 9.0, "value": 5.0}]])
+
+    def test_error_names_the_directives_file(self):
+        path = _write_csv("name,directions\ntypo[*],lb\n")
+        try:
+            _m, sc = _make_scenario([{"lb": 1.0, "ub": 9.0, "value": 5.0}])
+            opt = _make_opt([sc], {"directives_file": path})
+            ext = Slammer(opt)
+            with self.assertRaises(ValueError) as cm:
+                ext.pre_iter0()
+            self.assertIn(path, str(cm.exception))
+        finally:
+            os.remove(path)
+
+    def test_pattern_matched_on_another_rank_is_ok(self):
+        # a pattern that matches no *local* nonant but is reported as matched by
+        # the cross-rank reduction must not error (simulated via the fake comm)
+        class _OrComm:
+            def Allreduce(self, sendbuf, recvbuf, op=None):
+                recvbuf[0][:] = 1  # some other rank matched everything
+        ds = [SlamDirective("only_elsewhere[*]", True, ("lb",), 1.0)]
+        _m, sc = _make_scenario([{"lb": 1.0, "ub": 9.0, "value": 5.0}])
+        opt = _make_opt([sc], {"directives": ds})
+        opt.comms[NDN] = _OrComm()
+        ext = Slammer(opt)
+        ext.pre_iter0()  # must not raise
 
 
 # --------------------------------------------------------------------------- #
 # trigger + config (backward compatibility contract)
 # --------------------------------------------------------------------------- #
 class Test_trigger(unittest.TestCase):
-    def test_should_slam_predicate(self):
+    def test_iteration_for_slam_predicate(self):
         ds = [SlamDirective("v[*]", True, ("lb",), 1.0)]
         ext, _, _ = _build(ds, [[{"lb": 0.0, "ub": 1.0, "value": 0.0}]],
                            slam_start_iter=3, iters_between_slams=2)
-        self.assertFalse(ext.should_slam(1))
-        self.assertFalse(ext.should_slam(2))
-        self.assertTrue(ext.should_slam(3))
-        self.assertFalse(ext.should_slam(4))
-        self.assertTrue(ext.should_slam(5))
+        self.assertFalse(ext.iteration_for_slam(1))
+        self.assertFalse(ext.iteration_for_slam(2))
+        self.assertTrue(ext.iteration_for_slam(3))
+        self.assertFalse(ext.iteration_for_slam(4))
+        self.assertTrue(ext.iteration_for_slam(5))
 
     def test_miditer_respects_trigger(self):
         ds = [SlamDirective("v[*]", True, ("lb",), 1.0)]

--- a/mpisppy/tests/test_slammer.py
+++ b/mpisppy/tests/test_slammer.py
@@ -534,7 +534,7 @@ def _cfg_with_rho_seeded():
     the checker can run in isolation."""
     cfg = config.Config()
     cfg.slamming_args()
-    for n in ("grad_rho", "sensi_rho", "coeff_rho", "reduced_costs_rho", "sep_rho"):
+    for n in ("grad_rho", "sensi_rho", "coeff_rho", "sep_rho"):
         cfg.quick_assign(n, bool, False)
     return cfg
 

--- a/mpisppy/tests/test_slammer.py
+++ b/mpisppy/tests/test_slammer.py
@@ -1,0 +1,546 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+"""Tests for preference-driven in-hub slamming
+(mpisppy/extensions/slammer.py).
+
+Three groups, mirroring the three decoupled layers of the design
+(doc/designs/slamming_design.md):
+
+  * parser/matcher    -- the directives file and its wildcard semantics,
+  * action            -- each direction fixes to the expected value, plus
+                         selection / eligibility / stickiness,
+  * trigger + config  -- the iteration-count predicate and the backward
+                         compatibility contract in Config.checker().
+
+The action tests bypass MPI and the solver: a fake ``opt`` carries Pyomo
+scenario models directly, and a one-process ``_FakeComm`` makes the min/max
+Allreduce an identity, so the fix decisions can be checked deterministically.
+"""
+
+import os
+import tempfile
+import types
+import unittest
+import warnings
+
+import pyomo.environ as pyo
+from pyomo.common.collections import ComponentSet
+
+import mpisppy.utils.config as config
+from mpisppy.extensions.slammer import (
+    Slammer,
+    SlamDirective,
+    parse_directives_file,
+    resolve_directive,
+    VALID_DIRECTIONS,
+)
+
+NDN = "ROOT"
+
+
+# --------------------------------------------------------------------------- #
+# helpers
+# --------------------------------------------------------------------------- #
+def _write_csv(text):
+    """Write text to a temp CSV (under the repo tree's default tmp) and return
+    its path; caller removes it."""
+    fd, path = tempfile.mkstemp(suffix=".csv", text=True)
+    with os.fdopen(fd, "w") as f:
+        f.write(text)
+    return path
+
+
+def _make_scenario(specs):
+    """One Pyomo scenario model from a list of var specs.
+
+    Each spec is a dict with keys: value, and optional lb, ub, xbar, integer,
+    binary, modeler_fixed, surrogate.  A var is named ``v[i]``.
+    """
+    n = len(specs)
+
+    def _bounds(m, i):
+        return (specs[i].get("lb", 0.0), specs[i].get("ub", 10.0))
+
+    def _domain(m, i):
+        if specs[i].get("binary"):
+            return pyo.Binary
+        return pyo.Integers if specs[i].get("integer") else pyo.Reals
+
+    sm = pyo.ConcreteModel()
+    sm.v = pyo.Var(range(n), bounds=_bounds, domain=_domain)
+
+    nonant_indices = {}
+    xbars = {}
+    surrogates = ComponentSet()
+    for i, sp in enumerate(specs):
+        var = sm.v[i]
+        var._value = sp["value"]
+        if sp.get("modeler_fixed"):
+            var.fix(sp["value"])
+        nonant_indices[(NDN, i)] = var
+        xbars[(NDN, i)] = sp.get("xbar", sp["value"])  # pyo.value() of a float is the float
+        if sp.get("surrogate"):
+            surrogates.add(var)
+
+    scenario = types.SimpleNamespace(
+        _solver_plugin=None,  # is_persistent(None) is False -> no update_var calls
+        _mpisppy_data=types.SimpleNamespace(
+            nonant_indices=nonant_indices,
+            all_surrogate_nonants=surrogates,
+        ),
+        _mpisppy_model=types.SimpleNamespace(xbars=xbars),
+    )
+    return sm, scenario
+
+
+class _FakeComm:
+    """One-process communicator: Allreduce is the identity (local == global)."""
+    def Allreduce(self, sendbuf, recvbuf, op=None):
+        recvbuf[0][:] = sendbuf[0]
+
+
+def _build(directives, scenario_specs, slam_start_iter=1, iters_between_slams=1,
+           rounding_bias=0.0, suppress_warnings=True):
+    """Build (ext, opt, models) from directives and a list of scenarios, each a
+    list of var specs.  pre_iter0() is called so the eligibility map is ready."""
+    models, scenarios = [], []
+    for specs in scenario_specs:
+        m, sc = _make_scenario(specs)
+        models.append(m)
+        scenarios.append(sc)
+
+    opt = types.SimpleNamespace(
+        cylinder_rank=0,
+        _PHIter=1,
+        comms={NDN: _FakeComm()},
+        local_scenarios={f"Scen{i+1}": s for i, s in enumerate(scenarios)},
+        options={"slammer_options": {
+            "directives": directives,
+            "slam_start_iter": slam_start_iter,
+            "iters_between_slams": iters_between_slams,
+            "rounding_bias": rounding_bias,
+            "verbose": False,
+        }},
+    )
+    opt.local_scenario_names = list(opt.local_scenarios.keys())
+
+    ext = Slammer(opt)
+    if suppress_warnings:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            ext.pre_iter0()
+    else:
+        ext.pre_iter0()
+    return ext, opt, models
+
+
+def _var(models, scen_idx, var_idx):
+    return models[scen_idx].v[var_idx]
+
+
+# --------------------------------------------------------------------------- #
+# parser / matcher
+# --------------------------------------------------------------------------- #
+class Test_parser(unittest.TestCase):
+    def test_basic_parse(self):
+        path = _write_csv(
+            "name,can_slam,directions,priority\n"
+            "DoBuild[*],1,ub|lb,100\n"
+            "NumUnits[*],1,nearest,50\n"
+        )
+        try:
+            ds = parse_directives_file(path)
+        finally:
+            os.remove(path)
+        self.assertEqual(len(ds), 2)
+        self.assertEqual(ds[0].pattern, "DoBuild[*]")
+        self.assertTrue(ds[0].can_slam)
+        self.assertEqual(ds[0].directions, ("ub", "lb"))
+        self.assertEqual(ds[0].priority, 100.0)
+
+    def test_can_slam_defaults_true(self):
+        path = _write_csv("name,directions\nDoBuild[*],lb\n")
+        try:
+            ds = parse_directives_file(path)
+        finally:
+            os.remove(path)
+        self.assertTrue(ds[0].can_slam)
+        self.assertEqual(ds[0].priority, 0.0)  # default
+
+    def test_can_slam_zero_allows_empty_directions(self):
+        path = _write_csv(
+            "name,can_slam,directions,priority\n"
+            "NumUnits[*],1,nearest,50\n"
+            "NumUnits[7],0,,0\n"
+        )
+        try:
+            ds = parse_directives_file(path)
+        finally:
+            os.remove(path)
+        self.assertFalse(ds[1].can_slam)
+        self.assertEqual(ds[1].directions, ())
+
+    def test_blank_name_rows_skipped(self):
+        path = _write_csv("name,directions\nDoBuild[*],lb\n,\n")
+        try:
+            ds = parse_directives_file(path)
+        finally:
+            os.remove(path)
+        self.assertEqual(len(ds), 1)
+
+    def test_comments_and_blanks_ignored(self):
+        # comments are allowed before the header and between rows
+        path = _write_csv(
+            "# leading comment\n"
+            "\n"
+            "name,directions,priority\n"
+            "# a note about DoBuild\n"
+            "DoBuild[*],lb,1\n"
+            "\n"
+            "NumUnits[*],ub,2\n"
+        )
+        try:
+            ds = parse_directives_file(path)
+        finally:
+            os.remove(path)
+        self.assertEqual([d.pattern for d in ds], ["DoBuild[*]", "NumUnits[*]"])
+
+    def test_quoted_multi_index_name(self):
+        # a name with a comma must be quoted to survive the CSV split
+        path = _write_csv(
+            'name,directions,priority\n'
+            '"Cut[*,*]",max,10\n'
+        )
+        try:
+            ds = parse_directives_file(path)
+        finally:
+            os.remove(path)
+        self.assertEqual(ds[0].pattern, "Cut[*,*]")
+        self.assertTrue(ds[0].matches("Cut[1,2]"))
+
+    def test_sizes_example_file_parses(self):
+        # the shipped example must stay valid
+        here = os.path.dirname(__file__)
+        example = os.path.join(
+            here, "..", "..", "examples", "sizes", "config",
+            "slamming_directives.csv")
+        ds = parse_directives_file(example)
+        self.assertTrue(any(d.pattern == "NumUnitsCutFirstStage[*,*]" for d in ds))
+        # last-match-wins gives the per-index priority, slammed to max
+        d = resolve_directive(ds, "NumProducedFirstStage[10]")
+        self.assertEqual(d.directions, ("max",))
+        self.assertEqual(d.priority, 10.0)
+
+    def test_unknown_direction_raises(self):
+        path = _write_csv("name,directions\nDoBuild[*],sideways\n")
+        try:
+            with self.assertRaises(ValueError):
+                parse_directives_file(path)
+        finally:
+            os.remove(path)
+
+    def test_can_slam_one_no_directions_raises(self):
+        path = _write_csv("name,can_slam,directions\nDoBuild[*],1,\n")
+        try:
+            with self.assertRaises(ValueError):
+                parse_directives_file(path)
+        finally:
+            os.remove(path)
+
+    def test_missing_name_column_raises(self):
+        path = _write_csv("pattern,directions\nDoBuild[*],lb\n")
+        try:
+            with self.assertRaises(ValueError):
+                parse_directives_file(path)
+        finally:
+            os.remove(path)
+
+    def test_unparseable_priority_raises(self):
+        path = _write_csv("name,directions,priority\nDoBuild[*],lb,high\n")
+        try:
+            with self.assertRaises(ValueError):
+                parse_directives_file(path)
+        finally:
+            os.remove(path)
+
+
+class Test_matcher(unittest.TestCase):
+    def test_brackets_are_literal(self):
+        # the design's own examples; raw fnmatch would fail all of these
+        d = SlamDirective("DoBuild[*]", True, ("lb",), 0.0)
+        self.assertTrue(d.matches("DoBuild[Seattle]"))
+        self.assertFalse(d.matches("DoBuildX"))  # bracket is literal, not a class
+        d2 = SlamDirective("Reservoir*.spill[*]", True, ("lb",), 0.0)
+        self.assertTrue(d2.matches("Reservoir1.spill[3]"))
+        d3 = SlamDirective("NumUnits[7]", True, ("lb",), 0.0)
+        self.assertTrue(d3.matches("NumUnits[7]"))
+        self.assertFalse(d3.matches("NumUnits7"))
+
+    def test_question_mark_one_char(self):
+        d = SlamDirective("NumUnits[?]", True, ("lb",), 0.0)
+        self.assertTrue(d.matches("NumUnits[7]"))
+        self.assertFalse(d.matches("NumUnits[70]"))
+
+    def test_full_match_required(self):
+        d = SlamDirective("DoBuild", True, ("lb",), 0.0)
+        self.assertTrue(d.matches("DoBuild"))
+        self.assertFalse(d.matches("DoBuildMore"))
+
+    def test_last_match_wins(self):
+        ds = [
+            SlamDirective("NumUnits[*]", True, ("nearest",), 50.0),
+            SlamDirective("NumUnits[7]", False, (), 0.0),
+        ]
+        self.assertTrue(resolve_directive(ds, "NumUnits[3]").can_slam)
+        self.assertFalse(resolve_directive(ds, "NumUnits[7]").can_slam)
+
+    def test_unmatched_is_none(self):
+        ds = [SlamDirective("NumUnits[*]", True, ("lb",), 0.0)]
+        self.assertIsNone(resolve_directive(ds, "Other[1]"))
+
+
+# --------------------------------------------------------------------------- #
+# action -- directions
+# --------------------------------------------------------------------------- #
+class Test_directions(unittest.TestCase):
+    def test_slam_lb(self):
+        ds = [SlamDirective("v[*]", True, ("lb",), 1.0)]
+        ext, opt, models = _build(ds, [[{"lb": 2.0, "ub": 9.0, "value": 5.0}]])
+        ext._slam_one()
+        self.assertTrue(_var(models, 0, 0).fixed)
+        self.assertEqual(_var(models, 0, 0).value, 2.0)
+
+    def test_slam_ub(self):
+        ds = [SlamDirective("v[*]", True, ("ub",), 1.0)]
+        ext, opt, models = _build(ds, [[{"lb": 2.0, "ub": 9.0, "value": 5.0}]])
+        ext._slam_one()
+        self.assertEqual(_var(models, 0, 0).value, 9.0)
+
+    def test_nearest_picks_closer_bound(self):
+        ds = [SlamDirective("v[*]", True, ("nearest",), 1.0)]
+        # xbar 2 is closer to lb 0 than ub 10
+        ext, _, models = _build(ds, [[{"lb": 0.0, "ub": 10.0, "value": 2.0, "xbar": 2.0}]])
+        ext._slam_one()
+        self.assertEqual(_var(models, 0, 0).value, 0.0)
+        # xbar 8 is closer to ub 10
+        ds = [SlamDirective("v[*]", True, ("nearest",), 1.0)]
+        ext, _, models = _build(ds, [[{"lb": 0.0, "ub": 10.0, "value": 8.0, "xbar": 8.0}]])
+        ext._slam_one()
+        self.assertEqual(_var(models, 0, 0).value, 10.0)
+
+    def test_anywhere_rounds_integer(self):
+        ds = [SlamDirective("v[*]", True, ("anywhere",), 1.0)]
+        ext, _, models = _build(
+            ds, [[{"lb": 0, "ub": 10, "value": 3.4, "xbar": 3.4, "integer": True}]])
+        ext._slam_one()
+        self.assertEqual(_var(models, 0, 0).value, 3)  # round(3.4)
+
+    def test_anywhere_rounding_bias(self):
+        ds = [SlamDirective("v[*]", True, ("anywhere",), 1.0)]
+        ext, _, models = _build(
+            ds, [[{"lb": 0, "ub": 10, "value": 3.4, "xbar": 3.4, "integer": True}]],
+            rounding_bias=0.2)
+        ext._slam_one()
+        self.assertEqual(_var(models, 0, 0).value, 4)  # round(3.4 + 0.2)
+
+    def test_anywhere_continuous_uses_xbar(self):
+        ds = [SlamDirective("v[*]", True, ("anywhere",), 1.0)]
+        ext, _, models = _build(ds, [[{"lb": 0.0, "ub": 10.0, "value": 3.7, "xbar": 3.7}]])
+        ext._slam_one()
+        self.assertAlmostEqual(_var(models, 0, 0).value, 3.7)
+
+    def test_min_across_scenarios(self):
+        ds = [SlamDirective("v[*]", True, ("min",), 1.0)]
+        ext, _, models = _build(ds, [
+            [{"lb": 0.0, "ub": 10.0, "value": 5.5}],
+            [{"lb": 0.0, "ub": 10.0, "value": 2.5}],
+        ])
+        ext._slam_one()
+        # fixed to the min (2.5) in *every* scenario
+        self.assertAlmostEqual(_var(models, 0, 0).value, 2.5)
+        self.assertAlmostEqual(_var(models, 1, 0).value, 2.5)
+
+    def test_max_across_scenarios(self):
+        ds = [SlamDirective("v[*]", True, ("max",), 1.0)]
+        ext, _, models = _build(ds, [
+            [{"lb": 0.0, "ub": 10.0, "value": 5.5}],
+            [{"lb": 0.0, "ub": 10.0, "value": 2.5}],
+        ])
+        ext._slam_one()
+        self.assertAlmostEqual(_var(models, 0, 0).value, 5.5)
+        self.assertAlmostEqual(_var(models, 1, 0).value, 5.5)
+
+    def test_infinite_bound_falls_through(self):
+        # lb is not finite (unbounded below) -> skip lb, use anywhere
+        ds = [SlamDirective("v[*]", True, ("lb", "anywhere"), 1.0)]
+        ext, _, models = _build(
+            ds, [[{"lb": None, "ub": None, "value": 4.0, "xbar": 4.0}]])
+        ext._slam_one()
+        self.assertAlmostEqual(_var(models, 0, 0).value, 4.0)  # anywhere -> xbar
+
+    def test_no_applicable_direction_is_skipped(self):
+        # only lb requested, but var is unbounded below -> nothing to slam
+        ds = [SlamDirective("v[*]", True, ("lb",), 1.0)]
+        ext, _, models = _build(
+            ds, [[{"lb": None, "ub": None, "value": 4.0, "xbar": 4.0}]])
+        ext._slam_one()
+        self.assertFalse(_var(models, 0, 0).fixed)
+
+
+# --------------------------------------------------------------------------- #
+# action -- selection / eligibility / stickiness
+# --------------------------------------------------------------------------- #
+class Test_selection(unittest.TestCase):
+    def test_highest_priority_first(self):
+        ds = [
+            SlamDirective("v[0]", True, ("lb",), 10.0),
+            SlamDirective("v[1]", True, ("lb",), 50.0),
+        ]
+        ext, _, models = _build(ds, [[
+            {"lb": 1.0, "ub": 9.0, "value": 5.0},
+            {"lb": 2.0, "ub": 9.0, "value": 5.0},
+        ]])
+        ext._slam_one()
+        self.assertFalse(_var(models, 0, 0).fixed)  # priority 10 -> not yet
+        self.assertTrue(_var(models, 0, 1).fixed)   # priority 50 -> slammed
+        self.assertEqual(_var(models, 0, 1).value, 2.0)
+
+    def test_priority_tie_broken_by_name(self):
+        ds = [SlamDirective("v[*]", True, ("lb",), 5.0)]  # both same priority
+        ext, _, models = _build(ds, [[
+            {"lb": 1.0, "ub": 9.0, "value": 5.0},
+            {"lb": 2.0, "ub": 9.0, "value": 5.0},
+        ]])
+        ext._slam_one()
+        self.assertTrue(_var(models, 0, 0).fixed)   # 'v[0]' < 'v[1]'
+        self.assertFalse(_var(models, 0, 1).fixed)
+
+    def test_sticky_one_per_event(self):
+        ds = [
+            SlamDirective("v[0]", True, ("lb",), 10.0),
+            SlamDirective("v[1]", True, ("lb",), 50.0),
+        ]
+        ext, _, models = _build(ds, [[
+            {"lb": 1.0, "ub": 9.0, "value": 5.0},
+            {"lb": 2.0, "ub": 9.0, "value": 5.0},
+        ]])
+        ext._slam_one()  # slams v[1] (priority 50)
+        ext._slam_one()  # v[1] sticky -> now slams v[0]
+        self.assertTrue(_var(models, 0, 0).fixed)
+        self.assertTrue(_var(models, 0, 1).fixed)
+        self.assertEqual(len(ext._slammed), 2)
+
+    def test_surrogate_skipped(self):
+        ds = [SlamDirective("v[*]", True, ("lb",), 1.0)]
+        ext, _, models = _build(
+            ds, [[{"lb": 1.0, "ub": 9.0, "value": 5.0, "surrogate": True}]])
+        ext._slam_one()
+        self.assertFalse(_var(models, 0, 0).fixed)
+
+    def test_modeler_fixed_skipped(self):
+        ds = [SlamDirective("v[*]", True, ("lb",), 1.0)]
+        ext, _, models = _build(
+            ds, [[{"lb": 1.0, "ub": 9.0, "value": 5.0, "modeler_fixed": True}]])
+        ext._slam_one()
+        self.assertTrue(_var(models, 0, 0).fixed)
+        self.assertEqual(_var(models, 0, 0).value, 5.0)  # not moved to lb
+
+    def test_already_fixed_skipped(self):
+        ds = [SlamDirective("v[*]", True, ("lb",), 1.0)]
+        ext, _, models = _build(ds, [[{"lb": 1.0, "ub": 9.0, "value": 5.0}]])
+        _var(models, 0, 0).fix(7.0)  # fixed after pre_iter0 (e.g. another fixer)
+        ext._slam_one()
+        self.assertEqual(_var(models, 0, 0).value, 7.0)  # left alone
+
+    def test_unmatched_nonant_never_slammed(self):
+        ds = [SlamDirective("other[*]", True, ("lb",), 1.0)]
+        ext, _, models = _build(ds, [[{"lb": 1.0, "ub": 9.0, "value": 5.0}]])
+        ext._slam_one()
+        self.assertFalse(_var(models, 0, 0).fixed)
+
+    def test_zero_match_pattern_warns(self):
+        # a pattern matching no nonant is almost always a typo -> warn (rank 0)
+        ds = [SlamDirective("typo[*]", True, ("lb",), 1.0)]
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            _build(ds, [[{"lb": 1.0, "ub": 9.0, "value": 5.0}]],
+                   suppress_warnings=False)
+        self.assertTrue(any(issubclass(w.category, UserWarning) and
+                            "typo[*]" in str(w.message) for w in caught))
+
+
+# --------------------------------------------------------------------------- #
+# trigger + config (backward compatibility contract)
+# --------------------------------------------------------------------------- #
+class Test_trigger(unittest.TestCase):
+    def test_should_slam_predicate(self):
+        ds = [SlamDirective("v[*]", True, ("lb",), 1.0)]
+        ext, _, _ = _build(ds, [[{"lb": 0.0, "ub": 1.0, "value": 0.0}]],
+                           slam_start_iter=3, iters_between_slams=2)
+        self.assertFalse(ext.should_slam(1))
+        self.assertFalse(ext.should_slam(2))
+        self.assertTrue(ext.should_slam(3))
+        self.assertFalse(ext.should_slam(4))
+        self.assertTrue(ext.should_slam(5))
+
+    def test_miditer_respects_trigger(self):
+        ds = [SlamDirective("v[*]", True, ("lb",), 1.0)]
+        ext, opt, models = _build(ds, [[{"lb": 2.0, "ub": 9.0, "value": 5.0}]],
+                                  slam_start_iter=5, iters_between_slams=1)
+        opt._PHIter = 2
+        ext.miditer()
+        self.assertFalse(_var(models, 0, 0).fixed)  # before start
+        opt._PHIter = 5
+        ext.miditer()
+        self.assertTrue(_var(models, 0, 0).fixed)
+
+
+def _cfg_with_rho_seeded():
+    """A Config with slamming_args plus the rho flags Config.checker() sums, so
+    the checker can run in isolation."""
+    cfg = config.Config()
+    cfg.slamming_args()
+    for n in ("grad_rho", "sensi_rho", "coeff_rho", "reduced_costs_rho", "sep_rho"):
+        cfg.quick_assign(n, bool, False)
+    return cfg
+
+
+class Test_backward_compat(unittest.TestCase):
+    def test_no_slamming_options_is_fine(self):
+        cfg = _cfg_with_rho_seeded()
+        cfg.checker()  # must not raise
+
+    def test_slam_option_without_file_errors(self):
+        cfg = _cfg_with_rho_seeded()
+        cfg.slam_start_iter = 5
+        with self.assertRaises(ValueError):
+            cfg.checker()
+
+    def test_iters_between_without_file_errors(self):
+        cfg = _cfg_with_rho_seeded()
+        cfg.iters_between_slams = 3
+        with self.assertRaises(ValueError):
+            cfg.checker()
+
+    def test_file_with_options_is_fine(self):
+        cfg = _cfg_with_rho_seeded()
+        cfg.slamming_directives_file = "directives.csv"
+        cfg.slam_start_iter = 5
+        cfg.checker()  # must not raise
+
+
+class Test_valid_directions(unittest.TestCase):
+    def test_all_tokens_present(self):
+        self.assertEqual(
+            set(VALID_DIRECTIONS),
+            {"lb", "ub", "nearest", "anywhere", "min", "max"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mpisppy/utils/cfg_vanilla.py
+++ b/mpisppy/utils/cfg_vanilla.py
@@ -824,6 +824,30 @@ def add_relaxed_ph_fixer(hub_dict,
 
     return hub_dict
 
+def add_slammer(hub_dict,
+                cfg,
+                ):
+    # Preference-driven in-hub slamming; activated only when the directives
+    # file is supplied (see doc/designs/slamming_design.md).
+    from mpisppy.extensions.slammer import Slammer
+    hub_dict = extension_adder(hub_dict, Slammer)
+
+    # slam_start_iter / iters_between_slams default to None in Config so the
+    # checker can detect "supplied without a file"; resolve to the Slammer's
+    # built-in defaults here.
+    slammer_options = {
+        "directives_file": cfg.slamming_directives_file,
+        "rounding_bias": cfg.rounding_bias,
+        "verbose": cfg.verbose,
+    }
+    if cfg.get("slam_start_iter") is not None:
+        slammer_options["slam_start_iter"] = cfg.slam_start_iter
+    if cfg.get("iters_between_slams") is not None:
+        slammer_options["iters_between_slams"] = cfg.iters_between_slams
+
+    hub_dict["opt_kwargs"]["options"]["slammer_options"] = slammer_options
+    return hub_dict
+
 def add_wxbar_read_write(hub_dict, cfg):
     """
     Add the wxbar read and write extensions to the hub_dict

--- a/mpisppy/utils/config.py
+++ b/mpisppy/utils/config.py
@@ -187,6 +187,16 @@ class Config(pyofig.ConfigDict):
             _bad_options("--cc-indicator-var (chance constraint) is currently "
                          "supported only with --EF")
 
+        # Slamming options other than the directives file are meaningless
+        # without it; require the file so that a run with no slamming options
+        # behaves exactly as it does today (total backward compatibility).
+        if self.get("slamming_directives_file") is None and (
+                self.get("slam_start_iter") is not None
+                or self.get("iters_between_slams") is not None):
+            _bad_options("slamming options (--slam-start-iter / "
+                         "--iters-between-slams) require "
+                         "--slamming-directives-file")
+
     def add_solver_specs(self, prefix=""):
         sstr = f"{prefix}_solver" if prefix else "solver"
         if prefix:
@@ -643,6 +653,33 @@ class Config(pyofig.ConfigDict):
                                        "to spend with relaxed integers",
                            domain=float,
                            default=0.5)
+
+    def slamming_args(self):
+        # Phase-1 preference-driven slamming (see doc/designs/slamming_design.md).
+        # The Slammer extension is activated iff slamming_directives_file is set;
+        # supplying the other slam options without the file is a hard error
+        # (enforced in checker()) so that a run with no slamming options behaves
+        # exactly as it does today.
+        self.add_to_config("slamming_directives_file",
+                           description="CSV of by-name (wildcard) slamming "
+                           "directives; its presence activates the Slammer "
+                           "extension (default None)",
+                           domain=str,
+                           default=None)
+
+        self.add_to_config("slam_start_iter",
+                           description="first hub iteration at which slamming "
+                           "may occur (default 1); requires "
+                           "--slamming-directives-file",
+                           domain=int,
+                           default=None)
+
+        self.add_to_config("iters_between_slams",
+                           description="once started, slam at most once every "
+                           "this many iterations (default 1); requires "
+                           "--slamming-directives-file",
+                           domain=int,
+                           default=None)
 
     def reduced_costs_rho_args(self):
         self.add_to_config("reduced_costs_rho",

--- a/run_coverage.bash
+++ b/run_coverage.bash
@@ -181,7 +181,8 @@ run_phase "serial unit tests (serial)" \
         mpisppy/tests/test_ciutils.py \
         mpisppy/tests/test_prox_approx.py \
         mpisppy/tests/test_sep_rho.py \
-        mpisppy/tests/test_reduced_costs_fixer.py
+        mpisppy/tests/test_reduced_costs_fixer.py \
+        mpisppy/tests/test_slammer.py
 
 run_phase "test_conf_int_farmer (spawns mpiexec)" \
     coverage run --rcfile=.coveragerc mpisppy/tests/test_conf_int_farmer.py


### PR DESCRIPTION
## What

Adds **slamming** to mpi-sppy: forcing (fixing) selected nonanticipative
variables according to pre-specified user preferences while a decomposition hub
is running, to drive toward a feasible/converged incumbent when ordinary
convergence is slow. It is an `Extension` (in the in-hub-fixing family with
`fixer.py`, `reduced_costs_fixer.py`, `relaxed_ph_fixer.py`) and runs under any
`PHBase`-derived hub (PH, APH, Subgradient, FWPH).

This is distinct from the existing `SlamMin`/`SlamMax` *spokes*, which are
non-destructive incumbent finders; the slammer alters the hub search per user
preference and is multistage-capable (the spokes are two-stage only).

Design: `doc/designs/slamming_design.md`.

## How it's used

Activated only when a directives file is supplied, so a run with no slamming
options is byte-for-byte unchanged:

- `--slamming-directives-file <file>` — activates the extension
- `--slam-start-iter K` — first iteration at which slamming may occur (default 1)
- `--iters-between-slams M` — cadence once started (default 1)

Supplying the other options without the file is a hard error.

The directives file is a CSV keyed by nonant name with shell-style wildcards
(`*`/`?`; index brackets `[ ]` are matched literally — deliberately not
`fnmatch`, whose bracket semantics would make `DoBuild[*]` fail to match
`DoBuild[Seattle]`). Each row gives a name pattern, an optional `can_slam`
(`1`/`0`), an ordered `|`-separated list of `directions` from
`{lb, ub, nearest, anywhere, min, max}` (first applicable is used), and a
`priority` (largest is slammed first; ties by name). Matching is
last-match-wins; only variables matched by a `can_slam` rule are ever slammed;
a pattern that matches nothing is an error that names the file.

A worked example translated from PySP's `wwph.suffixes` ships at
`examples/sizes/config/slamming_directives.csv`.

## Behavior

- One variable is slammed per event, by largest priority (name-tiebroken so the
  choice is identical on every rank). Eligibility: matched + `can_slam`, not
  already fixed, not a surrogate, has an applicable direction. There is no
  convergence gate (slamming an already-settled variable just pins it).
- `lb`/`ub`/`nearest`/`anywhere` use only rank-identical data (no
  communication); `min`/`max` do one small reduction over the per-node
  communicator, and only when such a slam actually fires.
- Slams are sticky.

## Scope

This is the slamming *mechanism*. Deciding *when* to slam beyond the built-in
iteration-count trigger (genuine stall/cycle detection) is a separate future
project that would invoke this mechanism as a consumer; it is intentionally not
part of this PR.

## Tests / docs

- `mpisppy/tests/test_slammer.py` — 43 solver-free unit tests (parser, matcher,
  every direction, selection / eligibility / stickiness, trigger,
  backward-compatibility, zero-match error). Wired into `run_coverage.bash`
  **and** `test_pr_and_main.yml`.
- Docs: `doc/src/extensions.rst` (slammer section + flag) and the design doc.
- Verified live on the sizes MIP (serial and `mpiexec -np 2`): slams fire on
  cadence, the cross-rank `max` reduction stays coherent, persistent-solver
  updates work, and a bad pattern errors naming the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
