### PR TITLE
Defer attaching W and prox terms until after PH iteration 0 (#772)

### DIFF
--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -570,7 +570,8 @@ jobs:
       - name: Install dependencies
         run: |
           conda install mpi4py pandas setuptools
-          pip install pyomo xpress cplex coverage
+          # scipy is needed for the prox-linearization (linearize_proximal_terms) test
+          pip install pyomo xpress cplex scipy coverage
 
       - name: setup the program
         run: |

--- a/mpisppy/cylinders/lagrangian_bounder.py
+++ b/mpisppy/cylinders/lagrangian_bounder.py
@@ -15,8 +15,12 @@ class _LagrangianMixin:
     def lagrangian_prep(self):
         # Split up PH_Prep? Prox option is important for APH.
         # Seems like we shouldn't need the Lagrangian stuff, so attach_prox=False
-        # Scenarios are created here
-        self.opt.PH_Prep(attach_prox=False)
+        # Scenarios are created here.
+        # defer_attach=False: the Lagrangian spoke never runs Iter0; it attaches
+        # W here, re-enables it, and solves directly, so the W term must be
+        # spliced into the objective now rather than deferred to the end of
+        # Iter0 (which is where the PH hub attaches it).
+        self.opt.PH_Prep(attach_prox=False, defer_attach=False)
         self.opt._reenable_W()
         self.opt._create_solvers()
 

--- a/mpisppy/opt/fwph.py
+++ b/mpisppy/opt/fwph.py
@@ -104,7 +104,11 @@ class FWPH(mpisppy.phbase.PHBase):
         return mip_solver_name, qp_solver_name
 
     def fwph_main(self, finalize=True):
-        self.PH_Prep(attach_duals=True, attach_prox=False)
+        # defer_attach=False: FWPH snarfs the subproblem objective (with W
+        # attached) between PH_Prep and Iter0 via _attach_nonant_objective and
+        # _set_QP_objective, so the W terms must be spliced in here rather than
+        # deferred to the end of Iter0.
+        self.PH_Prep(attach_duals=True, attach_prox=False, defer_attach=False)
         self._output_header()
         self._attach_MIP_vars()
         self._cache_nonant_var_swap_mip()

--- a/mpisppy/phbase.py
+++ b/mpisppy/phbase.py
@@ -846,23 +846,59 @@ class PHBase(mpisppy.spopt.SPOpt):
                                           "add_duals": add_duals, "add_prox": add_prox})
 
 
+    def _attach_PH_to_objective_after_iter0(self):
+        """ Splice the W/prox terms into the objective after the iteration-0
+        solve, and refresh any persistent solvers.
+
+        ``attach_PH_to_objective`` mutates each subproblem objective and, in
+        prox-approximation mode, also adds the ``xsqvar`` variable plus its cut
+        constraints. Because the subproblem solvers were already created (and
+        persistent solvers had ``set_instance`` called) on the user's original
+        objective during Iter0, a persistent solver does not see these later
+        changes; we re-run ``set_instance`` so the new terms and components
+        reach the solver. Non-persistent solvers re-read the model on the next
+        solve, so they need nothing here.
+        """
+        self.attach_PH_to_objective(self._attach_duals,
+                                    self._attach_prox,
+                                    self._attach_smooth)
+        if (not self._attach_duals) and (not self._attach_prox):
+            # attach_PH_to_objective made no change to the objective
+            # (e.g. APH passes both flags False); nothing to re-push.
+            return
+        for sname, s in self.local_scenarios.items():
+            if sputils.is_persistent(s._solver_plugin):
+                mpisppy.spopt.set_instance_retry(s, s._solver_plugin, sname)
+
 
     def PH_Prep(
         self,
         attach_duals=True,
         attach_prox=True,
-        attach_smooth=0
+        attach_smooth=0,
+        defer_attach=True,
     ):
         """ Set up PH objectives (duals and prox terms), and prepare
         extensions, if available.
 
         Args:
-            add_duals (boolean, optional):
+            attach_duals (boolean, optional):
                 If True, adds dual weight (Ws) to the objective. Default True.
-            add_prox (boolean, optional):
+            attach_prox (boolean, optional):
                 If True, adds prox terms to the objective. Default True.
             attach_smooth (int, optional):
                 If 0, no smoothing; if 1, p_value is used; if 2, p_ratio is used.
+            defer_attach (boolean, optional):
+                If True (default), the W and prox terms are not spliced into
+                the subproblem objectives here; instead they are attached at
+                the end of Iter0 (see _attach_PH_to_objective_after_iter0) so
+                that the iteration-0 solve uses exactly the user's objective --
+                no PH machinery in the expression tree. If False, the terms are
+                attached immediately (legacy behavior, needed by FWPH, which
+                snarfs the subproblem objective between PH_Prep and Iter0).
+                Agnostic (AML guest) runs are always attached immediately
+                regardless of this flag (the guest builds its xbars Param in
+                the attach callout, which solve_one needs from iteration 0).
 
         Note:
             This function constructs an Extension object if one was specified
@@ -872,7 +908,24 @@ class PHBase(mpisppy.spopt.SPOpt):
         self.attach_Ws_and_prox()
         if attach_smooth:
             self.attach_smoothing()
-        self.attach_PH_to_objective(attach_duals, attach_prox, attach_smooth)
+        # attach_PH_to_objective sets self._prox_approx; when the attach is
+        # deferred it has not run yet, but the iteration-0 solve_loop reads
+        # this flag. Prox terms (and any prox approximation) are structurally
+        # absent in iteration 0, so the flag must read False there regardless.
+        self._prox_approx = False
+        # Remember what to attach and whether it was deferred, so Iter0 can
+        # splice the terms in after the iteration-0 solve.
+        self._attach_duals = attach_duals
+        self._attach_prox = attach_prox
+        self._attach_smooth = attach_smooth
+        # Agnostic (AML) guests build the W/prox terms -- including the guest
+        # xbars Param that solve_one copies into on every solve -- inside the
+        # guest's attach_PH_to_objective callout, which must run before the
+        # iteration-0 solve. The deferral is therefore not applied to agnostic
+        # runs; they keep the legacy attach-in-PH_Prep behavior.
+        self._deferred_ph_attach = defer_attach and (self.Ag is None)
+        if not self._deferred_ph_attach:
+            self.attach_PH_to_objective(attach_duals, attach_prox, attach_smooth)
 
 
     def options_check(self):
@@ -1109,6 +1162,15 @@ class PHBase(mpisppy.spopt.SPOpt):
 
         if dconvergence_detail:
             self.report_var_values_at_rank0(header="Convergence detail:", fixed_vars=False)
+
+        # Iteration 0 solved the user's original objective. Now (unless a
+        # caller already attached them in PH_Prep) splice the dual (W) and
+        # proximal terms into the subproblem objectives. Deferring to here
+        # keeps the iteration-0 model structurally identical to what the user
+        # passed in -- helpful for debugging and for LP-only solvers that
+        # cannot handle the quadratic prox term until iteration 1.
+        if getattr(self, "_deferred_ph_attach", False):
+            self._attach_PH_to_objective_after_iter0()
 
         self.reenable_W_and_prox()
 

--- a/mpisppy/tests/test_ph_main.py
+++ b/mpisppy/tests/test_ph_main.py
@@ -211,6 +211,96 @@ class TestPHMainFarmer(unittest.TestCase):
         conv, obj, tbound = ph.ph_main()
         self.assertIsNotNone(obj)
 
+    def _has_ph_objective_terms(self, s):
+        """Return (has_W, has_prox) for a scenario's PH objective terms."""
+        m = s._mpisppy_model
+        return hasattr(m, "WExpr"), hasattr(m, "ProxExpr")
+
+    def _objective_has_quadratic(self, s):
+        """True if the active objective has any quadratic/nonlinear part."""
+        from pyomo.repn import generate_standard_repn
+        import mpisppy.utils.sputils as sputils
+        obj = sputils.find_active_objective(s)
+        repn = generate_standard_repn(obj.expr, compute_values=False,
+                                      quadratic=True)
+        return bool(repn.quadratic_vars) or (repn.nonlinear_expr is not None)
+
+    @unittest.skipIf(not solver_available,
+                     "%s solver is not available" % (solver_name,))
+    def test_iter0_uses_user_objective(self):
+        """W/prox terms are absent during iteration 0 and attached afterward.
+
+        Regression test for issue #772: iteration 0 should solve exactly the
+        objective the user passed in -- no PH machinery (W, prox, xsqvar) in
+        the expression tree -- with the terms spliced in only at the end of
+        Iter0.
+        """
+        ph = mpisppy.opt.ph.PH(
+            self._copy_options(),
+            self.scenario_names,
+            farmer.scenario_creator,
+            farmer.scenario_denouement,
+            scenario_creator_kwargs=self.creator_kwargs,
+        )
+        ph.PH_Prep(attach_prox=True)
+        s0 = ph.local_scenarios[self.scenario_names[0]]
+
+        # Before Iter0: pure user objective, no PH terms, not quadratic.
+        has_W, has_prox = self._has_ph_objective_terms(s0)
+        self.assertFalse(has_W, "W term should be absent before Iter0")
+        self.assertFalse(has_prox, "prox term should be absent before Iter0")
+        self.assertFalse(self._objective_has_quadratic(s0),
+                         "iteration-0 objective should be the user's "
+                         "(non-quadratic for farmer) objective")
+
+        ph.Iter0()
+
+        # After Iter0: PH terms attached and re-enabled.
+        has_W, has_prox = self._has_ph_objective_terms(s0)
+        self.assertTrue(has_W, "W term should be attached after Iter0")
+        self.assertTrue(has_prox, "prox term should be attached after Iter0")
+        self.assertFalse(ph.prox_disabled,
+                         "prox should be re-enabled after Iter0")
+        self.assertFalse(ph.W_disabled,
+                         "W should be re-enabled after Iter0")
+
+    @unittest.skipIf(not persistent_available,
+                     "%s solver is not available" % (persistent_solver_name,))
+    def test_iter0_defers_with_prox_approx_persistent(self):
+        """Deferred attach works with prox linearization on a persistent solver.
+
+        With ``linearize_proximal_terms`` the prox term introduces the new
+        ``xsqvar`` variable and cut constraints inside attach_PH_to_objective.
+        Because the persistent solver was built on the user's objective during
+        Iter0, the deferred attach must re-push the instance. Confirms xsqvar
+        is absent before Iter0, present after, and the run completes.
+        """
+        options = self._copy_options()
+        options["solver_name"] = persistent_solver_name
+        options["PHIterLimit"] = 20
+        options["linearize_proximal_terms"] = True
+        options["proximal_linearization_tolerance"] = 1e-1
+        ph = mpisppy.opt.ph.PH(
+            options,
+            self.scenario_names,
+            farmer.scenario_creator,
+            farmer.scenario_denouement,
+            scenario_creator_kwargs=self.creator_kwargs,
+        )
+        ph.PH_Prep(attach_prox=True)
+        s0 = ph.local_scenarios[self.scenario_names[0]]
+        self.assertFalse(hasattr(s0._mpisppy_model, "xsqvar"),
+                         "xsqvar should not exist before Iter0")
+
+        ph.Iter0()
+        self.assertTrue(hasattr(s0._mpisppy_model, "xsqvar"),
+                        "xsqvar should be created by the deferred attach")
+
+        # Remaining iterations exercise the re-pushed persistent instance.
+        ph.iterk_loop()
+        obj = ph.post_loops(ph.extensions)
+        self.assertAlmostEqual(obj, FARMER_EF_OBJ, delta=500)
+
 
 class TestPHMainSizes(unittest.TestCase):
     """Test PH.ph_main() with the sizes (MIP) model, including fixer."""


### PR DESCRIPTION
## Summary

Defer attaching the PH dual (`W`) and proximal (`prox`) terms to the subproblem
objectives until **after iteration 0**, so that the iteration-0 solve uses
exactly the objective the user passed in — no PH machinery in the expression
tree. Implements #772 for the native (Pyomo) PH path.

Motivation (from #772):
- **Debugging:** iteration 0 is exactly the model the user handed us.
- **LP-only solvers:** cbc/glpk no longer see even a `0 * x**2` term in
  iteration 0; the quadratic prox first appears at iteration 1.

## What changed

- **`PHBase.PH_Prep`** no longer splices the W/prox terms into the objective. It
  still creates the Params (`W`, `prox_on`, `rho`, smoothing) and now stashes the
  attach flags, deferring by default (`defer_attach=True`).
- **`PHBase.Iter0`** calls the new `_attach_PH_to_objective_after_iter0()` at the
  end (after the solve and trivial bound, before `reenable_W_and_prox`). For
  **persistent** solvers it re-runs `set_instance` so the added terms — and, in
  prox-approximation mode, the new `xsqvar` variable and its cut constraints —
  reach the solver. Non-persistent solvers re-read the model on the next solve.

### Opt-outs (`defer_attach=False`)

- **FWPH** snarfs the subproblem objective between `PH_Prep` and `Iter0`
  (`_attach_nonant_objective` / `_set_QP_objective`), so it attaches immediately.
- **Lagrangian / Lagranger** spokes never run `Iter0` (they attach `W`,
  re-enable it, and solve directly), so they attach immediately.

### Agnostic (AML) guests

Auto-excluded from the deferral (`self.Ag is None` gate): each guest builds its
`xbars` Param inside the attach callout, which `solve_one` copies into from
iteration 0. Extending the deferral to the guests is tracked as a follow-up in
**#775**. Agnostic runs keep their exact current behavior here.

## Testing

- New tests in `mpisppy/tests/test_ph_main.py` (already wired into the coverage
  harness): structural purity (no `WExpr` / `ProxExpr` / quadratic term before
  `Iter0`, present and re-enabled after) and a persistent prox-approximation case
  that exercises the re-`set_instance` path and still converges.
- Regression sweep (gurobi_persistent): `test_ef_ph`, `test_ph_main`,
  `test_prox_approx{,_e2e}`, `test_ph_extensions`, `test_aph`,
  `test_gradient_rho`, `test_generic_cylinders`, and the MPI cylinder tests — all
  green. `ruff` clean.
- Agnostic AMPL and pyomo guest PH tests pass (the pre-existing GAMS
  environment/license failure and the gurobipy skip are unrelated to this
  change).

## Scope

PH-family only; APH (`opt/aph.py`) attaches neither term in `PH_Prep`, so it is
unaffected.

Addresses #772. Agnostic-guest deferral follow-up: #775.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
