### PR TITLE
W-oscillation detection (PR1: detect + report)

### DIFF
--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -124,6 +124,10 @@ jobs:
         run: |
           coverage run $COV_ARGS -m pytest mpisppy/tests/test_generic_cylinders.py -v
 
+      - name: Test W-oscillation detection
+        run: |
+          coverage run $COV_ARGS -m pytest mpisppy/tests/test_w_oscillation.py -v
+
       - name: Test xhat from file
         run: |
           coverage run $COV_ARGS -m pytest mpisppy/tests/test_xhat_from_file.py -v

--- a/doc/designs/w_oscillation_design.md
+++ b/doc/designs/w_oscillation_design.md
@@ -1,0 +1,525 @@
+# W-oscillation detection and interruption — design
+
+**Status:** PR1 *detection + reporting* (pure observation, no behavior
+change) is implemented in ``mpisppy/extensions/w_oscillation.py``; PR2
+*interruption* (acts on the detector to break the oscillation) is not yet
+started. Shipped as **two review-sized PRs**.
+**Author:** dlw (captured with Claude Code assistance)
+**Last updated:** 2026-06-30
+
+Related work:
+
+- **wtracker** (`mpisppy/utils/w_utils/`) already tracks the W vector and
+  computes moving statistics; `wtracker.py` even lists "track oscillations,
+  which are important for MIPs" as an explicit TODO, and ships a crude
+  `check_cross_zero`. This design is the planned successor to that TODO. The
+  user documentation for the detection PR **cross-references the wtracker
+  docs** as the way to get the full W trajectory and moving-stat reports;
+  this extension is the focused *oscillation* layer on top of the same data.
+- **sorgw** (PySP's `pysp/plugins/sorgw.py`) — the zero-crossing detector
+  this design adopts as method A (§5.1).
+- **Watson–Woodruff "Progressive Hedging Innovations for a Class of Stochastic
+  Mixed-Integer Resource Allocation Problems"** (Computational Management
+  Science, 2011; optimization-online 2089), §2.4 "Detecting Cyclic Behavior" —
+  the W-vector-hashing cycle detector this design adopts as method B (§5.2).
+  Its §2.1 (SEP / cost-proportional rho) motivates the rho-reduction action
+  (§9).
+- **slammer** (`mpisppy/extensions/slammer.py`, `doc/designs/slamming_design.md`)
+  — the slamming *mechanism* whose action layer (its §7) PR2's "slam" action
+  invokes. The slamming design explicitly anticipated "a separate future
+  project that detects stalls/cycles" as the consumer of that mechanism;
+  **this is that project.**
+
+---
+
+## 0. Vocabulary
+
+We say a nonanticipative variable's dual weight **W oscillates** when, for a
+given (scenario, nonant) pair, the trajectory of `W` over PH iterations
+changes sign repeatedly or fails to damp — the hallmark of PH cycling, which
+is common and convergence-killing for MIPs. Watson–Woodruff §2.1 describes the
+mechanism: "Oscillation can occur when the `w` values are updated too
+aggressively or converge from both sides, particularly in MIPs, because the
+changes in the value of one integer variable can induce changes in others,
+which are then reversed if the `w` multiplier 'shoots past' its optimal
+value." Detection is **per (scenario, nonant)**; a nonant is *reported* /
+*acted on* using an aggregate across scenarios (§6).
+
+---
+
+## 1. Goals and non-goals
+
+### Goals
+
+1. A **hub extension** that, while a PH hub runs, observes the W vector and
+   **detects oscillation** per the methods in §5, configured entirely from a
+   **JSON control file**.
+2. **Report** detected oscillations to a **CSV file** (header + one row per
+   detection event), filename from the JSON, **written by cylinder rank 0**.
+   Each row names the **full variable name** and the oscillation evidence
+   relative to the JSON's control parameters (e.g. how many crossings, in how
+   many scenarios).
+3. (PR2) Optionally **interrupt** detected oscillation, via **rho reduction**
+   and/or **slamming**, configured from a second JSON control file.
+4. **Pluggable detection methods.** The JSON selects which method(s) run and
+   parameterizes each, so methods can be added without touching the CLI.
+5. **Reuse, don't duplicate, the W-tracking code.** Capture the W trajectory
+   with the same idiom wtracker uses; cross-reference wtracker in the docs.
+6. **Total backward compatibility.** A run with neither new flag behaves
+   exactly as today; PR1 never changes the algorithm (pure observation).
+
+### Non-goals
+
+- **APH.** The hooks run under any `PHBase` hub, but oscillation/cadence
+  notions assume synchronous iterations. Scope is **synchronous PH**; APH is
+  not specially wired (consistent with the project's "PH-only, C++ APH
+  incoming" posture and the slamming design's APH caveat).
+- **Spokes.** This is a hub extension. Outer/inner-bound spokes are untouched.
+- **Replacing wtracker.** wtracker remains the general W-logging / moving-stat
+  tool; this extension is the narrower oscillation detector/actor that reuses
+  its capture idiom.
+- **A new slamming mechanism.** PR2 *calls* the existing Slammer action layer;
+  it does not reimplement fixing.
+
+---
+
+## 2. User interface
+
+Two flags on the generic driver (and any Config-based driver), each taking a
+**JSON filename**:
+
+| Flag | Effect |
+|---|---|
+| `--detect-W-oscillations PATH` | Activates the extension in **detect+report** mode; controls in the JSON at `PATH`. |
+| `--interrupt-W-oscillations PATH` | (PR2) Activates **interruption**; controls in the JSON at `PATH`. Implies detection — if `--detect-W-oscillations` is absent, a default detector config is used (or the interrupt JSON may carry a `detect` block, see §9). |
+
+Presence of a flag activates the extension (mirroring how
+`--slamming-directives-file` activates the Slammer). Neither flag ⇒ extension
+never constructed ⇒ identical behavior to today.
+
+### 2.1 Detection JSON schema (PR1)
+
+```jsonc
+{
+  "output_csv": "w_oscillations.csv",  // per-nonant aggregate; rank-0 writes (required)
+  "per_scenario_csv": null, // optional per-(scenario,nonant) detail file (§7.1); null = off
+  "warmup_iters": 5,        // don't evaluate until this many W samples exist
+  "check_every": 1,         // evaluate detectors every N iterations after warmup
+  "report_mode": "on_detect", // "on_detect" | "final" | "every_check"
+  "min_scenarios_to_report": 1, // a nonant is reported once >= this many
+                                // scenarios flag it (int; or use "frac" below)
+  "min_frac_to_report": null,   // alternative: fraction of scenarios (0..1)
+  "methods": {              // which detectors run; keys are method names
+    "zero_crossings": {     // method A (§5.1); params override defaults
+      "tol": 1e-6,
+      "window": null,                 // null = whole trajectory so far
+      "thresh_w_crossings": 2,
+      "thresh_diff_crossings": 3,
+      "thresh_diffs_ratio": 0.2
+    },
+    "w_hash_recurrence": {  // method B (§5.2)
+      "window": 20,         // look back this many iterations for a repeat
+      "quantum": 1e-6,      // W values quantized to this before hashing
+      "min_period": 2       // ignore period-1 (constant W = convergence)
+    }
+  }
+}
+```
+
+Only methods **present** in `"methods"` are run; a method's omitted params
+fall back to documented defaults. `report_mode` defaults to `on_detect`
+(write a row the first time, and each subsequent `check_every`, a nonant
+crosses into the flagged state). `final` writes one report at
+`post_everything` (sorgw's behavior). The exact set of knobs per method lives
+with that method (§5).
+
+### 2.2 Interruption JSON schema (PR2)
+
+```jsonc
+{
+  "action": "rho_reduction",      // "rho_reduction" | "slam" | "both"
+                                  // docs encourage one or the other; "both"
+                                  // simply applies both, no coordination (§9)
+  "trigger": {
+    "min_scenarios_flagged": 1,   // act when >= this many scenarios flag a nonant
+    "start_iter": 5,
+    "iters_between_actions": 3
+  },
+  "rho_reduction": { "factor": 0.5, "min_rho": 1e-3 },
+  "slam": { "directives_file": "slam_directives.csv" }  // feeds the Slammer
+}
+```
+
+---
+
+## 3. Where it lives
+
+- New module `mpisppy/extensions/w_oscillation.py`, class
+  `WOscillationMonitor(Extension)`. One extension does both jobs: a
+  **detection engine** (always on when either flag is set) plus two consumers
+  of its results — a **reporter** (PR1) and an **interrupter** (PR2). This
+  keeps a single W-capture path and a single source of truth for "what is
+  oscillating."
+- Detectors live as small, independently testable callables/classes in the
+  same module (or a `w_oscillation/` subpackage if it grows): each takes one
+  W trajectory and returns a per-trajectory verdict + stats (§5).
+- Config plumbing in `config.py` / `cfg_vanilla.py` / `mpisppy/generic/`
+  (§10), following the Slammer wiring exactly.
+
+---
+
+## 4. Hook placement and the per-iteration flow
+
+The PH per-iteration order around the extension hooks is: *xbar computed →
+W updated →* `miditer()` *→* `solve_loop()` *→* `enditer()`. So at
+`miditer(k)` the freshest **post-update** `W^k` is in place, and any change we
+make (rho, slam) takes effect for that iteration's `solve_loop`.
+
+| Hook | Action |
+|---|---|
+| `pre_iter0` | Parse JSON; build the detector set; build the nonant→name map; allocate the bounded W history buffer. |
+| `miditer` | **Capture** `W^k` into the buffer (reusing wtracker's grab idiom). After `warmup_iters`, every `check_every`: **evaluate** detectors locally, **reduce** across scenarios (§6), and — PR1 — **report** flagged nonants; PR2 — **interrupt** per the trigger. |
+| `post_everything` | If `report_mode == "final"`, run one last evaluate+reduce+report. Close the CSV. Rank-0 summary line. |
+
+Capturing in `miditer` (post-update W) is the natural sampling point for the
+*updated* dual trajectory; it differs from `Wtracker_extension`, which grabs
+in `enditer` (same numeric W that iteration, but framed as pre-update). We
+reuse the one-line grab (`[w._value for w in s._mpisppy_model.W.values()]`)
+and keep our **own bounded ring buffer** of length
+`max(window over active methods)` rather than wtracker's keep-everything
+dict — bounding memory for long runs (wtracker explicitly warns it is
+"intended for diagnostics, not everyday use"). The full-history path remains
+available via wtracker itself (cross-referenced in the docs).
+
+---
+
+## 5. Detection methods
+
+A **detector** consumes one W trajectory `w[0..m]` for a single (scenario,
+nonant) and returns `(flagged: bool, stats: dict)`. The engine runs every
+selected detector on every local (scenario, nonant) trajectory. Per-method
+defaults are the sorgw values where applicable.
+
+### 5.1 Method A — `zero_crossings` (from sorgw)
+
+Counts sign changes of `W` and of the consecutive differences `ΔW`, plus a
+damping ratio, over the trajectory (optionally only the last `window`
+samples):
+
+- `WZeroCrossings` — number of sign changes of `w[i]` (ignoring `|w| < tol`).
+- `DiffZeroCrossings` — number of sign changes of `Δw[i] = w[i+1]-w[i]`.
+- `diffs_ratio = mean(|Δw|, back half) / mean(|Δw|, front half)` — ratio ≥ 1
+  means the swings are **not** damping.
+
+Flagged iff any of:
+`WZeroCrossings >= thresh_w_crossings (2)` **or**
+`DiffZeroCrossings >= thresh_diff_crossings (3)` **or**
+`diffs_ratio >= thresh_diffs_ratio (0.2)`.
+
+This is a faithful port of sorgw's `Of_Interest` test; the per-trajectory
+counting logic is pure Python and unit-testable with no MPI (§11).
+
+### 5.2 Method B — `w_hash_recurrence` (Watson–Woodruff §2.4)
+
+Watson–Woodruff §2.4 ("Detecting Cyclic Behavior") detects a cycle by
+**repeated occurrence of the per-scenario weight vector** for a variable:
+
+> "To detect cycles, we chose to focus on repeated occurrences of `w_s(i)`
+> vectors, implemented using a simple hashing scheme to minimize impact on
+> run-time. Once a cycle is detected for any decision variable `x(i)`, the
+> value of `x(i)` is immediately fixed to `max_{s∈S} x_s(i)`…"
+
+So for each nonant `i`, the object hashed is the **vector across scenarios**
+`w(i) = (w_s(i))_{s∈S}` at the current iteration; a **recurrence** of that
+vector (same hash seen before, within a look-back window) signals a cycle.
+This keys directly on **W** (not x/x-bar), making it the natural complement to
+method A (vector recurrence vs. per-trajectory sign counting).
+
+Note the paper's *native remediation* is "fix `x(i)` to `max_s x_s(i)`" — i.e.
+**slam to max**, which is exactly the Slammer `max` direction (so PR2's
+method-B-driven action is a one-line wiring, §9).
+
+**Distributed implementation (our addition — the paper was serial).** The
+hashed vector spans scenarios that live on different ranks, so we compute a
+**distribution-independent signature** with a sum reduction (fitting the §6
+framework). Each rank forms, per nonant `i`, a partial signature over its local
+scenarios at node `ndn`:
+
+```
+term_s(i) = hash64( scenario_index_s, round(w_s(i) / quantum) )   # 64-bit
+partial_sig(i) = Σ_{local s} term_s(i)   (mod 2^64)
+```
+
+then `comms[ndn].Allreduce(partial_sig, global_sig, op=MPI.SUM)`. Mixing
+`scenario_index` into each term preserves per-scenario identity, and the sum is
+commutative, so `global_sig(i)` is **independent of how scenarios are mapped to
+ranks** — two iterations whose quantized `w(i)` vectors match (per scenario)
+get the same signature. (64-bit collisions are vanishingly rare; the paper
+likewise accepted a "simple hashing scheme" and "few variables are fixed…
+minimal impact.")
+
+Each rank keeps a per-nonant ring buffer of the last `window` global
+signatures. **Flagged** iff the current signature equals one from `min_period`
+to `window` iterations back — a genuine cycle of period ≥ `min_period`.
+`min_period ≥ 2` is required so a **constant** W (convergence, period-1
+"recurrence") is *not* mistaken for a cycle. Reported stats: detected period
+and the signature.
+
+#### 5.2.1 Background and keywords (to read more)
+
+Two well-studied ideas underpin method B; these are the search terms / references
+for anyone extending it:
+
+- **Order-/distribution-independent set hashing** — the trick that makes the
+  signature `Σ hash(scenario_index, value)` independent of how scenarios are
+  spread across ranks. Keywords: *incremental hashing*, *multiset hashing*,
+  *homomorphic / set hashing*, **AdHash / XHash / MuHash**. References:
+  Bellare & Micciancio, "A New Paradigm for Collision-Free Hashing:
+  Incrementality at Reduced Cost" (EUROCRYPT 1997); Clarke, Devadas, van Dijk,
+  Gassend & Suh, "Incremental Multiset Hash Functions and Their Application to
+  Memory Integrity Checking" (ASIACRYPT 2003). The additive (sum-mod-2^64)
+  variant is what we use; XOR is the alternative if a different collision
+  profile is wanted.
+- **Recurrence / cycle detection by state hashing** — storing a digest of each
+  visited state and flagging a repeat. This is exactly Watson–Woodruff §2.4's
+  "simple hashing scheme," and the same idea used in explicit-state model
+  checking: keywords *hash compaction*, *bitstate hashing*; references Wolper &
+  Leroy, "Reliable Hashing without Collision Detection" (CAV 1993); Holzmann,
+  "An Analysis of Bitstate Hashing" (1998). If O(1) memory is ever preferred
+  over the ring buffer, the classic sequence-cycle algorithms apply: **Floyd's**
+  (tortoise-and-hare) and **Brent's** cycle detection.
+
+### 5.3 Adding methods
+
+A new detector is a new entry in the method registry keyed by its JSON name,
+with a `(trajectory, params) -> (flagged, stats)` signature and a defaults
+dict. No CLI or wiring change needed.
+
+---
+
+## 6. Data flow and MPI reductions
+
+Detection is per (scenario, nonant); reporting/acting is per nonant, so we
+**reduce across scenarios** (the "primarily sum reductions" the spec calls
+for). The nonant index `i` aligns across scenarios at a node, so for each
+node `ndn`:
+
+1. **Local pass.** For each active method, over local scenarios at `ndn`,
+   accumulate per-nonant:
+   - `n_flagged[i]` += 1 per local scenario whose trajectory is flagged
+     (**SUM**),
+   - `max_w_crossings[i]`, `max_diff_crossings[i]`, `max_diffs_ratio[i]`
+     (**MAX**), and any other reported stat.
+2. **Reduce.** `opt.comms[ndn].Allreduce(local, global, op=MPI.SUM)` for the
+   counts and `op=MPI.MAX` for the maxes — the exact `norm_rho_updater` /
+   `dyn_rho_base` idiom, on the per-node communicators x-bar already uses.
+   Results are identical on every rank.
+3. **Decide.** A nonant is *reported* (PR1) / *eligible to act on* (PR2) iff
+   `n_flagged[i] >= min_scenarios_to_report` (or the fraction variant). Total
+   scenarios per node is known, so the fraction is exact.
+4. **Write.** Cylinder **rank 0** appends rows to the CSV; all other ranks
+   skip the write. Because step 2 makes the inputs rank-identical, rank 0's
+   rows do not depend on how scenarios were distributed across ranks (a
+   property the MPI test asserts, §11).
+
+Method B folds into the **same SUM pass**: its per-nonant signature
+(§5.2) is itself an `op=MPI.SUM` Allreduce over `comms[ndn]`, computed
+alongside the method-A counts, after which recurrence is decided locally from
+each rank's (now rank-identical) ring buffer. So one reduction round per check
+covers every active method — "primarily sum reductions," as specified.
+
+For the common **two-stage** case there is a single node `ROOT`; multistage
+falls out of iterating `s._mpisppy_node_list` and using `comms[ndn]` per node.
+
+---
+
+## 7. CSV output
+
+Header + one row per (reported nonant, method, detection event):
+
+| Column | Meaning |
+|---|---|
+| `iteration` | PH iteration at which the check fired |
+| `node` | node name (`ROOT` for two-stage) |
+| `variable` | **full nonant name** (e.g. `DevotedAcreage[SUGAR_BEETS]`) |
+| `method` | detector name (`zero_crossings`, `w_hash_recurrence`, …) |
+| `num_scenarios_total` | scenarios at this node |
+| `num_scenarios_flagged` | how many flagged this nonant (the SUM reduction; for method B, scenarios participating in the recurring vector) |
+| `max_w_crossings` | method A: max over scenarios |
+| `max_diff_crossings` | method A: " |
+| `max_diffs_ratio` | method A: " |
+| `cycle_period` | method B: detected period |
+
+Method-specific stat columns are the union over active methods (missing ⇒
+blank). Filename and (optionally) which columns to emit come from the JSON.
+
+### 7.1 Per-scenario detail file (optional)
+
+When `per_scenario_csv` is set, the extension also emits a **per-(scenario,
+nonant) breakdown** — useful for seeing *which* scenarios are driving an
+oscillation, not just the aggregate. The aggregate report (§6/§7) uses a SUM/MAX
+**reduction**, which discards per-scenario identity; the detail file instead
+**gathers** the (small) set of flagged per-scenario rows to rank 0
+(`comms[ndn].gather` of only the rows a rank flagged), and rank 0 writes them as
+one file. Columns: `iteration, node, scenario, variable, method`, plus the
+per-trajectory stats (`w_crossings, diff_crossings, diffs_ratio` for method A;
+the scenario's quantized `w` value and whether its node's vector recurred for
+method B).
+
+Two notes: (1) the detail is most meaningful for **per-trajectory** methods
+(A), since method B's verdict is a property of the whole cross-scenario vector,
+not one scenario; for B we report each participating scenario's `w` value at the
+recurrence. (2) Only flagged rows are gathered, so the volume is bounded by what
+is actually oscillating — but on a badly thrashing problem this can still be
+large, so the file is **off by default**.
+
+---
+
+## 8. Reuse of wtracker
+
+- **Capture:** identical one-liner
+  (`[w._value for w in s._mpisppy_model.W.values()]`) over
+  `opt.local_scenarios`; the nonant→name alignment is wtracker's
+  `varnames` construction. We factor this into a tiny shared helper if it
+  reads cleanly, else replicate the one line (it is trivial and already
+  duplicated in `wxbarutils`).
+- **Docs:** the detection PR's user doc cross-references the wtracker docs for
+  the full W trajectory + moving-stat (`stdev` / `CV`) reports, positioning
+  this extension as the focused oscillation layer.
+- We do **not** reuse wtracker's keep-everything buffer (memory); we keep a
+  bounded ring buffer (§4).
+
+---
+
+## 9. Interruption (PR2)
+
+When a nonant is flagged (and the trigger in §2.2 fires), act in `miditer`
+before the solve:
+
+- **`rho_reduction`** — multiply that nonant's `rho` by `factor (<1)` in every
+  local scenario, floored at `min_rho > 0` (consistent with the merged rho>0
+  enforcement, #767). Reducing rho relaxes the proximal pull that is driving
+  the overshoot/cycle. The motivation is in Watson–Woodruff §2.1: the update is
+  `w_s += ρ(x_s − x̄)`, so a too-large ρ is exactly what lets `w` "shoot past"
+  its optimum and thrash; their SEP rho is designed to approach `w*` "from
+  below" to avoid this. Reducing ρ on a *detected-cycling* nonant is the
+  dynamic analogue. Which nonants to touch comes from the rank-identical
+  reduced set (§6), so the change is coherent with no extra communication; the
+  per-scenario rho write is local (push to persistent solver via
+  `update_var`).
+- **`slam`** — invoke the **Slammer action layer** (`slammer.py` §7) on the
+  flagged nonant: pick by the directives file's priority/direction and `fix()`
+  it across all scenarios. This is exactly the consumer the slamming design
+  anticipated; PR2 wires the detector's "this nonant is cycling" signal into
+  Slammer's `slam(ndn_i, direction)` rather than Slammer's built-in
+  iteration-count trigger. **Method B's paper-native remediation is precisely
+  this:** Watson–Woodruff §2.4 fixes the cycling `x(i)` to `max_s x_s(i)`,
+  which is the Slammer `max` direction — so a directives file of `*,1,max,…`
+  driven by the detector reproduces their §2.4 behavior exactly.
+- **`both`** — the user docs **encourage choosing one or the other**, but if
+  `action == "both"` we **simply apply both** with no coordination/escalation
+  logic: for each flagged nonant this event, run the `rho_reduction` action
+  *and* the `slam` action. (No special-casing of the interaction: a nonant the
+  slam directives `fix()` becomes `is_fixed()`, so the subsequent rho change on
+  it is inert — harmless; and a nonant slamming declines, e.g. not in the
+  directives file, still gets its rho reduced. The two mechanisms act on
+  whatever each is configured to act on.) Keep-it-simple was the explicit
+  decision (§13).
+
+PR2 must demonstrate interruption **helps** (§11): on a model tuned to cycle,
+the interrupted run reaches a better gap / converges in fewer iterations than
+the plain run in the same budget.
+
+---
+
+## 10. Config / CLI plumbing and backward compatibility
+
+Following the Slammer wiring precisely:
+
+- **`config.py`:** a `w_oscillation_args()` method adding
+  `--detect-W-oscillations` (PR1) and `--interrupt-W-oscillations` (PR2), both
+  `domain=str, default=None` (filename-valued, like
+  `--slamming-directives-file`). Registered in `mpisppy/generic/parsing.py`.
+- **`cfg_vanilla.py`:** `add_w_oscillation(hub_dict, cfg)` appends
+  `WOscillationMonitor` via `extension_adder` (the `MultiExtension` path) and
+  attaches `hub_dict["opt_kwargs"]["options"]["w_oscillation_options"]` =
+  `{detect_json, interrupt_json, verbose}`.
+- **`mpisppy/generic/extensions.py`:** activate iff
+  `cfg.detect_W_oscillations is not None or cfg.interrupt_W_oscillations is not None`.
+- **Validation:** JSON parsed and validated at `pre_iter0`; unknown method
+  names, bad params, a missing `output_csv`, and (PR2) interrupt-without-a-
+  valid-action are hard errors. Parse/validate failures raise on all ranks
+  (inputs are rank-identical).
+- **Compatibility contract:** no flag ⇒ extension never built ⇒ byte-identical
+  behavior. PR1's extension is pure observation (no rho/fix writes) ⇒ even
+  *with* `--detect-W-oscillations`, the optimization trajectory is unchanged.
+
+---
+
+## 11. Testing
+
+- **Unit (no MPI):** each detector on synthetic trajectories — a known
+  oscillating series (e.g. `[+a,-a,+a,-a,…]`) flags with the expected
+  crossing counts; a monotone/damping series does not; threshold boundaries
+  (exactly `thresh` crossings) behave as specified; `window` truncation works.
+- **Reduction/aggregation (no MPI):** drive the per-node SUM/MAX aggregation
+  with a fake multi-scenario fixture; assert `num_scenarios_flagged` and the
+  maxes.
+- **End-to-end (serial):** **farmer** with a deliberately **high rho on one
+  variable** (e.g. `DevotedAcreage[SUGAR_BEETS]` via a `_rho_setter`) to
+  induce W oscillation; run `generic_cylinders --detect-W-oscillations`;
+  assert the CSV is written, has the header, and flags that variable. Mirrors
+  the existing `TestGenericCylindersWtracker` end-to-end test. A **sizes**
+  (MIP) variant is a natural second case, since integer cycling is the prime
+  motivation.
+- **MPI (`mpiexec -np 2`/`3`):** the same induced-oscillation run; assert the
+  rank-0 CSV is **independent of scenario→rank distribution** (the reduction
+  is correct).
+- **PR2 — improvement:** on the cycle-tuned model, assert the interrupted run
+  improves on the plain run (fewer iters to a target gap, or better gap at the
+  iteration cap).
+- **Coverage harness:** add `mpisppy/tests/test_w_oscillation.py` to
+  `run_coverage.bash` **and** `.github/workflows/test_pr_and_main.yml` in the
+  **same commit** (else codecov/patch reports 0%).
+
+---
+
+## 12. Phased rollout
+
+**PR1 — detection + reporting.**
+`w_oscillation.py` (engine + reporter + detector A + detector B), the
+`--detect-W-oscillations` flag and JSON, config/cfg_vanilla/generic wiring,
+CSV writer (rank 0), unit + reduction + end-to-end + MPI tests, and a user-doc
+page cross-referencing wtracker. Pure observation ⇒ green on its own,
+backward compatible.
+
+**PR2 — interruption.**
+`--interrupt-W-oscillations` flag and JSON, the rho-reduction action, the
+slam action (calling the Slammer action layer), the trigger layer, the
+`both` = apply-both rule (§9), and an improvement test. Builds on PR1's engine.
+
+Each PR is review-sized and green independently (per the project's
+phased-PR-for-redesigns practice).
+
+---
+
+## 13. Decisions
+
+Settled in review (DLW, 2026-06-27); recorded for provenance.
+
+1. **Method B = Watson–Woodruff §2.4** — hash the per-scenario `w(i)` vector,
+   flag on recurrence (§5.2). Distributed via a **distribution-independent
+   sum-reduced signature** (identity-mixed per-scenario 64-bit hashes).
+   *Confirmed* ("I like the idea"). Background/keywords for the technique are in
+   §5.2.1 (incremental/multiset hashing; state-hash cycle detection).
+2. **`both` interruption (Q2)** — docs **encourage one or the other**; if both
+   are configured, **just apply both**, no coordination/escalation logic (§9).
+3. **Per-scenario reporting (Q3)** — **yes**, an optional `per_scenario_csv`
+   detail file (gather-based, off by default) is in scope for PR1 (§7.1).
+4. **Capture hook (Q4)** — **`miditer`** (post-update W), §4. (Differs from
+   `Wtracker_extension`, which grabs in `enditer`.)
+
+### Still open
+
+- **`quantum` / `min_period` / `window` defaults** for method B — proposed
+  `1e-6 / 2 / 20`; tune against the induced-oscillation test once it exists.

--- a/doc/src/extensions.rst
+++ b/doc/src/extensions.rst
@@ -24,6 +24,8 @@ command-line flags:
 
 - ``--fixer`` -- activates the fixer extension
 - ``--slamming-directives-file <file>`` -- activates the slammer extension
+- ``--detect-W-oscillations <file>`` -- activates W-oscillation detection
+  (see :ref:`w_oscillation`)
 - ``--mipgaps-json <file>`` -- activates the mipgapper extension
 - ``--user-defined-extensions <module>`` -- loads a custom extension
 - ``--grad-rho`` -- activates gradient-based rho (see :ref:`rho_setting`)
@@ -347,6 +349,73 @@ Each CSV row is indexed by ``(varname, scenario_name)`` and gives the
 windowed mean and stdev of W for that nonant/scenario pair. This is a
 diagnostic tool intended for tuning rho and convergence behavior; it
 adds time and memory and is not recommended for production runs.
+
+
+.. _w_oscillation:
+
+w_oscillation
+^^^^^^^^^^^^^
+
+The ``w_oscillation`` extension (``mpisppy.extensions.w_oscillation``)
+*detects* oscillation / cycling in the PH dual weight (W) vector and
+reports it to a CSV. Oscillating (sign-flipping, non-damping) weights are
+a common, convergence-killing symptom for mixed-integer problems. The
+extension is **pure observation**: it changes no rho values and fixes no
+variables, so a run with detection enabled follows exactly the same
+optimization trajectory as one without.
+
+For a broader view of how W evolves -- moving means, standard deviations,
+and coefficient of variation across all nonant/scenario traces -- use the
+:ref:`wtracker_extension`; ``w_oscillation`` is the focused layer that
+flags the specific traces that are *cycling*.
+
+From ``generic_cylinders.py``, enable it with::
+
+  --detect-W-oscillations <control.json>
+
+The JSON control file selects and parameterizes the detection methods and
+controls the output. Keys:
+
+- ``output_csv`` (required) -- the per-nonant aggregate report; written by
+  cylinder rank 0.
+- ``per_scenario_csv`` (optional) -- a per-(scenario, nonant) detail file
+  (gathered to rank 0); off by default.
+- ``warmup_iters`` -- do not evaluate until this many W samples exist
+  (default 5).
+- ``check_every`` -- evaluate the detectors every this many iterations
+  after warm-up (default 1).
+- ``report_mode`` -- ``on_detect`` (a row the first time a nonant is
+  flagged; the default), ``every_check``, or ``final`` (one report at the
+  end).
+- ``min_scenarios_to_report`` / ``min_frac_to_report`` -- a nonant is
+  reported once at least this many scenarios (or this fraction of them)
+  flag it.
+- ``methods`` -- a (non-empty) object selecting one or both detectors;
+  per-method keys override documented defaults.
+
+Two detection methods are available:
+
+- ``zero_crossings`` -- a port of PySP's ``sorgw`` plugin: per
+  (scenario, nonant) it counts sign changes of W and of the consecutive
+  differences, plus a back-half/front-half damping ratio of ``|ΔW|``, and
+  flags a trace when any of ``thresh_w_crossings`` (default 2),
+  ``thresh_diff_crossings`` (default 3), or ``thresh_diffs_ratio``
+  (default 0.2) is met.
+- ``w_hash_recurrence`` -- the Watson-Woodruff "Progressive Hedging
+  Innovations" (Computational Management Science, 2011) §2.4 cycle
+  detector: it hashes the per-scenario W vector for each nonant and flags
+  a *recurrence* of that vector (a genuine cycle of period
+  ``min_period`` or more, so convergence is not mistaken for a cycle).
+  Keys: ``window`` (default 20), ``quantum`` (default 1e-6),
+  ``min_period`` (default 2).
+
+The aggregate CSV has a header row and one row per flagged nonant per
+detection event, with columns ``iteration, node, variable, method,
+num_scenarios_total, num_scenarios_flagged, max_w_crossings,
+max_diff_crossings, max_diffs_ratio, cycle_period``. The report is
+independent of how scenarios are distributed across MPI ranks.
+
+See ``doc/designs/w_oscillation_design.md`` for the full design.
 
 
 gradient_extension

--- a/doc/src/extensions.rst
+++ b/doc/src/extensions.rst
@@ -412,30 +412,29 @@ Two detection methods are available:
 An example control file is shipped at
 ``examples/sizes/config/w_oscillation.json``. It enables both detectors,
 keeps a 20-iteration window, and reports a nonant once at least half of the
-scenarios (``min_frac_to_report``) flag it::
+scenarios (``min_frac_to_report``) flag it:
 
-  {
-      "output_csv": "w_oscillations.csv",
-      "per_scenario_csv": null,
-      "warmup_iters": 5,
-      "check_every": 1,
-      "report_mode": "on_detect",
-      "min_frac_to_report": 0.5,
-      "methods": {
-          "zero_crossings": {
-              "tol": 1e-6,
-              "window": 20,
-              "thresh_w_crossings": 2,
-              "thresh_diff_crossings": 3,
-              "thresh_diffs_ratio": 0.2
-          },
-          "w_hash_recurrence": {
-              "window": 20,
-              "quantum": 1e-6,
-              "min_period": 2
-          }
-      }
-  }
+.. literalinclude:: ../../examples/sizes/config/w_oscillation.json
+   :language: json
+
+That example leaves ``per_scenario_csv`` at ``null``, so only the aggregate
+report is written. To also emit the per-(scenario, nonant) detail file --
+one row per flagged trace per check, gathered to rank 0 -- set
+``per_scenario_csv`` to a path (other keys fall back to their defaults):
+
+.. code-block:: json
+
+    {
+        "output_csv": "w_oscillations.csv",
+        "per_scenario_csv": "w_oscillations_per_scenario.csv",
+        "report_mode": "every_check",
+        "methods": {
+            "zero_crossings": {}
+        }
+    }
+
+The detail file has columns ``iteration, node, scenario, variable, method,
+w_crossings, diff_crossings, diffs_ratio, w_value``.
 
 The aggregate CSV has a header row and one row per flagged nonant per
 detection event, with columns ``iteration, node, variable, method,

--- a/doc/src/extensions.rst
+++ b/doc/src/extensions.rst
@@ -409,6 +409,34 @@ Two detection methods are available:
   Keys: ``window`` (default 20), ``quantum`` (default 1e-6),
   ``min_period`` (default 2).
 
+An example control file is shipped at
+``examples/sizes/config/w_oscillation.json``. It enables both detectors,
+keeps a 20-iteration window, and reports a nonant once at least half of the
+scenarios (``min_frac_to_report``) flag it::
+
+  {
+      "output_csv": "w_oscillations.csv",
+      "per_scenario_csv": null,
+      "warmup_iters": 5,
+      "check_every": 1,
+      "report_mode": "on_detect",
+      "min_frac_to_report": 0.5,
+      "methods": {
+          "zero_crossings": {
+              "tol": 1e-6,
+              "window": 20,
+              "thresh_w_crossings": 2,
+              "thresh_diff_crossings": 3,
+              "thresh_diffs_ratio": 0.2
+          },
+          "w_hash_recurrence": {
+              "window": 20,
+              "quantum": 1e-6,
+              "min_period": 2
+          }
+      }
+  }
+
 The aggregate CSV has a header row and one row per flagged nonant per
 detection event, with columns ``iteration, node, variable, method,
 num_scenarios_total, num_scenarios_flagged, max_w_crossings,

--- a/doc/src/generic_cylinders.rst
+++ b/doc/src/generic_cylinders.rst
@@ -217,6 +217,8 @@ Some extensions can be activated directly from the command line:
 - ``--wtracker`` -- Track W (Lagrange-multiplier) values per iteration
   and write a convergence report at the end of the run
   (see :ref:`wtracker_extension`)
+- ``--detect-W-oscillations <file>`` -- Detect oscillation/cycling in the
+  W vector and report it to a CSV (see :ref:`w_oscillation`)
 
 See :ref:`Extensions` for details on available extensions.
 

--- a/examples/sizes/config/w_oscillation.json
+++ b/examples/sizes/config/w_oscillation.json
@@ -1,0 +1,22 @@
+{
+    "output_csv": "w_oscillations.csv",
+    "per_scenario_csv": null,
+    "warmup_iters": 5,
+    "check_every": 1,
+    "report_mode": "on_detect",
+    "min_frac_to_report": 0.5,
+    "methods": {
+        "zero_crossings": {
+            "tol": 1e-6,
+            "window": 20,
+            "thresh_w_crossings": 2,
+            "thresh_diff_crossings": 3,
+            "thresh_diffs_ratio": 0.2
+        },
+        "w_hash_recurrence": {
+            "window": 20,
+            "quantum": 1e-6,
+            "min_period": 2
+        }
+    }
+}

--- a/mpisppy/extensions/w_oscillation.py
+++ b/mpisppy/extensions/w_oscillation.py
@@ -54,6 +54,14 @@ VALID_REPORT_MODES = ("on_detect", "final", "every_check")
 
 _MASK64 = (1 << 64) - 1
 
+# numpy dtype -> MPI datatype for the arrays reduced by _reduce_per_node. Keyed
+# explicitly (rather than an int/else fallback) so an unexpected dtype fails
+# loudly instead of being silently treated as a double.
+_NUMPY_TO_MPI = {
+    np.dtype(np.int32): MPI.INT,
+    np.dtype(np.float64): MPI.DOUBLE,
+}
+
 # Default parameters per method; a method's omitted JSON keys fall back here.
 _ZERO_CROSSINGS_DEFAULTS = {
     "tol": 1e-6,
@@ -122,6 +130,12 @@ def zero_crossings_detect(traj, tol=1e-6, window=None,
     diffs = [w[i + 1] - w[i] for i in range(len(w) - 1)]
     diff_crossings = count_sign_changes(diffs, tol)
 
+    # diffs_ratio is a damping check: split |ΔW| into a front (older) and back
+    # (newer) half and compare their mean step sizes. If the W swings are
+    # shrinking over time (converging), the back-half mean is small relative to
+    # the front-half mean and the ratio is well below 1; if the swings are not
+    # damping out (sustained oscillation), the ratio stays near or above 1. A
+    # high ratio therefore signals oscillation that is failing to settle.
     absdiffs = [abs(d) for d in diffs]
     half = len(absdiffs) // 2
     front = absdiffs[:half]
@@ -486,7 +500,12 @@ class WOscillationMonitor(Extension):
             comm = self.opt.comms[ndn]
             pos = np.array(positions)
             for (a, op), out in zip(arrays_and_ops, outs):
-                mpitype = MPI.INT if a.dtype == np.int32 else MPI.DOUBLE
+                try:
+                    mpitype = _NUMPY_TO_MPI[a.dtype]
+                except KeyError:
+                    raise ValueError(
+                        f"_reduce_per_node got array of unsupported dtype "
+                        f"{a.dtype}; add it to _NUMPY_TO_MPI.")
                 loc = np.ascontiguousarray(a[pos])
                 res = np.zeros(len(pos), a.dtype)
                 comm.Allreduce([loc, mpitype], [res, mpitype], op=op)

--- a/mpisppy/extensions/w_oscillation.py
+++ b/mpisppy/extensions/w_oscillation.py
@@ -1,0 +1,552 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+"""Detect oscillation / cycling in the PH dual weight (W) vector.
+
+This is a *hub* extension that observes the W vector while a synchronous PH hub
+runs and reports detected oscillation to a CSV.  It is **pure observation**: it
+attaches no rho or fixing changes, so a run with ``--detect-W-oscillations``
+produces the same optimization trajectory as one without.  Interrupting the
+oscillation (rho reduction / slamming) is a separate piece of work.
+
+Two detection methods are available, selected and parameterized from a JSON
+control file (see :func:`parse_detect_config`):
+
+``zero_crossings``
+    A port of PySP's ``sorgw`` plugin: for each (scenario, nonant) W trajectory,
+    count sign changes of W and of the consecutive differences, plus a damping
+    ratio of the back half vs. the front half of |ΔW|.  Flag the trajectory when
+    any threshold is exceeded.  Per-trajectory and embarrassingly parallel.
+
+``w_hash_recurrence``
+    The Watson--Woodruff "Progressive Hedging Innovations" (Computational
+    Management Science, 2011) §2.4 cycle detector: hash the *per-scenario* W
+    vector for each nonant and flag a recurrence of that vector.  In the
+    distributed setting we form a **distribution-independent signature** by
+    summing identity-mixed per-scenario 64-bit hashes (an additive/multiset
+    hash; see Bellare & Micciancio 1997, Clarke et al. ASIACRYPT 2003) and
+    reducing with ``MPI.SUM``; recurrence of the signature is the cycle.
+
+Per-(scenario, nonant) verdicts are aggregated across scenarios with per-node
+``SUM``/``MAX`` reductions, and cylinder rank 0 writes the CSV.  See
+``doc/designs/w_oscillation_design.md`` for the full design, and the wtracker
+utilities (``mpisppy/utils/w_utils/``) for general W-trajectory logging and
+moving statistics.
+"""
+
+import csv
+import json
+
+import numpy as np
+
+import mpisppy.MPI as MPI
+from mpisppy.extensions.extension import Extension
+
+
+# Method names recognized in the JSON "methods" block.
+VALID_METHODS = ("zero_crossings", "w_hash_recurrence")
+VALID_REPORT_MODES = ("on_detect", "final", "every_check")
+
+_MASK64 = (1 << 64) - 1
+
+# Default parameters per method; a method's omitted JSON keys fall back here.
+_ZERO_CROSSINGS_DEFAULTS = {
+    "tol": 1e-6,
+    "window": None,                 # None -> use the whole retained history
+    "thresh_w_crossings": 2,
+    "thresh_diff_crossings": 3,
+    "thresh_diffs_ratio": 0.2,
+}
+_W_HASH_DEFAULTS = {
+    "window": 20,                   # look back this many checks for a repeat
+    "quantum": 1e-6,                # W quantized to this before hashing
+    "min_period": 2,                # >=2 so constant W (convergence) is ignored
+}
+
+
+# --------------------------------------------------------------------------- #
+# Method A -- zero crossings (pure, per-trajectory; unit-testable, no MPI)
+# --------------------------------------------------------------------------- #
+def count_sign_changes(values, tol):
+    """Number of sign changes in a sequence, ignoring entries with ``|v| < tol``.
+
+    A "sign change" is counted each time the running sign flips from strictly
+    positive to strictly negative or vice versa (near-zero entries do not reset
+    the running sign).  This matches PySP ``sorgw``'s zero-crossing counter.
+    """
+    crossings = 0
+    above = False
+    below = False
+    for v in values:
+        if abs(v) < tol:
+            continue
+        if v > 0:
+            if below:
+                crossings += 1
+                below = False
+            above = True
+        else:
+            if above:
+                crossings += 1
+                above = False
+            below = True
+    return crossings
+
+
+def zero_crossings_detect(traj, tol=1e-6, window=None,
+                          thresh_w_crossings=2, thresh_diff_crossings=3,
+                          thresh_diffs_ratio=0.2):
+    """Run the zero-crossing detector on one W trajectory.
+
+    Args:
+        traj (sequence of float): the W values over iterations for one
+            (scenario, nonant), oldest first.
+        tol, window, thresh_* : see :data:`_ZERO_CROSSINGS_DEFAULTS`.
+
+    Returns:
+        dict with ``flagged`` (bool) and the stats ``w_crossings`` (int),
+        ``diff_crossings`` (int), ``diffs_ratio`` (float).  ``flagged`` is true
+        iff any of the three thresholds is met.
+    """
+    w = list(traj)
+    if window is not None and window > 0:
+        w = w[-window:]
+
+    w_crossings = count_sign_changes(w, tol)
+
+    diffs = [w[i + 1] - w[i] for i in range(len(w) - 1)]
+    diff_crossings = count_sign_changes(diffs, tol)
+
+    absdiffs = [abs(d) for d in diffs]
+    half = len(absdiffs) // 2
+    front = absdiffs[:half]
+    back = absdiffs[half:]
+    frontavg = sum(front) / len(front) if front else 0.0
+    diffs_ratio = (sum(back) / len(back) / frontavg) if (back and frontavg > tol) \
+        else 0.0
+
+    flagged = (w_crossings >= thresh_w_crossings
+               or diff_crossings >= thresh_diff_crossings
+               or diffs_ratio >= thresh_diffs_ratio)
+    return {
+        "flagged": flagged,
+        "w_crossings": w_crossings,
+        "diff_crossings": diff_crossings,
+        "diffs_ratio": diffs_ratio,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Method B -- W-vector hashing / recurrence
+# --------------------------------------------------------------------------- #
+def _mix64(x):
+    """splitmix64 finalizer: deterministic 64-bit avalanche mix (no salt)."""
+    x &= _MASK64
+    x = ((x ^ (x >> 30)) * 0xBF58476D1CE4E5B9) & _MASK64
+    x = ((x ^ (x >> 27)) * 0x94D049BB133111EB) & _MASK64
+    x ^= x >> 31
+    return x & _MASK64
+
+
+def signature_term(scenario_index, w_value, quantum):
+    """64-bit hash of ``(scenario_index, round(w_value / quantum))``.
+
+    Mixing the scenario index in keeps per-scenario identity, so the SUM of
+    these terms over a node's scenarios is a signature of the whole per-scenario
+    W vector that is independent of how scenarios are spread across MPI ranks
+    (the sum is commutative; see the module docstring).
+    """
+    q = int(round(w_value / quantum)) & _MASK64
+    return _mix64(_mix64(int(scenario_index) & _MASK64) ^ q)
+
+
+class RecurrenceTracker:
+    """Per-nonant ring buffer of W-vector signatures; flags genuine cycles.
+
+    ``push(sig)`` records the latest signature and returns ``(flagged, period)``.
+    A cycle of period ``p`` (``min_period <= p <= window``) is flagged when the
+    current signature equals the one ``p`` steps back **and** at least one
+    signature in between differs from it -- so a *constant* signature
+    (convergence, period 1) is never mistaken for a cycle.
+    """
+
+    def __init__(self, window=20, min_period=2):
+        self.window = window
+        self.min_period = max(2, int(min_period))
+        self._buf = []   # most-recent-last, capped at window + 1
+
+    def push(self, sig):
+        sig = int(sig) & _MASK64
+        self._buf.append(sig)
+        if len(self._buf) > self.window + 1:
+            self._buf.pop(0)
+        n = len(self._buf)
+        for p in range(self.min_period, n):
+            if self._buf[n - 1 - p] != sig:
+                continue
+            # equal at distance p; require a genuine change in between
+            if any(self._buf[n - 1 - t] != sig for t in range(1, p)):
+                return True, p
+        return False, 0
+
+
+# --------------------------------------------------------------------------- #
+# JSON control-file parsing / validation
+# --------------------------------------------------------------------------- #
+def parse_detect_config(path):
+    """Load and validate a ``--detect-W-oscillations`` JSON control file.
+
+    Returns the config dict with method parameters filled in from the per-method
+    defaults.  Raises ``ValueError`` on a missing ``output_csv``, an empty or
+    unknown ``methods`` block, or a bad ``report_mode``.
+    """
+    with open(path, "r") as f:
+        cfg = json.load(f)
+    return validate_detect_config(cfg, where=path)
+
+
+def validate_detect_config(cfg, where="<detect config>"):
+    if not isinstance(cfg, dict):
+        raise ValueError(f"{where}: top level must be a JSON object")
+    if not cfg.get("output_csv"):
+        raise ValueError(f"{where}: 'output_csv' is required")
+
+    report_mode = cfg.get("report_mode", "on_detect")
+    if report_mode not in VALID_REPORT_MODES:
+        raise ValueError(
+            f"{where}: report_mode {report_mode!r} not in {VALID_REPORT_MODES}")
+
+    methods = cfg.get("methods")
+    if not methods or not isinstance(methods, dict):
+        raise ValueError(
+            f"{where}: 'methods' must be a non-empty object selecting at least "
+            f"one of {VALID_METHODS}")
+    resolved = {}
+    for name, params in methods.items():
+        if name not in VALID_METHODS:
+            raise ValueError(
+                f"{where}: unknown method {name!r} (legal: {VALID_METHODS})")
+        params = dict(params or {})
+        defaults = _ZERO_CROSSINGS_DEFAULTS if name == "zero_crossings" \
+            else _W_HASH_DEFAULTS
+        merged = dict(defaults)
+        merged.update(params)
+        resolved[name] = merged
+
+    out = {
+        "output_csv": cfg["output_csv"],
+        "per_scenario_csv": cfg.get("per_scenario_csv"),
+        "warmup_iters": int(cfg.get("warmup_iters", 5)),
+        "check_every": max(1, int(cfg.get("check_every", 1))),
+        "report_mode": report_mode,
+        "min_scenarios_to_report": cfg.get("min_scenarios_to_report", 1),
+        "min_frac_to_report": cfg.get("min_frac_to_report"),
+        "max_history": int(cfg.get("max_history", 50)),
+        "methods": resolved,
+    }
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# The extension
+# --------------------------------------------------------------------------- #
+# CSV columns for the per-nonant aggregate report (§7 of the design).
+_AGG_COLUMNS = [
+    "iteration", "node", "variable", "method",
+    "num_scenarios_total", "num_scenarios_flagged",
+    "max_w_crossings", "max_diff_crossings", "max_diffs_ratio", "cycle_period",
+]
+_PER_SCEN_COLUMNS = [
+    "iteration", "node", "scenario", "variable", "method",
+    "w_crossings", "diff_crossings", "diffs_ratio", "w_value",
+]
+
+
+class WOscillationMonitor(Extension):
+    """Detect (and report) oscillation in the W vector; see the module docstring.
+
+    Constructed from ``opt.options["w_oscillation_options"]``, a dict with:
+
+    ``detect_config`` (dict) or ``detect_json`` (path)
+        the parsed control dict, or a path parsed with
+        :func:`parse_detect_config`.
+    ``verbose`` (bool, default False)
+        print a rank-0 summary line at the end.
+    """
+
+    def __init__(self, spobj):
+        super().__init__(spobj)
+        opts = spobj.options.get("w_oscillation_options", {})
+        if "detect_config" in opts:
+            self.cfg = validate_detect_config(opts["detect_config"])
+        else:
+            self.cfg = parse_detect_config(opts["detect_json"])
+        self.verbose = opts.get("verbose", False)
+
+        self._methods = self.cfg["methods"]
+        # how many checks of history to retain
+        self._history = self.cfg["max_history"]
+        if "w_hash_recurrence" in self._methods:
+            self._history = max(self._history,
+                                self._methods["w_hash_recurrence"]["window"] + 1)
+
+        # Built in pre_iter0():
+        self._ndn_i = []        # ordered monitored (ndn, i)
+        self._names = []        # parallel xvar.name
+        self._nodes = []        # parallel node name
+        self._node_pos = {}     # ndn -> list of positions j into the lists above
+        self._n_scen_total = {} # ndn -> total scenarios passing through node
+        # per local scenario: list (ring) of W vectors over the monitored nonants
+        self._traj = {}         # sname -> list[np.ndarray]
+        self._recur = {}        # j -> RecurrenceTracker (method B)
+        self._reported = set()  # (method, j) already reported (on_detect mode)
+
+        self._agg_writer = None
+        self._agg_file = None
+        self._scen_writer = None
+        self._scen_file = None
+        self._n_flag_events = 0
+
+    @property
+    def _is_writer(self):
+        return self.opt.cylinder_rank == 0
+
+    # ------------------------------------------------------------------ #
+    def pre_iter0(self):
+        """Build the monitored-nonant catalog (node-grouped), per-node scenario
+        counts, per-method state, and open the CSV(s) on rank 0."""
+        rep = self.opt.local_scenarios[self.opt.local_scenario_names[0]]
+        surrogates = getattr(rep._mpisppy_data, "all_surrogate_nonants", set())
+        for ndn_i, xvar in rep._mpisppy_data.nonant_indices.items():
+            if xvar in surrogates:
+                continue  # zero-prob surrogate nonants have masked W
+            j = len(self._ndn_i)
+            self._ndn_i.append(ndn_i)
+            self._names.append(xvar.name)
+            self._nodes.append(ndn_i[0])
+            self._node_pos.setdefault(ndn_i[0], []).append(j)
+
+        # Total scenarios at each node (reduced once; identical on every rank).
+        for ndn, positions in self._node_pos.items():
+            local = sum(1 for s in self.opt.local_scenarios.values()
+                        if any(nd.name == ndn for nd in s._mpisppy_node_list))
+            loc = np.array([local], "i")
+            glob = np.zeros(1, "i")
+            self.opt.comms[ndn].Allreduce([loc, MPI.INT], [glob, MPI.INT],
+                                          op=MPI.SUM)
+            self._n_scen_total[ndn] = int(glob[0])
+
+        # Stable, rank-identical per-scenario index for the signature hash:
+        # position in the global scenario ordering (identical on every rank).
+        self._scen_idx = {name: i for i, name
+                          in enumerate(self.opt.all_scenario_names)}
+
+        for sname in self.opt.local_scenario_names:
+            self._traj[sname] = []
+        if "w_hash_recurrence" in self._methods:
+            hp = self._methods["w_hash_recurrence"]
+            for j in range(len(self._ndn_i)):
+                self._recur[j] = RecurrenceTracker(window=hp["window"],
+                                                   min_period=hp["min_period"])
+
+        if self._is_writer:
+            self._agg_file = open(self.cfg["output_csv"], "w", newline="")
+            self._agg_writer = csv.writer(self._agg_file)
+            self._agg_writer.writerow(_AGG_COLUMNS)
+            self._agg_file.flush()
+            if self.cfg["per_scenario_csv"]:
+                self._scen_file = open(self.cfg["per_scenario_csv"], "w",
+                                       newline="")
+                self._scen_writer = csv.writer(self._scen_file)
+                self._scen_writer.writerow(_PER_SCEN_COLUMNS)
+                self._scen_file.flush()
+
+    # ------------------------------------------------------------------ #
+    def _capture(self):
+        """Append the current (post-update) W vector for each local scenario."""
+        for sname, s in self.opt.local_scenarios.items():
+            W = s._mpisppy_model.W
+            vec = np.fromiter((W[k]._value for k in self._ndn_i), dtype="d",
+                              count=len(self._ndn_i))
+            buf = self._traj[sname]
+            buf.append(vec)
+            if len(buf) > self._history:
+                buf.pop(0)
+
+    def miditer(self):
+        self._capture()
+        phiter = self.opt._PHIter
+        if phiter < self.cfg["warmup_iters"]:
+            return
+        if (phiter - self.cfg["warmup_iters"]) % self.cfg["check_every"] != 0:
+            return
+        self._evaluate_and_report(phiter)
+
+    # ------------------------------------------------------------------ #
+    def _evaluate_and_report(self, phiter):
+        """Run the active detectors, reduce across scenarios per node, and emit
+        rows for nonants that meet the reporting threshold."""
+        nJ = len(self._ndn_i)
+        if "zero_crossings" in self._methods:
+            self._eval_zero_crossings(phiter, nJ)
+        if "w_hash_recurrence" in self._methods:
+            self._eval_w_hash(phiter, nJ)
+
+    def _threshold(self, ndn):
+        frac = self.cfg["min_frac_to_report"]
+        if frac is not None:
+            return max(1, int(np.ceil(frac * self._n_scen_total[ndn])))
+        return int(self.cfg["min_scenarios_to_report"])
+
+    def _eval_zero_crossings(self, phiter, nJ):
+        p = self._methods["zero_crossings"]
+        # local per-nonant accumulators
+        n_flag = np.zeros(nJ, "i")
+        mx_w = np.zeros(nJ, "i")
+        mx_d = np.zeros(nJ, "i")
+        mx_r = np.zeros(nJ, "d")
+        scen_rows = []  # per-scenario detail (gathered if requested)
+        for sname, buf in self._traj.items():
+            if len(buf) < 2:
+                continue
+            arr = np.array(buf)  # (T, nJ)
+            for j in range(nJ):
+                res = zero_crossings_detect(
+                    arr[:, j], tol=p["tol"], window=p["window"],
+                    thresh_w_crossings=p["thresh_w_crossings"],
+                    thresh_diff_crossings=p["thresh_diff_crossings"],
+                    thresh_diffs_ratio=p["thresh_diffs_ratio"])
+                if res["flagged"]:
+                    n_flag[j] += 1
+                    mx_w[j] = max(mx_w[j], res["w_crossings"])
+                    mx_d[j] = max(mx_d[j], res["diff_crossings"])
+                    mx_r[j] = max(mx_r[j], res["diffs_ratio"])
+                    if self.cfg["per_scenario_csv"]:
+                        scen_rows.append((
+                            phiter, self._nodes[j], sname, self._names[j],
+                            "zero_crossings", res["w_crossings"],
+                            res["diff_crossings"], round(res["diffs_ratio"], 6),
+                            round(float(arr[-1, j]), 9)))
+
+        g_flag, g_w, g_d, g_r = self._reduce_per_node(
+            nJ, [(n_flag, MPI.SUM), (mx_w, MPI.MAX),
+                 (mx_d, MPI.MAX), (mx_r, MPI.MAX)])
+        for j in range(nJ):
+            if g_flag[j] >= self._threshold(self._nodes[j]):
+                self._emit_agg(phiter, j, "zero_crossings",
+                               int(g_flag[j]),
+                               max_w_crossings=int(g_w[j]),
+                               max_diff_crossings=int(g_d[j]),
+                               max_diffs_ratio=round(float(g_r[j]), 6))
+        self._emit_scen(scen_rows)
+
+    def _eval_w_hash(self, phiter, nJ):
+        p = self._methods["w_hash_recurrence"]
+        q = p["quantum"]
+        # local partial signature per nonant (sum of identity-mixed hashes)
+        partial = np.zeros(nJ, dtype=np.uint64)
+        for sname, s in self.opt.local_scenarios.items():
+            sidx = self._scen_idx[sname]
+            W = s._mpisppy_model.W
+            for j, k in enumerate(self._ndn_i):
+                term = signature_term(sidx, W[k]._value, q)
+                partial[j] = (int(partial[j]) + term) & _MASK64
+        glob = self._reduce_signatures(nJ, partial)
+
+        scen_rows = []
+        for j in range(nJ):
+            flagged, period = self._recur[j].push(int(glob[j]))
+            if flagged and period >= self._threshold_period():
+                self._emit_agg(phiter, j, "w_hash_recurrence",
+                               self._n_scen_total[self._nodes[j]],
+                               cycle_period=period)
+                if self.cfg["per_scenario_csv"]:
+                    for sname, s in self.opt.local_scenarios.items():
+                        scen_rows.append((
+                            phiter, self._nodes[j], sname, self._names[j],
+                            "w_hash_recurrence", "", "", "",
+                            round(float(s._mpisppy_model.W[self._ndn_i[j]]._value),
+                                  9)))
+        self._emit_scen(scen_rows)
+
+    def _threshold_period(self):
+        return self._methods["w_hash_recurrence"]["min_period"]
+
+    # ------------------------------------------------------------------ #
+    def _reduce_per_node(self, nJ, arrays_and_ops):
+        """Allreduce each (array, op) over the per-node communicators, returning
+        rank-identical global arrays of length ``nJ``."""
+        outs = [np.zeros(nJ, a.dtype) for a, _ in arrays_and_ops]
+        for ndn, positions in self._node_pos.items():
+            comm = self.opt.comms[ndn]
+            pos = np.array(positions)
+            for (a, op), out in zip(arrays_and_ops, outs):
+                mpitype = MPI.INT if a.dtype == np.int32 else MPI.DOUBLE
+                loc = np.ascontiguousarray(a[pos])
+                res = np.zeros(len(pos), a.dtype)
+                comm.Allreduce([loc, mpitype], [res, mpitype], op=op)
+                out[pos] = res
+        return outs
+
+    def _reduce_signatures(self, nJ, partial):
+        """Sum-reduce the uint64 partial signatures over the per-node comms
+        (modular mod 2^64), so the result is independent of scenario->rank map."""
+        out = np.zeros(nJ, dtype=np.uint64)
+        for ndn, positions in self._node_pos.items():
+            comm = self.opt.comms[ndn]
+            pos = np.array(positions)
+            loc = np.ascontiguousarray(partial[pos])
+            res = np.zeros(len(pos), dtype=np.uint64)
+            comm.Allreduce([loc, MPI.UINT64_T], [res, MPI.UINT64_T], op=MPI.SUM)
+            out[pos] = res
+        return out
+
+    # ------------------------------------------------------------------ #
+    def _emit_agg(self, phiter, j, method, num_flagged, **stats):
+        mode = self.cfg["report_mode"]
+        if mode == "on_detect":
+            if (method, j) in self._reported:
+                return
+            self._reported.add((method, j))
+        self._n_flag_events += 1
+        if not self._is_writer:
+            return
+        row = {
+            "iteration": phiter, "node": self._nodes[j],
+            "variable": self._names[j], "method": method,
+            "num_scenarios_total": self._n_scen_total[self._nodes[j]],
+            "num_scenarios_flagged": num_flagged,
+            "max_w_crossings": "", "max_diff_crossings": "",
+            "max_diffs_ratio": "", "cycle_period": "",
+        }
+        row.update(stats)
+        self._agg_writer.writerow([row[c] for c in _AGG_COLUMNS])
+        self._agg_file.flush()
+
+    def _emit_scen(self, scen_rows):
+        if not self.cfg["per_scenario_csv"]:
+            return
+        gathered = self.opt.comms["ROOT"].gather(scen_rows, root=0)
+        if self._is_writer and gathered is not None:
+            for chunk in gathered:
+                for row in chunk:
+                    self._scen_writer.writerow(row)
+            self._scen_file.flush()
+
+    # ------------------------------------------------------------------ #
+    def post_everything(self):
+        if self.cfg["report_mode"] == "final":
+            self._evaluate_and_report(self.opt._PHIter)
+        if self._is_writer:
+            if self._agg_file is not None:
+                self._agg_file.close()
+            if self._scen_file is not None:
+                self._scen_file.close()
+        if self.verbose and self.opt.cylinder_rank == 0:
+            print(f"(rank0) WOscillationMonitor: {self._n_flag_events} "
+                  f"oscillation report event(s); see {self.cfg['output_csv']}")

--- a/mpisppy/generic/extensions.py
+++ b/mpisppy/generic/extensions.py
@@ -45,6 +45,9 @@ def configure_extensions(hub_dict, module, cfg):
     if cfg.slamming_directives_file is not None:
         vanilla.add_slammer(hub_dict, cfg)
 
+    if cfg.detect_W_oscillations is not None:
+        vanilla.add_w_oscillation(hub_dict, cfg)
+
     if cfg.grad_rho:
         from mpisppy.extensions.grad_rho import GradRho
         ext_classes.append(GradRho)

--- a/mpisppy/generic/parsing.py
+++ b/mpisppy/generic/parsing.py
@@ -138,6 +138,7 @@ def parse_args(m):
     cfg.relaxed_ph_fixer_args()
     cfg.integer_relax_then_enforce_args()
     cfg.slamming_args()
+    cfg.w_oscillation_args()
     cfg.gapper_args()
     cfg.gapper_args(name="lagrangian")
     cfg.ph_primal_args()

--- a/mpisppy/tests/test_w_oscillation.py
+++ b/mpisppy/tests/test_w_oscillation.py
@@ -1,0 +1,202 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+"""Tests for the W-oscillation detection extension (PR1).
+
+The pure detector logic (zero-crossing counting, the W-vector signature, and the
+recurrence tracker) is tested directly with no MPI; an end-to-end test confirms
+the ``--detect-W-oscillations`` flag wires the extension in and writes the CSV.
+"""
+import csv
+import json
+import os
+import sys
+import runpy
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from mpisppy.extensions import w_oscillation as wosc
+from mpisppy.tests.utils import get_solver
+
+solver_available, solver_name, _, _ = get_solver()
+
+_MASK64 = (1 << 64) - 1
+
+
+class TestZeroCrossings(unittest.TestCase):
+    def test_count_sign_changes_basic(self):
+        self.assertEqual(wosc.count_sign_changes([1, -1, 1, -1], tol=1e-6), 3)
+        self.assertEqual(wosc.count_sign_changes([1, 2, 3, 4], tol=1e-6), 0)
+        # near-zero entries are skipped, not treated as a crossing
+        self.assertEqual(wosc.count_sign_changes([1, 0.0, 1], tol=1e-6), 0)
+        self.assertEqual(wosc.count_sign_changes([1, 1e-9, -1], tol=1e-6), 1)
+
+    def test_oscillating_is_flagged(self):
+        res = wosc.zero_crossings_detect([1, -1, 1, -1, 1, -1])
+        self.assertTrue(res["flagged"])
+        self.assertGreaterEqual(res["w_crossings"], 2)
+
+    def test_converging_not_flagged(self):
+        # monotone, damping series: no sign changes and a small damping ratio
+        res = wosc.zero_crossings_detect([10, 5, 2, 1, 0.5, 0.2, 0.1])
+        self.assertFalse(res["flagged"])
+        self.assertEqual(res["w_crossings"], 0)
+        self.assertEqual(res["diff_crossings"], 0)
+        self.assertLess(res["diffs_ratio"], 0.2)
+
+    def test_w_crossing_threshold_boundary(self):
+        traj = [1, -1, 1]  # exactly 2 W sign changes
+        self.assertTrue(wosc.zero_crossings_detect(
+            traj, thresh_w_crossings=2, thresh_diff_crossings=99,
+            thresh_diffs_ratio=99)["flagged"])
+        self.assertFalse(wosc.zero_crossings_detect(
+            traj, thresh_w_crossings=3, thresh_diff_crossings=99,
+            thresh_diffs_ratio=99)["flagged"])
+
+    def test_window_truncation(self):
+        # only the last 2 points are kept -> no crossing seen
+        traj = [1, -1, 1, 1]
+        res = wosc.zero_crossings_detect(traj, window=2, thresh_w_crossings=1,
+                                         thresh_diff_crossings=99,
+                                         thresh_diffs_ratio=99)
+        self.assertEqual(res["w_crossings"], 0)
+
+
+class TestSignature(unittest.TestCase):
+    def test_deterministic(self):
+        a = wosc.signature_term(3, 1.2345, 1e-6)
+        b = wosc.signature_term(3, 1.2345, 1e-6)
+        self.assertEqual(a, b)
+        self.assertNotEqual(a, wosc.signature_term(4, 1.2345, 1e-6))
+
+    def test_quantization(self):
+        # values within a quantum hash identically; across a quantum, differ
+        self.assertEqual(wosc.signature_term(1, 1.0, 1e-3),
+                         wosc.signature_term(1, 1.0 + 1e-9, 1e-3))
+        self.assertNotEqual(wosc.signature_term(1, 1.0, 1e-3),
+                            wosc.signature_term(1, 1.01, 1e-3))
+
+    def test_distribution_independent_sum(self):
+        # full sum == sum of partial sums (mod 2^64), and order-independent
+        scen = [(0, 1.23), (1, -4.5), (2, 0.7), (3, 9.1)]
+        q = 1e-6
+        full = sum(wosc.signature_term(si, wv, q) for si, wv in scen) & _MASK64
+        g1 = sum(wosc.signature_term(si, wv, q) for si, wv in scen[:1]) & _MASK64
+        g2 = sum(wosc.signature_term(si, wv, q) for si, wv in scen[1:]) & _MASK64
+        self.assertEqual((g1 + g2) & _MASK64, full)
+        rev = sum(wosc.signature_term(si, wv, q)
+                  for si, wv in reversed(scen)) & _MASK64
+        self.assertEqual(rev, full)
+
+
+class TestRecurrenceTracker(unittest.TestCase):
+    def test_two_cycle_flagged(self):
+        rt = wosc.RecurrenceTracker(window=10, min_period=2)
+        out = [rt.push(s) for s in [10, 20, 10, 20]]
+        self.assertEqual(out[0], (False, 0))
+        self.assertEqual(out[1], (False, 0))
+        self.assertEqual(out[2], (True, 2))  # 10 recurs, 20 differed in between
+
+    def test_constant_not_flagged(self):
+        rt = wosc.RecurrenceTracker(window=10, min_period=2)
+        out = [rt.push(7) for _ in range(5)]
+        self.assertTrue(all(not f for f, _ in out))  # convergence != cycle
+
+    def test_monotone_not_flagged(self):
+        rt = wosc.RecurrenceTracker(window=10, min_period=2)
+        out = [rt.push(s) for s in [1, 2, 3, 4, 5]]
+        self.assertTrue(all(not f for f, _ in out))
+
+    def test_period_three(self):
+        rt = wosc.RecurrenceTracker(window=10, min_period=2)
+        out = [rt.push(s) for s in [1, 2, 3, 1, 2, 3]]
+        # first recurrence is at the 4th push (1 repeats at distance 3)
+        self.assertEqual(out[3], (True, 3))
+
+
+class TestConfigValidation(unittest.TestCase):
+    def test_requires_output_csv(self):
+        with self.assertRaises(ValueError):
+            wosc.validate_detect_config({"methods": {"zero_crossings": {}}})
+
+    def test_requires_methods(self):
+        with self.assertRaises(ValueError):
+            wosc.validate_detect_config({"output_csv": "x.csv"})
+
+    def test_unknown_method(self):
+        with self.assertRaises(ValueError):
+            wosc.validate_detect_config(
+                {"output_csv": "x.csv", "methods": {"bogus": {}}})
+
+    def test_bad_report_mode(self):
+        with self.assertRaises(ValueError):
+            wosc.validate_detect_config(
+                {"output_csv": "x.csv", "report_mode": "sometimes",
+                 "methods": {"zero_crossings": {}}})
+
+    def test_defaults_filled(self):
+        cfg = wosc.validate_detect_config(
+            {"output_csv": "x.csv", "methods": {"zero_crossings": {"tol": 1e-3}}})
+        zc = cfg["methods"]["zero_crossings"]
+        self.assertEqual(zc["tol"], 1e-3)                 # override honored
+        self.assertEqual(zc["thresh_w_crossings"], 2)     # default filled
+        self.assertEqual(cfg["report_mode"], "on_detect")
+        self.assertEqual(cfg["check_every"], 1)
+
+
+@unittest.skipIf(not solver_available, "no MIP solver available")
+class TestEndToEnd(unittest.TestCase):
+    """--detect-W-oscillations attaches the extension and writes the CSV."""
+
+    def test_detect_flag_writes_csv(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out_csv = os.path.join(tmp, "wosc.csv")
+            ctrl = os.path.join(tmp, "detect.json")
+            with open(ctrl, "w") as f:
+                json.dump({
+                    "output_csv": out_csv,
+                    "warmup_iters": 2,
+                    "report_mode": "every_check",
+                    "min_scenarios_to_report": 1,
+                    "methods": {
+                        "zero_crossings": {"thresh_w_crossings": 1,
+                                           "thresh_diff_crossings": 1,
+                                           "thresh_diffs_ratio": 0.0},
+                        "w_hash_recurrence": {"window": 6, "min_period": 2},
+                    },
+                }, f)
+
+            argv = [
+                "generic_cylinders",
+                "--module-name", "mpisppy.tests.examples.farmer",
+                "--num-scens", "3",
+                "--solver-name", solver_name,
+                "--max-solver-threads", "1",
+                "--max-iterations", "8",
+                "--default-rho", "1",
+                "--detect-W-oscillations", ctrl,
+            ]
+            with patch.object(sys, "argv", argv):
+                runpy.run_module("mpisppy.generic_cylinders",
+                                 run_name="__main__")
+
+            self.assertTrue(os.path.exists(out_csv),
+                            "detection CSV not written — extension not wired in")
+            with open(out_csv) as f:
+                rows = list(csv.reader(f))
+            self.assertEqual(rows[0], wosc._AGG_COLUMNS)
+            for row in rows[1:]:
+                self.assertEqual(len(row), len(wosc._AGG_COLUMNS))
+                self.assertIn(row[3], wosc.VALID_METHODS)
+                # full variable name, not an index tuple
+                self.assertIn("DevotedAcreage", row[2])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mpisppy/utils/cfg_vanilla.py
+++ b/mpisppy/utils/cfg_vanilla.py
@@ -869,6 +869,17 @@ def add_slammer(hub_dict,
     hub_dict["opt_kwargs"]["options"]["slammer_options"] = slammer_options
     return hub_dict
 
+def add_w_oscillation(hub_dict, cfg):
+    # W-oscillation detection/reporting; activated only when the detect JSON
+    # control file is supplied (see doc/designs/w_oscillation_design.md).
+    from mpisppy.extensions.w_oscillation import WOscillationMonitor
+    hub_dict = extension_adder(hub_dict, WOscillationMonitor)
+    hub_dict["opt_kwargs"]["options"]["w_oscillation_options"] = {
+        "detect_json": cfg.detect_W_oscillations,
+        "verbose": cfg.verbose,
+    }
+    return hub_dict
+
 def add_wxbar_read_write(hub_dict, cfg):
     """
     Add the wxbar read and write extensions to the hub_dict

--- a/mpisppy/utils/config.py
+++ b/mpisppy/utils/config.py
@@ -753,6 +753,20 @@ class Config(pyofig.ConfigDict):
                            domain=int,
                            default=None)
 
+    def w_oscillation_args(self):
+        # Detect oscillation/cycling in the PH W vector and report it to a CSV
+        # (see doc/designs/w_oscillation_design.md). The WOscillationMonitor
+        # extension is activated iff detect_W_oscillations is set; with no
+        # option a run behaves exactly as it does today (pure observation, no
+        # algorithm change). Interruption is a separate piece of work.
+        self.add_to_config("detect_W_oscillations",
+                           description="path to a JSON control file for "
+                           "W-oscillation detection; its presence activates the "
+                           "WOscillationMonitor extension and CSV reporting "
+                           "(default None)",
+                           domain=str,
+                           default=None)
+
     def reduced_costs_rho_args(self):
         self.add_to_config("reduced_costs_rho",
                            description="DEPRECATED and removed (2026-06-14); "

--- a/run_coverage.bash
+++ b/run_coverage.bash
@@ -122,6 +122,9 @@ run_phase "test_smps (serial)" \
 run_phase "test_generic_cylinders (serial)" \
     coverage run --rcfile=.coveragerc -m pytest mpisppy/tests/test_generic_cylinders.py -v
 
+run_phase "test_w_oscillation (serial)" \
+    coverage run --rcfile=.coveragerc -m pytest mpisppy/tests/test_w_oscillation.py -v
+
 run_phase "test_jensens (serial)" \
     coverage run --rcfile=.coveragerc -m pytest mpisppy/tests/test_jensens.py -v
 


### PR DESCRIPTION
## Summary

First of two PRs adding a hub extension to **detect** (this PR) and later
**interrupt** oscillation / cycling in the PH dual weight (W) vector. This PR is
**pure observation** — it attaches no rho or fixing changes, so a run with
`--detect-W-oscillations` follows exactly the same optimization trajectory as
one without. With no flag, behavior is unchanged (backward compatible).

Design: `doc/designs/w_oscillation_design.md` (on the `oscillation` design branch).

## What's added

- New extension `mpisppy/extensions/w_oscillation.py` (`WOscillationMonitor`)
  with two JSON-selectable, pluggable detectors:
  - **`zero_crossings`** — a port of PySP's `sorgw` plugin: per (scenario,
    nonant) it counts sign changes of W and of the consecutive differences,
    plus a back-half/front-half `|ΔW|` damping ratio.
  - **`w_hash_recurrence`** — the Watson–Woodruff *Progressive Hedging
    Innovations* (Computational Management Science, 2011) §2.4 cycle detector:
    hash the per-scenario W vector for each nonant and flag a recurrence. In
    the distributed setting the signature is made independent of the
    scenario→rank map by summing identity-mixed per-scenario 64-bit hashes and
    reducing with `MPI.SUM` (an additive/multiset hash); `min_period ≥ 2` so
    convergence (constant W) is not mistaken for a cycle.
- Per-(scenario, nonant) verdicts are aggregated across scenarios with per-node
  `SUM`/`MAX` reductions; cylinder rank 0 writes the aggregate CSV (full
  variable name + evidence). An optional per-scenario detail CSV is gathered to
  rank 0.
- CLI: `--detect-W-oscillations <json>`, wired through `config.py` /
  `cfg_vanilla.py` / `generic/extensions.py`, mirroring the Slammer.
- Example control file `examples/sizes/config/w_oscillation.json`.

## Tests

`mpisppy/tests/test_w_oscillation.py` (wired into `run_coverage.bash` **and**
`test_pr_and_main.yml`): unit tests for the pure detectors (sign counts,
signature determinism + distribution-independence, recurrence vs. convergence,
config validation) and an end-to-end farmer run asserting the flag attaches the
extension and writes a well-formed CSV. Verified manually that the aggregate
report is byte-identical at `np=1` and `np=2`.

## Docs

A `w_oscillation` section in `extensions.rst` cross-referencing the
`wtracker_extension` (for the full W trajectory / moving statistics), plus flag
entries in the generic-cylinders option lists.

## Notes

- Scope is **synchronous PH**.
- This is the detection half; **interruption** (rho reduction / slamming via the
  Slammer action layer) is the planned follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
