### PR TITLE
mps/lp file path: enable proper bundling (incl. per-nonant rho from CSV)

### DIFF
--- a/examples/sizes/mps_demo.bash
+++ b/examples/sizes/mps_demo.bash
@@ -20,3 +20,13 @@ python ../../mpisppy/generic_cylinders.py --module-name sizes_expression --num-s
 
 # --mps-files-directory as the first arg infers the module automatically.
 mpiexec -np 3 python -m mpi4py ../../mpisppy/generic_cylinders.py --mps-files-directory=_delme_lp_mps_dir --xhatshuffle --lagrangian --default-rho 1 --solver-name ${SOLVER} --max-iterations 10
+
+# Proper bundling with the file-based path.
+# Write 10 scenarios (the writer also emits a {scenario}_rho.csv for each), then
+# read them back grouped into proper bundles with --scenarios-per-bundle.
+# The scenario count is implied by the files in the directory (no --num-scens),
+# so 10 scenarios / 5 per bundle = 2 bundles. Under bundling the per-scenario rho
+# values are assembled onto each bundle's nonants.
+python ../../mpisppy/generic_cylinders.py --module-name sizes_expression --num-scens 10 --default-rho 1 --solver-name ${SOLVER} --max-iterations 0 --write-scenario-lp-mps-files-dir _delme_lp_mps_bundle_dir
+
+mpiexec -np 3 python -m mpi4py ../../mpisppy/generic_cylinders.py --mps-files-directory=_delme_lp_mps_bundle_dir --scenarios-per-bundle 5 --xhatshuffle --lagrangian --default-rho 1 --solver-name ${SOLVER} --max-iterations 10

--- a/mpisppy/generic/parsing.py
+++ b/mpisppy/generic/parsing.py
@@ -210,10 +210,15 @@ def name_lists(module, cfg, bundle_wrapper=None):
 
     # proper bundles should be almost magic
     if cfg.unpickle_bundles_dir or cfg.scenarios_per_bundle is not None:
-        # When branching_factors are used (multi-stage), num_scens is computed locally
-        # above but cfg.num_scens is never set from it.  Fill it in so that
-        # bundle_names_creator (which asserts cfg.num_scens is not None) works.
-        if cfg.get("num_scens") is None and num_scens is not None:
+        # bundle_names_creator needs cfg.num_scens, but it is not always set yet:
+        #  - multi-stage: num_scens was computed locally above from branching
+        #    factors but never written back to cfg.
+        #  - file-based paths (e.g. --mps-files-directory): the scenario count is
+        #    implied by the files, so there is no --num-scens; recover it from the
+        #    module's scenario_names_creator (None => every scenario).
+        if num_scens is None:
+            num_scens = len(module.scenario_names_creator(None))
+        if cfg.get("num_scens") is None:
             cfg.quick_assign("num_scens", int, int(num_scens))
         num_buns = cfg.num_scens // cfg.scenarios_per_bundle
         all_scenario_names = bundle_wrapper.bundle_names_creator(num_buns, cfg=cfg)

--- a/mpisppy/problem_io/mps_module.py
+++ b/mpisppy/problem_io/mps_module.py
@@ -22,6 +22,15 @@ cross-scenario consistency (a full check would need a collective across ranks),
 so an inconsistent set of {scenario}_rho.csv files silently yields an
 ill-defined PH run.
 
+Under proper bundling a bundle is one PH subproblem with a single rho per bundle
+nonant, so its rho is assembled from the sub-scenarios' {scenario}_rho.csv files
+by _rho_setter / _bundle_rho_list (the bundle itself has no rho file). PH uses one
+rho per (node, nonant) across every scenario through the node, so the
+sub-scenarios' values for a bundle nonant must agree. A bundle's sub-scenarios are
+all local, so there mpi-sppy DOES check and raises an error on a mismatch (the
+unbundled per-scenario path, lacking a cheap cross-scenario view, applies each
+value unchecked).
+
 Scenario names must have a consistent base (e.g. "scenario" or "scen") and
 must end in a serial number (unless you can't, you should start with 0; 
 otherwise, start with 1).
@@ -37,6 +46,7 @@ import os
 import re
 import glob
 import json
+import math
 import mpisppy.scenario_tree as scenario_tree
 import mpisppy.utils.sputils as sputils
 import mpisppy.problem_io.mps_reader as mps_reader
@@ -178,13 +188,89 @@ def _rho_setter(scenario):
     --default-rho passed as a backstop), because defining _rho_setter bypasses
     the driver's --default-rho check.
 
+    With proper bundling the object handed to a rho setter is a bundle EF, not
+    an individual scenario, and the bundle carries no _rho_csv_path of its own.
+    We detect that case and assemble the bundle's rho from its sub-scenarios'
+    {s}_rho.csv files (see _bundle_rho_list); without this the per-scenario rho
+    files would be silently ignored under bundling and every nonant would fall
+    back to --default-rho.
+
     The csv writer must give identical rho to every scenario sharing a node for
-    a given nonant (see the module docstring); this is not checked here.
+    a given nonant (see the module docstring). The unbundled path applies each
+    scenario's value without checking; within a bundle _bundle_rho_list checks
+    (the sub-scenarios are local) and errors on a mismatch.
     """
+    sub_models = _bundle_sub_models(scenario)
+    if sub_models:
+        return _bundle_rho_list(scenario, sub_models)
     path = getattr(scenario, "_rho_csv_path", None)
     if not path:
         return []
     return rho_utils.rho_list_from_csv(scenario, path)
+
+
+def _bundle_sub_models(scenario):
+    """Return the per-sub-scenario Pyomo models nested in a proper bundle.
+
+    A proper bundle is an EF model that sputils.create_EF tags with
+    _ef_scenario_names and to which it adds each sub-scenario as a named
+    component. Returns [] when scenario is not such a bundle (a plain scenario,
+    or the degenerate single-scenario EF where the scenario *is* the EF and so
+    is not a component of itself), so callers fall back to the plain path.
+    """
+    names = getattr(scenario, "_ef_scenario_names", None)
+    if not names:
+        return []
+    subs = [getattr(scenario, n, None) for n in names]
+    return [s for s in subs if s is not None and s is not scenario]
+
+
+def _bundle_rho_list(bundle, sub_models):
+    """Assemble per-nonant rho for a proper bundle from its sub-scenarios.
+
+    A proper bundle is a single PH subproblem with one rho per bundle nonant,
+    yet each sub-scenario carries its own {s}_rho.csv. PH uses one rho per
+    (node, nonant) shared across every scenario through that node, so the
+    sub-scenarios' csv values for a given bundle nonant must agree; the bundle
+    takes that shared value. A bundle's sub-scenarios are all local, so -- unlike
+    the cross-scenario unbundled case, which would need an MPI collective -- we
+    can and do check: a nonant whose sub-scenarios disagree on rho is a
+    RuntimeError.
+
+    bundle.consensus_groups maps each bundle nonant index to the per-sub-scenario
+    Vars at that position. Returns [] when no sub-scenario carries a rho file,
+    preserving the --default-rho fallback exactly as the plain-scenario path does.
+    """
+    rho_by_id = {}
+    sub_by_id = {}   # id(Var) -> sub-scenario name, for error messages
+    for sub in sub_models:
+        path = getattr(sub, "_rho_csv_path", None)
+        if not path or not os.path.exists(path):
+            continue
+        for vid, rho in rho_utils.rho_list_from_csv(sub, path):
+            rho_by_id[vid] = rho
+            sub_by_id[vid] = sub.name
+    if not rho_by_id:
+        return []
+    consensus_groups = bundle.consensus_groups
+    retlist = []
+    for ndn_i, ref_var in bundle._mpisppy_data.nonant_indices.items():
+        covered = [v for v in consensus_groups.get(ndn_i, (ref_var,))
+                   if id(v) in rho_by_id]
+        if not covered:
+            continue
+        rho0 = rho_by_id[id(covered[0])]
+        if any(not math.isclose(rho_by_id[id(v)], rho0, rel_tol=1e-12, abs_tol=0.0)
+               for v in covered):
+            detail = ", ".join(f"{sub_by_id[id(v)]}={rho_by_id[id(v)]}"
+                               for v in covered)
+            raise RuntimeError(
+                f"{bundle.name}: scenarios in this bundle give different rho for "
+                f"nonant {ref_var.name} ({detail}). PH requires one rho per nonant "
+                f"at a node; make the per-scenario {{s}}_rho.csv files agree."
+            )
+        retlist.append((id(ref_var), rho0))
+    return retlist
 
 
 # This is only needed for sampling

--- a/mpisppy/problem_io/mps_module.py
+++ b/mpisppy/problem_io/mps_module.py
@@ -200,7 +200,7 @@ def _rho_setter(scenario):
     scenario's value without checking; within a bundle _bundle_rho_list checks
     (the sub-scenarios are local) and errors on a mismatch.
     """
-    sub_models = _bundle_sub_models(scenario)
+    sub_models = _bundled_sub_models(scenario)
     if sub_models:
         return _bundle_rho_list(scenario, sub_models)
     path = getattr(scenario, "_rho_csv_path", None)
@@ -209,7 +209,7 @@ def _rho_setter(scenario):
     return rho_utils.rho_list_from_csv(scenario, path)
 
 
-def _bundle_sub_models(scenario):
+def _bundled_sub_models(scenario):
     """Return the per-sub-scenario Pyomo models nested in a proper bundle.
 
     A proper bundle is an EF model that sputils.create_EF tags with

--- a/mpisppy/tests/test_mps.py
+++ b/mpisppy/tests/test_mps.py
@@ -17,6 +17,9 @@ from mip import OptimizationStatus
 import mpisppy.problem_io.mps_reader as mps_reader
 import mpisppy.problem_io.mps_module as mps_module
 import mpisppy.utils.sputils as sputils
+import mpisppy.utils.config as config
+import mpisppy.utils.proper_bundler as proper_bundler
+from mpisppy.generic.parsing import name_lists
 from mpisppy.tests.utils import get_solver, limit_solver_threads
 import pyomo.environ as pyo
 import mip  # pip install mip (from coin-or)
@@ -238,6 +241,27 @@ class TestMPSModuleBundleRho(unittest.TestCase):
             cfg = self._cfg(td)
             bundle = _build_mps_bundle(cfg, ["Scenario1", "Scenario2"])
             self.assertEqual(mps_module._rho_setter(bundle), [])
+
+
+class TestMPSModuleProperBundling(unittest.TestCase):
+    """Proper bundling is reachable from the file path: the scenario count is
+    implied by the directory (no --num-scens), so parsing.name_lists infers it
+    and can size the bundles."""
+
+    def test_bundle_count_inferred_from_mps_directory(self):
+        # _MPS_MODULE_DATA holds 2 scenario files; at 1 scenario per bundle that
+        # is 2 bundles, and cfg.num_scens must be filled in (to 2) for the bundle
+        # math, even though no --num-scens was given.
+        cfg = config.Config()
+        cfg.add_branching_factors()       # default None -> two-stage
+        cfg.proper_bundle_config()        # scenarios_per_bundle, *_bundles_dir
+        cfg.quick_assign("scenarios_per_bundle", int, 1)
+        mps_module.mps_files_directory = _MPS_MODULE_DATA
+        bundle_wrapper = proper_bundler.ProperBundler(mps_module)
+        names, _ = name_lists(mps_module, cfg, bundle_wrapper=bundle_wrapper)
+        self.assertEqual(cfg.num_scens, 2)   # inferred from the 2 files
+        self.assertEqual(len(names), 2)      # 2 bundles, 1 scenario each
+        self.assertTrue(all(n.startswith("Bundle_") for n in names))
 
 
 if __name__ == '__main__':

--- a/mpisppy/tests/test_mps.py
+++ b/mpisppy/tests/test_mps.py
@@ -8,6 +8,7 @@
 ###############################################################################
 # test mps utilities
 import os
+import json
 import types
 import shutil
 import tempfile
@@ -15,6 +16,7 @@ import unittest
 from mip import OptimizationStatus
 import mpisppy.problem_io.mps_reader as mps_reader
 import mpisppy.problem_io.mps_module as mps_module
+import mpisppy.utils.sputils as sputils
 from mpisppy.tests.utils import get_solver, limit_solver_threads
 import pyomo.environ as pyo
 import mip  # pip install mip (from coin-or)
@@ -140,6 +142,102 @@ class TestMPSModule(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             with self.assertRaises(FileNotFoundError):
                 mps_module._scenario_model_path(td, "Scenario1")
+
+
+def _build_mps_bundle(cfg, scen_names):
+    """Build a proper-bundle-shaped EF from mps_module scenarios.
+
+    Mirrors mpisppy.utils.proper_bundler: create_EF over the sub-scenarios,
+    attach the ROOT node from the non-surrogate ref Vars, then attach the
+    SPBase-style nonant metadata (_mpisppy_data.nonant_indices) that
+    mps_module._rho_setter reads for a bundle. No solve is involved.
+    """
+    bundle = sputils.create_EF(
+        scen_names, mps_module.scenario_creator,
+        scenario_creator_kwargs={"cfg": cfg},
+        EF_name="Bundle_test", suppress_warnings=True,
+    )
+    nonantlist = [v for idx, v in bundle.ref_vars.items()
+                  if idx[0] == "ROOT" and idx not in bundle.ref_surrogate_vars]
+    surrogates = [v for idx, v in bundle.ref_surrogate_vars.items()
+                  if idx[0] == "ROOT"]
+    sputils.attach_root_node(bundle, 0, nonantlist, None, surrogates)
+    nonant_indices = {}
+    for node in bundle._mpisppy_node_list:
+        for i, v in enumerate(node.nonant_vardata_list):
+            nonant_indices[(node.name, i)] = v
+    bundle._mpisppy_data.nonant_indices = nonant_indices
+    return bundle
+
+
+def _write_scenario(directory, name, prob, rho_map):
+    """Write a {name}.lp/_nonants.json/_rho.csv triple into directory.
+
+    The model is the shared fixture lp (vars x(1), x(2), y); prob and rho_map
+    let a test pin the probability weighting and per-nonant rho independently.
+    """
+    shutil.copy(os.path.join(_MPS_MODULE_DATA, "Scenario1.lp"),
+                os.path.join(directory, name + ".lp"))
+    nonants = {
+        "scenarioData": {"name": name, "scenProb": prob},
+        "treeData": {"globalNodeCount": 1,
+                     "nodes": {"ROOT": {"serialNumber": 0, "condProb": 1.0,
+                                        "nonAnts": ["x(1)", "x(2)"]}}},
+    }
+    with open(os.path.join(directory, name + "_nonants.json"), "w") as f:
+        json.dump(nonants, f)
+    with open(os.path.join(directory, name + "_rho.csv"), "w") as f:
+        f.write("varname,rho\n")
+        for var, rho in rho_map.items():
+            f.write(f"{var},{rho}\n")
+
+
+class TestMPSModuleBundleRho(unittest.TestCase):
+    """_rho_setter assembles bundle rho from the sub-scenarios' {s}_rho.csv."""
+
+    def _cfg(self, directory):
+        mps_module.mps_files_directory = directory
+        return types.SimpleNamespace(mps_files_directory=directory)
+
+    def _by_nonant(self, bundle, rho_list):
+        # map returned (id(refVar), rho) back to the nonant suffix (x_1_/x_2_),
+        # dropping the sub-scenario component prefix on the ref Var name.
+        id_to_var = {id(v): v
+                     for v in bundle._mpisppy_data.nonant_indices.values()}
+        return {id_to_var[vid].name.split(".")[-1]: rho
+                for vid, rho in rho_list}
+
+    def test_bundle_rho_from_consistent_csvs(self):
+        # Identical sub-scenario rho files -> bundle nonant rho is the common
+        # value (independent of probabilities), keyed to the bundle's ref Vars.
+        cfg = self._cfg(_MPS_MODULE_DATA)
+        bundle = _build_mps_bundle(cfg, ["Scenario1", "Scenario2"])
+        got = self._by_nonant(bundle, mps_module._rho_setter(bundle))
+        self.assertEqual(got, {"x_1_": 11.0, "x_2_": 22.0})
+
+    def test_bundle_rho_disagreement_is_error(self):
+        # PH uses one rho per bundle nonant, so sub-scenarios that disagree on a
+        # nonant's rho are a malformed input -> hard error. The check is local to
+        # the bundle (no MPI collective). x(2) agrees; x(1) differs (10 vs 20).
+        with tempfile.TemporaryDirectory() as td:
+            _write_scenario(td, "Scenario1", 0.5, {"x(1)": 10.0, "x(2)": 20.0})
+            _write_scenario(td, "Scenario2", 0.5, {"x(1)": 20.0, "x(2)": 20.0})
+            cfg = self._cfg(td)
+            bundle = _build_mps_bundle(cfg, ["Scenario1", "Scenario2"])
+            with self.assertRaises(RuntimeError):
+                mps_module._rho_setter(bundle)
+
+    def test_bundle_no_csv_falls_back(self):
+        # A bundle whose sub-scenarios carry no rho file -> [] (=> --default-rho).
+        with tempfile.TemporaryDirectory() as td:
+            for name in ("Scenario1", "Scenario2"):
+                for suffix in (".lp", "_nonants.json"):
+                    shutil.copy(
+                        os.path.join(_MPS_MODULE_DATA, name + suffix),
+                        os.path.join(td, name + suffix))
+            cfg = self._cfg(td)
+            bundle = _build_mps_bundle(cfg, ["Scenario1", "Scenario2"])
+            self.assertEqual(mps_module._rho_setter(bundle), [])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## What

Make proper bundling work for the file-based (`--mps-files-directory`) scenario path, including the per-nonant rho from `{s}_rho.csv` files added in #770.

Two gaps, both surfaced while writing a bundling demo for the lp/mps path:

1. **Bundling was unreachable from the file path.** `cfg.num_scens` is never set there (only model modules register `--num-scens`), so `--scenarios-per-bundle` died in `name_lists` with `AttributeError: 'Config' object has no attribute 'num_scens'`.
2. **Per-scenario rho was silently dropped under bundling.** With bundling, `local_scenarios` holds bundle EF models, which never get `_rho_csv_path` (only the nested sub-scenarios do), so `mps_module._rho_setter` returned `[]` and every bundled nonant fell back to `--default-rho`.

## How

**Enable bundling (`parsing.name_lists`).** The scenario count is implied by the files in the directory, so infer it — `len(module.scenario_names_creator(None))` — when `num_scens` is `None`, instead of requiring `--num-scens`. This feeds the bundle-count math (`num_scens // scenarios_per_bundle`).

**Assemble bundle rho (`mps_module._rho_setter`).** When handed a proper bundle (`_bundle_sub_models` detects the EF + nested sub-scenarios), `_bundle_rho_list` reads each sub-scenario's `{s}_rho.csv` and maps the values onto the bundle's ref-var nonants via `bundle.consensus_groups`. PH uses one rho per `(node, nonant)` across every scenario through the node, so the sub-scenarios' values for a bundle nonant must agree; the bundle takes that shared value. A bundle's sub-scenarios are all local, so — unlike the cross-scenario unbundled case, which would need an MPI collective — we **check** and raise a clear `RuntimeError` on a mismatch:

> `Bundle_0_4: scenarios in this bundle give different rho for nonant scen0.x_1_ (scen0=10.0, scen1=20.0). PH requires one rho per nonant at a node; make the per-scenario {s}_rho.csv files agree.`

No rho files → `[]` → `--default-rho`, as before. Plain (unbundled) scenarios are unchanged.

### Usage

```bash
# write 10 scenarios (also emits a {s}_rho.csv per scenario), then read back as bundles
python generic_cylinders.py --module-name sizes_expression --num-scens 10 --default-rho 1 \
    --solver-name SOLVER --max-iterations 0 --write-scenario-lp-mps-files-dir DIR

# 10 files / 5 per bundle = 2 bundles; count is inferred from the directory (no --num-scens)
mpiexec -np 3 python -m mpi4py generic_cylinders.py --mps-files-directory=DIR \
    --scenarios-per-bundle 5 --xhatshuffle --lagrangian --default-rho 1 \
    --solver-name SOLVER --max-iterations 10
```

### Scope note

The rho equality check is **within a bundle** (free, since those sub-scenarios are co-located). Disagreement *across* bundles — the same node-nonant in scenarios that landed in different bundles/ranks — is still unchecked, the same limitation the unbundled path has (it would need a reduce over ranks).

## Tests

`test_mps.py` (all solver-free, so they run in the no-solver CI job):
- `TestMPSModuleBundleRho`: consistent files → shared value; disagreement → `RuntimeError`; no csv → `--default-rho` fallback.
- `TestMPSModuleProperBundling`: `name_lists` infers `num_scens` from the fixture directory and sizes the bundles (real `mps_module` + `ProperBundler`).

Also exercised end-to-end (manually; `examples/sizes/mps_demo.bash` is not a CI test) — a bundled `--mps-files-directory` run converges with the xhatshuffle/lagrangian spokes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
