### PR TITLE
Consistent CROSS_SCENARIO_COST/CUT buffer sizing above one rank per cylinder (#727)

### DIFF
--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -98,6 +98,10 @@ jobs:
         run: |
           coverage run $COV_ARGS -m pytest mpisppy/tests/test_chance_constraint.py -v
 
+      - name: Test cross-scenario buffer sizing
+        run: |
+          coverage run $COV_ARGS -m pytest mpisppy/tests/test_cross_scenario_buffer_sizing.py -v
+
       - name: Test afew
         run: |
           PYARGS="-m coverage run $COV_ARGS"

--- a/mpisppy/cylinders/spwindow.py
+++ b/mpisppy/cylinders/spwindow.py
@@ -58,8 +58,13 @@ _field_lengths = {
         Field.OBJECTIVE_OUTER_BOUND : 1,
         Field.EXPECTED_REDUCED_COST : field_length_components._total_number_nonants,
         Field.SCENARIO_REDUCED_COST : field_length_components._local_nonant_length,
+        # CROSS_SCENARIO_CUT is global-sized: every rank holds one cut row (eta
+        # coef + nonant coefs + constant) for every scenario, replicated across a
+        # cylinder's ranks. CROSS_SCENARIO_COST is local-sized: one recourse-cost
+        # (eta) value per global scenario, for each *local* scenario. Both must use
+        # the global scenario count (_total_number_scenarios), not the local one.
         Field.CROSS_SCENARIO_CUT : field_length_components._total_number_scenarios * (field_length_components._total_number_nonants + 1 + 1),
-        Field.CROSS_SCENARIO_COST : field_length_components._total_number_scenarios * field_length_components._total_number_scenarios,
+        Field.CROSS_SCENARIO_COST : field_length_components._total_number_scenarios * field_length_components._local_scenario_length,
         Field.NONANT_LOWER_BOUNDS : field_length_components._total_number_nonants,
         Field.NONANT_UPPER_BOUNDS : field_length_components._total_number_nonants,
         Field.BEST_XHAT : field_length_components._local_nonant_length + field_length_components._local_scenario_length,
@@ -80,7 +85,7 @@ class FieldLengths:
         field_length_components._local_nonant_length.value = number_nonants
         field_length_components._local_scenario_length.value = len(opt.local_scenarios)
         field_length_components._total_number_nonants.value = opt.nonant_length
-        field_length_components._total_number_scenarios.value = len(opt.local_scenarios)
+        field_length_components._total_number_scenarios.value = len(opt.all_scenario_names)
 
         self._field_lengths = {k : pyo.value(v) for k, v in _field_lengths.items()}
 

--- a/mpisppy/extensions/cross_scen_extension.py
+++ b/mpisppy/extensions/cross_scen_extension.py
@@ -238,9 +238,12 @@ class CrossScenarioExtension(Extension):
             )
             self.send_nonants = True
         ## End if-else
+        # CROSS_SCENARIO_COST is local-sized: one eta value per global scenario,
+        # for each local scenario (see send_to_cross_cuts). It is nscen * nscen
+        # only when every cylinder has exactly one rank (local_scen_count==nscen).
         self.all_etas = spcomm.register_send_field(
             Field.CROSS_SCENARIO_COST,
-            nscen * nscen,
+            nscen * local_scen_count,
         )
         return
 

--- a/mpisppy/tests/test_cross_scenario_buffer_sizing.py
+++ b/mpisppy/tests/test_cross_scenario_buffer_sizing.py
@@ -1,0 +1,132 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+"""
+Regression test for issue #727: the CROSS_SCENARIO_COST and CROSS_SCENARIO_CUT
+window buffers must be sized consistently when a cylinder spans more than one
+rank, i.e. when the number of *local* scenarios on a rank is smaller than the
+*global* scenario count.
+
+The bug was that FieldLengths set ``_total_number_scenarios`` to the local
+scenario count, so:
+
+  * CROSS_SCENARIO_COST (logically nscen * local) was sized local * local, and
+  * CROSS_SCENARIO_CUT (logically nscen * (nonants + 2)) was sized
+    local * (nonants + 2),
+
+while the CrossScenarioExtension sender advertised nscen * nscen for the cost
+field and the spoke wrote nscen rows into the cut buffer. All three sizings
+only agree when local == nscen (one rank per cylinder), which is why the bug
+was invisible in single-rank-per-cylinder runs.
+
+These checks are deterministic and serial: they drive the length computation
+directly with a stand-in ``opt`` for which local < nscen, so they pin the
+sizes without needing an MPI window. They fail on the pre-fix code (which
+yields local*local and nscen*nscen) and pass once every site agrees on
+nscen * local.
+"""
+
+import types
+import unittest
+
+from mpisppy.cylinders.spwindow import Field, FieldLengths
+from mpisppy.extensions.cross_scen_extension import CrossScenarioExtension
+
+# local < nscen: the regime where the three sizings used to diverge.
+NSCEN = 5
+LOCAL = 2
+NONANTS_PER_SCEN = 3
+
+
+def _fake_opt_for_field_lengths(nscen, local, nonants_per_scen):
+    """Minimal stand-in carrying exactly what FieldLengths.__init__ reads."""
+    def _scen():
+        # nonant_indices only needs a length here.
+        return types.SimpleNamespace(
+            _mpisppy_data=types.SimpleNamespace(
+                nonant_indices=list(range(nonants_per_scen))
+            )
+        )
+
+    return types.SimpleNamespace(
+        local_scenarios={f"Scen{i}": _scen() for i in range(local)},
+        all_scenario_names=[f"Scen{i}" for i in range(nscen)],
+        # nonant_length is the global (per-scenario, first-stage) nonant count.
+        nonant_length=nonants_per_scen,
+    )
+
+
+class _RecordingSpcomm:
+    """Records register_send_field lengths so the sender can be inspected."""
+
+    def __init__(self):
+        self.registered = {}
+
+    def is_send_field_registered(self, field):
+        return field in self.registered
+
+    def register_send_field(self, field, length):
+        self.registered[field] = length
+        return [0.0] * length
+
+
+def _fake_opt_for_extension(nscen, local, nonants_per_scen):
+    return types.SimpleNamespace(
+        multistage=False,
+        options={},
+        spcomm=_RecordingSpcomm(),
+        all_scenario_names=[f"Scen{i}" for i in range(nscen)],
+        local_scenario_names=[f"Scen{i}" for i in range(local)],
+        nonant_length=nonants_per_scen,
+    )
+
+
+class TestCrossScenarioBufferSizing(unittest.TestCase):
+
+    def setUp(self):
+        self.fl = FieldLengths(
+            _fake_opt_for_field_lengths(NSCEN, LOCAL, NONANTS_PER_SCEN)
+        )
+
+    def test_cross_scenario_cost_is_nscen_times_local(self):
+        # one eta per global scenario, for each local scenario
+        self.assertEqual(self.fl[Field.CROSS_SCENARIO_COST], NSCEN * LOCAL)
+        # guard: the pre-fix sizing was local*local; with local < nscen these
+        # differ, so this assertion would have caught the bug.
+        self.assertNotEqual(NSCEN * LOCAL, LOCAL * LOCAL)
+
+    def test_cross_scenario_cut_is_global_sized(self):
+        # one cut row [const, eta_coef, *nonant_coefs] per global scenario
+        row_len = NONANTS_PER_SCEN + 1 + 1
+        self.assertEqual(self.fl[Field.CROSS_SCENARIO_CUT], NSCEN * row_len)
+        # guard: the pre-fix sizing was local * row_len.
+        self.assertNotEqual(NSCEN * row_len, LOCAL * row_len)
+
+    def test_sender_cost_registration_matches_receiver_default(self):
+        opt = _fake_opt_for_extension(NSCEN, LOCAL, NONANTS_PER_SCEN)
+        ext = CrossScenarioExtension(opt)
+        ext.register_send_fields()
+
+        registered = opt.spcomm.registered
+        # The sender (extension) and the receiver default (FieldLengths) must
+        # agree, both at nscen * local -- not the pre-fix nscen * nscen.
+        self.assertEqual(
+            registered[Field.CROSS_SCENARIO_COST], NSCEN * LOCAL
+        )
+        self.assertEqual(
+            registered[Field.CROSS_SCENARIO_COST],
+            self.fl[Field.CROSS_SCENARIO_COST],
+        )
+        # the nonant send field is local-sized as before
+        self.assertEqual(
+            registered[Field.NONANTS_VALS], LOCAL * NONANTS_PER_SCEN
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/run_coverage.bash
+++ b/run_coverage.bash
@@ -71,6 +71,9 @@ run_phase "test_cvar (serial)" \
 run_phase "test_chance_constraint (serial)" \
     coverage run --rcfile=.coveragerc -m pytest mpisppy/tests/test_chance_constraint.py -v
 
+run_phase "test_cross_scenario_buffer_sizing (serial)" \
+    coverage run --rcfile=.coveragerc -m pytest mpisppy/tests/test_cross_scenario_buffer_sizing.py -v
+
 run_phase "test_component_map_usage (serial)" \
     coverage run --rcfile=.coveragerc -m pytest mpisppy/tests/test_component_map_usage.py -v
 


### PR DESCRIPTION
Fixes #727.

## Problem

`Field.CROSS_SCENARIO_COST` and `Field.CROSS_SCENARIO_CUT` were sized three
different ways that only agree when each cylinder has exactly **one rank**
(`local == nscen`). The root cause is `FieldLengths.__init__` in `spwindow.py`
setting `_total_number_scenarios` to the **local** scenario count
(`len(opt.local_scenarios)`) despite the "total" name.

With more than one rank per cylinder (`local < nscen`):

- **`CROSS_SCENARIO_COST`** (logically `nscen * local`): the sender advertised
  `nscen * nscen`, the receiver default was `local * local`, and the read loop
  assumed `nscen * local` — three different sizes. `_validate_recv_field`
  rejects the sender/receiver mismatch at window creation.
- **`CROSS_SCENARIO_CUT`** (logically `nscen * (nonants + 2)`): sender and
  receiver both took the default `local * (nonants + 2)`, but the spoke writes
  `nscen` rows — an out-of-bounds write.

## Fix

1. **`spwindow.py`** — `_total_number_scenarios` now holds the global count
   (`len(opt.all_scenario_names)`); the name is finally truthful. This corrects
   `CROSS_SCENARIO_CUT` to its global size. `CROSS_SCENARIO_COST` becomes
   `_total_number_scenarios * _local_scenario_length` (`nscen * local`), not
   squared.
2. **`cross_scen_extension.py`** — the sender registers `CROSS_SCENARIO_COST`
   as `nscen * local_scen_count` to match.

`_total_number_scenarios` is used only by these two fields, so the change is
safe for all other cylinder configurations.

## Test

`mpisppy/tests/test_cross_scenario_buffer_sizing.py` (serial, deterministic, 3
tests) drives the length computation and the extension's `register_send_fields`
with a stand-in `opt` where `local < nscen`, pinning all three sizings at
`nscen * local` / `nscen * (nonants + 2)`. It fails on the pre-fix code and
passes on the fix. Wired into `run_coverage.bash` and `test_pr_and_main.yml`.

## Note (out of scope)

A serial unit test was chosen deliberately. An end-to-end MPI run with more
than one rank per cylinder currently aborts **before** the buffer logic, at
`MPI.Win.Allocate` (`MPI_ERR_WIN`), and this reproduces on `main` without these
changes — a separate, pre-existing issue independent of #727 (the buffer fix is
necessary but not sufficient to fully exercise multirank cross-scenario). Cross
scenario at one rank per cylinder is unaffected and continues to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
