### PR TITLE
W-oscillation interruption (PR2: slamming)

### DIFF
--- a/doc/designs/w_oscillation_design.md
+++ b/doc/designs/w_oscillation_design.md
@@ -2,13 +2,16 @@
 
 **Status:** PR1 *detection + reporting* is implemented in
 ``mpisppy/extensions/w_oscillation.py`` (pure observation, no behavior change).
-PR2 *interruption* (``--interrupt-W-oscillations``: **W-damping** and/or
-slamming, the latter via the existing Slammer action layer) acts on the detector
-to break the oscillation. **PR2's action set is being revised on this branch**:
-the original rho-reduction action is replaced by **W-damping** (§9.1) and slam
-now fixes **one** nonant per slam event, with successive slams paced by an
-`iters_between_slams` cooldown (§9.2); the design below is the target,
-ahead of the code. Shipped as **two review-sized PRs**.
+PR2 *interruption* (``--interrupt-W-oscillations``) acts on the detector to
+break the oscillation by **slamming** (fixing) a cycling nonant, via the
+existing Slammer action layer — one nonant per slam event, with successive slams
+paced by an `iters_between_slams` cooldown (§9). **Slam is the only remedy.**
+Earlier drafts also offered dual-side remedies (rho reduction, then W-damping);
+both were dropped after experiments showed that no state-perturbing move breaks
+the cycle on the ``sizes`` model — only fixing a variable does. That empirical
+study lives in a separate experiments PR
+(``examples/sizes/w_oscillation_experiments/``). Shipped as **two review-sized
+PRs**.
 **Author:** dlw (captured with Claude Code assistance)
 **Last updated:** 2026-07-02
 
@@ -28,8 +31,9 @@ Related work:
   Science, 2011; optimization-online 2089), §2.4 "Detecting Cyclic Behavior" —
   the W-vector-hashing cycle detector this design adopts as method B (§5.2).
   Its §2.1 — oscillation is `w` "shoot[ing] past its optimal value" —
-  motivates the **W-damping** action (§9.1), which damps the dual (`w`) step
-  directly.
+  motivated the dual-side remedies (rho reduction, then W-damping) that earlier
+  drafts tried; experiments (separate PR) found they do not break the cycle, so
+  the shipped remedy is slam.
 - **slammer** (`mpisppy/extensions/slammer.py`, `doc/designs/slamming_design.md`)
   — the slamming *mechanism* whose action layer (its §7) PR2's "slam" action
   invokes. The slamming design explicitly anticipated "a separate future
@@ -65,8 +69,8 @@ value." Detection is **per (scenario, nonant)**; a nonant is *reported* /
    Each row names the **full variable name** and the oscillation evidence
    relative to the JSON's control parameters (e.g. how many crossings, in how
    many scenarios).
-3. (PR2) Optionally **interrupt** detected oscillation, via **W-damping**
-   and/or **slamming**, configured from a second JSON control file.
+3. (PR2) Optionally **interrupt** detected oscillation, via **slamming**,
+   configured from a second JSON control file.
 4. **Pluggable detection methods.** The JSON selects which method(s) run and
    parameterizes each, so methods can be added without touching the CLI.
 5. **Reuse, don't duplicate, the W-tracking code.** Capture the W trajectory
@@ -150,21 +154,18 @@ with that method (§5).
 
 ```jsonc
 {
-  "action": "w_damping",          // "w_damping" | "slam" | "both"
-                                  // docs encourage one or the other; "both"
-                                  // simply applies both, no coordination (§9)
+  "action": "slam",               // slam is the only remedy; the field is
+                                  // retained for a possible future action
   "trigger": {
     "min_scenarios_flagged": 1,   // act when >= this many scenarios flag a nonant
     "start_iter": 5               // first acting iteration; then every iteration
-                                  // a nonant is still flagged (damping has no
-                                  // cadence; slams have a cooldown, §9)
+                                  // a nonant is still flagged (slams have a
+                                  // cooldown, §9)
   },
-  "w_damping": { "factor": 0.5 },  // retained fraction of each dual (W) step on
-                                   // a flagged nonant; 0 <= factor < 1
   "slam": {
     "directives_file": "slam_directives.csv",  // priority column ranks which
-                                   // single nonant is slammed (§9.2)
-    "iters_between_slams": 3       // cooldown after a successful slam (§9.2)
+                                   // single nonant is slammed (§9)
+    "iters_between_slams": 3       // cooldown after a successful slam (§9)
   }
 }
 ```
@@ -191,10 +192,8 @@ with that method (§5).
 
 The PH per-iteration order around the extension hooks is: *xbar computed →
 W updated →* `miditer()` *→* `solve_loop()` *→* `enditer()`. So at
-`miditer(k)` the freshest **post-update** `W^k` is in place, so any change we
-make (W-damping, slam) takes effect for that iteration's `solve_loop` — and
-because `Update_W` has already run, W-damping can *correct the very increment it
-just applied* (§9.1).
+`miditer(k)` the freshest **post-update** `W^k` is in place, so a slam we apply
+takes effect for that iteration's `solve_loop`.
 
 | Hook | Action |
 |---|---|
@@ -412,76 +411,27 @@ large, so the file is **off by default**.
 
 ---
 
-## 9. Interruption (PR2)
+## 9. Interruption (PR2): slam
 
 When a nonant is flagged, act in `miditer` (after `Update_W`, before the
 solve). The trigger is simply `phiter >= start_iter`: once past the start
-iteration the detector is evaluated **every** iteration, and W-damping lands on
-a nonant **exactly on the iterations it is still flagged** (§4) — no
-inter-action cadence; a nonant is regulated for as long as it keeps
-oscillating and left alone once it settles.
+iteration the detector is evaluated **every** iteration, and slam fixes at most
+**one** flagged nonant, subject to a cooldown of `iters_between_slams`
+iterations since the last successful slam (fixing is drastic and the flags
+outlive a fix).
 
-The two actions are deliberately asymmetric: **W-damping nudges *every* flagged
-nonant this iteration** (it is gentle, reversible, and self-correcting), while
-**slam fixes at most *one*, and only after a cooldown** of
-`iters_between_slams` iterations since the last successful slam (fixing is
-drastic and the flags outlive a fix, §9.2).
+Slam is the **only** remedy. Earlier drafts also offered dual-side remedies —
+first rho reduction, then a W-step damper (`w_damping`) — on the theory that
+oscillation is `w` overshooting (WW §2.1) and can be tamed by shrinking the dual
+step while leaving the prox intact. Experiments (separate PR,
+`examples/sizes/w_oscillation_experiments/`) refuted that on the `sizes` model:
+neither damping nor resetting W nor reducing rho breaks the cycle (rho reduction
+is actively counterproductive; a geometric reduction only *appears* to help by
+freezing W while the primal gap explodes). Only fixing a variable — changing the
+problem structure — drives the PH primal gap down. So the dual-side remedies
+were dropped.
 
-### 9.1 `w_damping` — the dual-step damper (replaces rho reduction)
-
-Rather than weaken the proximal term, damp the **dual (`w`) step** that is
-overshooting. On each acting iteration `Update_W` has just applied, per
-(scenario, nonant),
-
-    W_s[j]  +=  rho[j] · (x_s[j] − x̄[j])            # phbase.py Update_W
-
-Had that step used `rho'[j] = factor · rho[j]` (`factor ∈ [0, 1)`) instead of
-`rho[j]`, W would be smaller by `(rho[j] − rho'[j])·(x_s[j] − x̄[j])`. So on
-**every** flagged nonant, in every local scenario, we **retroactively rescale
-the increment just applied**:
-
-    W_s[j]  −=  (1 − factor) · rho[j] · (x_s[j] − x̄[j])
-
-recomputing `x_s[j] − x̄[j]` from the live values (robust to the check
-cadence). Equivalently it is an under-relaxation of W toward its previous
-value, `W ← factor·W_new + (1−factor)·W_old`; applied every flagged iteration it
-damps the W swing by `factor` per step. This is the "simulate a lower rho on the
-last iteration" idea made exact and O(1) per nonant.
-
-Why this instead of rho reduction:
-
-- **It decouples the two jobs `rho` does.** PH uses one `rho` for both the prox
-  penalty *and* the dual ascent step. `w_damping` keeps the prox at `rho` (so x
-  stays pinned near x̄) but takes a **smaller dual step** — the classic ADMM
-  move of separating the penalty parameter from the dual step-size
-  (Fortin–Glowinski / generalized ADMM; a dual step `γ·rho` with
-  `γ ∈ (0, (1+√5)/2)` preserves convergence). Rho reduction does the opposite:
-  it loosens the prox and lets x wander while leaving the overshooting W alone.
-- **It attacks the cause named in WW §2.1** — oscillation is `w` "shoot[ing]
-  past its optimal value"; damping the dual step targets that overshoot
-  directly.
-
-Correctness (all favorable, and simpler than rho reduction):
-
-- **Preserves dual feasibility.** `Σ_s p_s W_s = 0` is invariant under the
-  rescale exactly when the base `Update_W` preserves it (scenario-uniform
-  `rho[j]`): `Σ_s p_s (rho−rho')(x_s−x̄) = (rho−rho')(x̄−x̄) = 0`. No new
-  dual-infeasibility beyond what scenario-varying rho already introduces in
-  stock PH.
-- **Inert at a fixed point.** At convergence `x_s = x̄`, the increment is 0, so
-  `w_damping` cannot perturb a converged solution.
-- **No positivity floor.** W is sign/magnitude-unconstrained, so unlike rho
-  (which PH requires `> 0`, #767) there is no `min_rho`. Config is just
-  `{"factor": <0..1>}`; `factor = 1` is a no-op (rejected as a
-  misconfiguration), `factor = 0` fully cancels the flagged nonant's dual step
-  that iteration.
-
-The flagged set is rank-identical (§6), so the change is coherent with no extra
-communication; the per-scenario W write is local and picked up by the next
-`set_objective` (W is a mutable Param in the objective — the same mechanism the
-rho-updating extensions rely on).
-
-### 9.2 `slam` — one highest-priority nonant per slam event, with a cooldown
+### 9.1 `slam` — one highest-priority nonant per slam event, with a cooldown
 
 Invoke the **Slammer action layer** (`slammer.py` §7), but slam **at most one**
 nonant per slam event even when many are flagged: fixing is drastic and
@@ -501,10 +451,9 @@ long as the stale signal persists — far more fixing than the re-settle story
 calls for. So successive slams are separated by a **cooldown**:
 `slam.iters_between_slams` (default 3), counted from the last **successful**
 slam (a no-candidate event starts no cooldown and retries on the next flagged
-iteration; `1` recovers slam-every-flagged-iteration). W-damping is *not*
-throttled — it is a per-step under-relaxation whose semantics depend on acting
-each flagged iteration. The cooldown state derives from the rank-identical
-slam count, so the slam/skip decision is identical on every rank and the
+iteration; `1` recovers slam-every-flagged-iteration). The cooldown state
+derives from the rank-identical slam count, so the slam/skip decision is
+identical on every rank and the
 direction extremum's `Allreduce` stays symmetric. (This reinstates, slam-scoped
 and as a cooldown rather than a modulo grid, the `iters_between_actions`
 cadence an earlier revision dropped.)
@@ -523,21 +472,6 @@ one-per-iteration semantics are already Slammer's.
 cycling `x(i)` to `max_s x_s(i)`, the Slammer `max` direction — so a directives
 file of `*,1,max,…` driven by the detector reproduces their §2.4 behavior (now
 one nonant at a time).
-
-### 9.3 `both`
-
-The user docs **encourage choosing one or the other**, but if `action ==
-"both"` we **simply apply both**, no coordination/escalation: this iteration
-`w_damping` nudges *all* flagged nonants and `slam` fixes the *one*
-highest-priority flagged nonant that can be slammed. No special-casing of the
-interaction — a slammed nonant becomes `is_fixed()`, so W-damping of it is inert
-(harmless), and its `x_s = x̄` afterward zeroes its future W increments, so it
-leaves the flagged set on its own. Keep-it-simple was the explicit decision
-(§13).
-
-PR2 must demonstrate interruption **helps** (§11): on a model tuned to cycle,
-the interrupted run reaches a better gap / converges in fewer iterations than
-the plain run in the same budget.
 
 ---
 
@@ -584,25 +518,21 @@ Following the Slammer wiring precisely:
 - **MPI (`mpiexec -np 2`/`3`):** the same induced-oscillation run; assert the
   rank-0 CSV is **independent of scenario→rank distribution** (the reduction
   is correct).
-- **PR2 — action layers fire end-to-end:** tests cover the interrupt-config
-  validators (action ∈ `{w_damping, slam, both}`, `factor` in `[0,1)`,
-  slam-needs-a-file, `iters_between_slams` defaulting/validation, trigger
-  defaults with no `iters_between_actions`), pure arithmetic checks of the
-  W-damping rescale (`w_damped(...)`) and the slam cooldown (`slam_due(...)`)
-  (no MPI), and an end-to-end farmer run with `--interrupt-W-oscillations`
-  (with a `detect` block, so the report *is* requested) asserting that both the
-  W-damping and the slam action execute through a real PH loop and the detection
-  CSV is written. The W-damping assertion checks a flagged nonant's post-action
-  W equals its pre-action W minus `(1−factor)·rho·(x−x̄)`; the slam assertions
+- **PR2 — the slam action fires end-to-end:** tests cover the interrupt-config
+  validators (action ∈ `{slam}`, slam-needs-a-file, `iters_between_slams`
+  defaulting/validation, trigger defaults with no `iters_between_actions`), a
+  pure arithmetic check of the slam cooldown (`slam_due(...)`) (no MPI), and an
+  end-to-end farmer run with `--interrupt-W-oscillations` (with a `detect`
+  block, so the report *is* requested) asserting that the slam action executes
+  through a real PH loop and the detection CSV is written. The slam assertions
   check **exactly one** nonant is fixed per slam event (the highest-priority
-  flagged one) and that the cooldown then suppresses further slams (the
-  `slam cooling down` log line) while damping continues. A second end-to-end run with **no** detection
-  request asserts the **opt-in** rule: the engine still drives the actions but
-  **no report CSV is written**. The slam path's per-node min/max `Allreduce` is
-  exercised under `mpiexec -np 2` to confirm it is reached symmetrically (no
-  deadlock; slam value = the global per-scenario max). A cycle-tuned
-  *numeric*-improvement assertion (fewer iters to a target gap) is a natural
-  follow-up, omitted to avoid a flaky test.
+  flagged one) and that the cooldown then suppresses further slams. A second
+  end-to-end run with **no** detection request asserts the **opt-in** rule: the
+  engine still drives the action but **no report CSV is written**. The slam
+  path's per-node min/max `Allreduce` is exercised under `mpiexec -np 2` to
+  confirm it is reached symmetrically (no deadlock; slam value = the global
+  per-scenario max). Whether slam (and not the dropped dual-side remedies)
+  actually breaks a cycle is established in the experiments PR (§9).
 - **Coverage harness:** add `mpisppy/tests/test_w_oscillation.py` to
   `run_coverage.bash` **and** `.github/workflows/test_pr_and_main.yml` in the
   **same commit** (else codecov/patch reports 0%).
@@ -619,15 +549,15 @@ page cross-referencing wtracker. Pure observation ⇒ green on its own,
 backward compatible.
 
 **PR2 — interruption.**
-`--interrupt-W-oscillations` flag and JSON, the **W-damping** action (§9.1), the
-**slam** action (one highest-priority nonant per slam event via Slammer's
-`_slam_one` restricted to the flagged set, paced by the `iters_between_slams`
-cooldown, §9.2), the trigger layer (`start_iter`; damping itself has no
-cadence), and the `both` = apply-both rule (§9.3). Builds on PR1's engine: the
+`--interrupt-W-oscillations` flag and JSON, the **slam** action (§9.1: one
+highest-priority nonant per slam event via Slammer's `_slam_one` restricted to
+the flagged set, paced by the `iters_between_slams` cooldown), and the trigger
+layer (`start_iter`, `min_scenarios_flagged`). Builds on PR1's engine: the
 detectors also return the rank-identical flagged set the interrupter acts on.
 Backward compatible — with neither flag the extension is never built, and a
 detect-only run is byte-identical to PR1. (Supersedes the earlier
-rho-reduction-based PR2 draft on this branch.)
+rho-reduction- and W-damping-based PR2 drafts on this branch; the experiments PR
+records why the dual-side remedies were dropped.)
 
 Each PR is review-sized and green independently (per the project's
 phased-PR-for-redesigns practice).
@@ -643,33 +573,40 @@ Settled in review (DLW, 2026-06-27); recorded for provenance.
    sum-reduced signature** (identity-mixed per-scenario 64-bit hashes).
    *Confirmed* ("I like the idea"). Background/keywords for the technique are in
    §5.2.1 (incremental/multiset hashing; state-hash cycle detection).
-2. **`both` interruption (Q2)** — docs **encourage one or the other**; if both
-   are configured, **just apply both**, no coordination/escalation logic (§9.3).
+2. **`both` interruption (Q2)** — *obsolete:* there was briefly a `both` action
+   combining a dual-side remedy with slam; with the dual-side remedies dropped
+   (decision 8), slam is the only action and `both` is gone.
 3. **Per-scenario reporting (Q3)** — **yes**, an optional `per_scenario_csv`
    detail file (gather-based, off by default) is in scope for PR1 (§7.1).
 4. **Capture hook (Q4)** — **`miditer`** (post-update W), §4. (Differs from
    `Wtracker_extension`, which grabs in `enditer`.)
 
 Revised (DLW, 2026-07-02), superseding the rho-reduction action of the first
-PR2 draft:
+PR2 draft (itself later superseded — see decision 8):
 
-5. **Drop rho reduction; add `w_damping`.** The interruption action formerly
-   `rho_reduction` is replaced by `w_damping` (§9.1): a one-step retroactive
-   rescale of the dual (`w`) step, `W −= (1−factor)·rho·(x−x̄)`, leaving the
-   prox `rho` untouched. Simpler (no `min_rho` floor), targets the WW §2.1
-   overshoot directly, and preserves `Σ_s p_s W_s = 0`. It applies to **every**
-   flagged nonant each acting iteration. `action ∈ {w_damping, slam, both}`.
+5. **Drop rho reduction; add `w_damping`.** The `rho_reduction` action was
+   replaced by a W-step damper `w_damping`. *(Later dropped — decision 8.)*
 6. **One slam per iteration.** Slam fixes **at most one** nonant per iteration
    — the highest-priority flagged one that can be slammed, via Slammer's
    `_slam_one` restricted to the flagged set (priority from the directives file,
-   ties by name) — not every flagged nonant (§9.2).
+   ties by name) — not every flagged nonant (§9.1).
 7. **No `iters_between_actions`.** Drop the inter-action cadence: once past
    `start_iter`, act every iteration a nonant is still flagged (§9). Trigger is
    `{min_scenarios_flagged, start_iter}`.
+
+Revised (DLW, 2026-07-08):
+
+8. **Slam is the only remedy; drop all dual-side remedies.** Experiments on the
+   `sizes` model (separate PR, `examples/sizes/w_oscillation_experiments/`)
+   showed that no state-perturbing move — W-damping, W-reset, or rho reduction —
+   breaks the cycle: they leave it intact, decouple the scenarios (primal gap
+   explodes while W freezes), or worsen it. Only fixing a variable (slam) drives
+   the primal gap down. So `w_damping` (decision 5) is removed and `action`'s
+   only value is `slam`. The root cause on `sizes` is that rho is *too small*
+   (its `_rho_setter` uses cost × 0.001); a larger rho converges without any
+   interruption.
 
 ### Still open
 
 - **`quantum` / `min_period` / `window` defaults** for method B — proposed
   `1e-6 / 2 / 20`; tune against the induced-oscillation test once it exists.
-- **`w_damping` default `factor`** — proposed `0.5`; tune against the
-  induced-oscillation test.

--- a/doc/designs/w_oscillation_design.md
+++ b/doc/designs/w_oscillation_design.md
@@ -6,7 +6,8 @@ PR2 *interruption* (``--interrupt-W-oscillations``: **W-damping** and/or
 slamming, the latter via the existing Slammer action layer) acts on the detector
 to break the oscillation. **PR2's action set is being revised on this branch**:
 the original rho-reduction action is replaced by **W-damping** (§9.1) and slam
-now fixes **one** nonant per iteration (§9.2); the design below is the target,
+now fixes **one** nonant per slam event, with successive slams paced by an
+`iters_between_slams` cooldown (§9.2); the design below is the target,
 ahead of the code. Shipped as **two review-sized PRs**.
 **Author:** dlw (captured with Claude Code assistance)
 **Last updated:** 2026-07-02
@@ -155,12 +156,16 @@ with that method (§5).
   "trigger": {
     "min_scenarios_flagged": 1,   // act when >= this many scenarios flag a nonant
     "start_iter": 5               // first acting iteration; then every iteration
-                                  // a nonant is still flagged (no cadence, §9)
+                                  // a nonant is still flagged (damping has no
+                                  // cadence; slams have a cooldown, §9)
   },
   "w_damping": { "factor": 0.5 },  // retained fraction of each dual (W) step on
                                    // a flagged nonant; 0 <= factor < 1
-  "slam": { "directives_file": "slam_directives.csv" }  // priority column ranks
-                                   // which single nonant is slammed (§9.2)
+  "slam": {
+    "directives_file": "slam_directives.csv",  // priority column ranks which
+                                   // single nonant is slammed (§9.2)
+    "iters_between_slams": 3       // cooldown after a successful slam (§9.2)
+  }
 }
 ```
 
@@ -411,14 +416,16 @@ large, so the file is **off by default**.
 
 When a nonant is flagged, act in `miditer` (after `Update_W`, before the
 solve). The trigger is simply `phiter >= start_iter`: once past the start
-iteration the detector is evaluated **every** iteration, and an action lands on
-a nonant **exactly on the iterations it is still flagged** (§4). There is no
-inter-action cadence — a nonant is regulated for as long as it keeps
+iteration the detector is evaluated **every** iteration, and W-damping lands on
+a nonant **exactly on the iterations it is still flagged** (§4) — no
+inter-action cadence; a nonant is regulated for as long as it keeps
 oscillating and left alone once it settles.
 
 The two actions are deliberately asymmetric: **W-damping nudges *every* flagged
 nonant this iteration** (it is gentle, reversible, and self-correcting), while
-**slam fixes at most *one*** (fixing is drastic, §9.2).
+**slam fixes at most *one*, and only after a cooldown** of
+`iters_between_slams` iterations since the last successful slam (fixing is
+drastic and the flags outlive a fix, §9.2).
 
 ### 9.1 `w_damping` — the dual-step damper (replaces rho reduction)
 
@@ -474,14 +481,31 @@ communication; the per-scenario W write is local and picked up by the next
 `set_objective` (W is a mutable Param in the objective — the same mechanism the
 rho-updating extensions rely on).
 
-### 9.2 `slam` — one highest-priority nonant per iteration
+### 9.2 `slam` — one highest-priority nonant per slam event, with a cooldown
 
 Invoke the **Slammer action layer** (`slammer.py` §7), but slam **at most one**
-nonant per iteration even when many are flagged: fixing is drastic and
+nonant per slam event even when many are flagged: fixing is drastic and
 near-irreversible, and fixing the single worst oscillator often re-settles the
 others for free (WW §2.1: changes in one integer variable induce changes in
-others). This is the graceful pace that dropping the cadence enables — fix one,
-re-solve, re-detect, fix the next if it is still cycling.
+others). The intended pace is: fix one, re-solve, re-detect, fix the next *if
+it is still cycling*.
+
+But "re-detect" cannot answer *still cycling?* one iteration after a fix: the
+detectors judge a **trailing history window**, so a nonant that is re-settling
+keeps its flag until the old oscillation ages out of the buffer (with the
+zero-crossings defaults, potentially tens of iterations). Acting on the raw
+flag every iteration would therefore fix one variable per iteration for as
+long as the stale signal persists — far more fixing than the re-settle story
+calls for. So successive slams are separated by a **cooldown**:
+`slam.iters_between_slams` (default 3), counted from the last **successful**
+slam (a no-candidate event starts no cooldown and retries on the next flagged
+iteration; `1` recovers slam-every-flagged-iteration). W-damping is *not*
+throttled — it is a per-step under-relaxation whose semantics depend on acting
+each flagged iteration. The cooldown state derives from the rank-identical
+slam count, so the slam/skip decision is identical on every rank and the
+direction extremum's `Allreduce` stays symmetric. (This reinstates, slam-scoped
+and as a cooldown rather than a modulo grid, the `iters_between_actions`
+cadence an earlier revision dropped.)
 
 Selection reuses Slammer's existing `_slam_one`, restricted to the flagged set:
 among the flagged nonants it ranks by the directives file's **`priority`**
@@ -560,15 +584,17 @@ Following the Slammer wiring precisely:
   is correct).
 - **PR2 — action layers fire end-to-end:** tests cover the interrupt-config
   validators (action ∈ `{w_damping, slam, both}`, `factor` in `[0,1)`,
-  slam-needs-a-file, trigger defaults with no `iters_between_actions`), a pure
-  arithmetic check of the W-damping rescale (a `w_damped(...)` helper, no MPI),
-  and an end-to-end farmer run with `--interrupt-W-oscillations` (with a
-  `detect` block, so the report *is* requested) asserting that both the
+  slam-needs-a-file, `iters_between_slams` defaulting/validation, trigger
+  defaults with no `iters_between_actions`), pure arithmetic checks of the
+  W-damping rescale (`w_damped(...)`) and the slam cooldown (`slam_due(...)`)
+  (no MPI), and an end-to-end farmer run with `--interrupt-W-oscillations`
+  (with a `detect` block, so the report *is* requested) asserting that both the
   W-damping and the slam action execute through a real PH loop and the detection
   CSV is written. The W-damping assertion checks a flagged nonant's post-action
-  W equals its pre-action W minus `(1−factor)·rho·(x−x̄)`; the slam assertion
-  checks **exactly one** nonant is fixed per acting iteration (the
-  highest-priority flagged one). A second end-to-end run with **no** detection
+  W equals its pre-action W minus `(1−factor)·rho·(x−x̄)`; the slam assertions
+  check **exactly one** nonant is fixed per slam event (the highest-priority
+  flagged one) and that the cooldown then suppresses further slams (the
+  `slam cooling down` log line) while damping continues. A second end-to-end run with **no** detection
   request asserts the **opt-in** rule: the engine still drives the actions but
   **no report CSV is written**. The slam path's per-node min/max `Allreduce` is
   exercised under `mpiexec -np 2` to confirm it is reached symmetrically (no
@@ -592,8 +618,9 @@ backward compatible.
 
 **PR2 — interruption.**
 `--interrupt-W-oscillations` flag and JSON, the **W-damping** action (§9.1), the
-**slam** action (one highest-priority nonant per iteration via Slammer's
-`_slam_one` restricted to the flagged set, §9.2), the trigger layer (no
+**slam** action (one highest-priority nonant per slam event via Slammer's
+`_slam_one` restricted to the flagged set, paced by the `iters_between_slams`
+cooldown, §9.2), the trigger layer (`start_iter`; damping itself has no
 cadence), and the `both` = apply-both rule (§9.3). Builds on PR1's engine: the
 detectors also return the rank-identical flagged set the interrupter acts on.
 Backward compatible — with neither flag the extension is never built, and a

--- a/doc/designs/w_oscillation_design.md
+++ b/doc/designs/w_oscillation_design.md
@@ -486,9 +486,10 @@ rho-updating extensions rely on).
 Invoke the **Slammer action layer** (`slammer.py` §7), but slam **at most one**
 nonant per slam event even when many are flagged: fixing is drastic and
 permanent (a slammed variable stays fixed for the rest of the run, even after
-its flag clears), and fixing the single worst oscillator often re-settles the
+its flag clears), and fixing just one cycling variable often re-settles the
 others for free (WW §2.1: changes in one integer variable induce changes in
-others). The intended pace is: fix one, re-solve, re-detect, fix the next *if
+others). Which one is slammed is decided by the directives file's `priority`
+ranking, not by any measure of oscillation severity. The intended pace is: fix one, re-solve, re-detect, fix the next *if
 it is still cycling*.
 
 But "re-detect" cannot answer *still cycling?* one iteration after a fix: the

--- a/doc/designs/w_oscillation_design.md
+++ b/doc/designs/w_oscillation_design.md
@@ -1,9 +1,10 @@
 # W-oscillation detection and interruption — design
 
-**Status:** PR1 *detection + reporting* (pure observation, no behavior
-change) is implemented in ``mpisppy/extensions/w_oscillation.py``; PR2
-*interruption* (acts on the detector to break the oscillation) is not yet
-started. Shipped as **two review-sized PRs**.
+**Status:** both PRs implemented in ``mpisppy/extensions/w_oscillation.py``.
+PR1 *detection + reporting* is pure observation (no behavior change); PR2
+*interruption* (``--interrupt-W-oscillations``: rho reduction and/or slamming,
+the latter via the existing Slammer action layer) acts on the detector to
+break the oscillation. Shipped as **two review-sized PRs**.
 **Author:** dlw (captured with Claude Code assistance)
 **Last updated:** 2026-06-30
 
@@ -475,9 +476,16 @@ Following the Slammer wiring precisely:
 - **MPI (`mpiexec -np 2`/`3`):** the same induced-oscillation run; assert the
   rank-0 CSV is **independent of scenario→rank distribution** (the reduction
   is correct).
-- **PR2 — improvement:** on the cycle-tuned model, assert the interrupted run
-  improves on the plain run (fewer iters to a target gap, or better gap at the
-  iteration cap).
+- **PR2 — action layers fire end-to-end:** the shipped tests cover the
+  interrupt-config validators (action / factor-range / positive-`min_rho` /
+  slam-needs-a-file / trigger defaults), the `reduced_rho` floor, and an
+  end-to-end farmer run with `--interrupt-W-oscillations` asserting that **both**
+  the rho-reduction and the slam action actually execute through a real PH loop
+  (and the detection CSV is still written). The slam path's per-node min/max
+  `Allreduce` was exercised under `mpiexec -np 2` to confirm it is reached
+  symmetrically (no deadlock; slam value = the global per-scenario max). A
+  cycle-tuned *numeric*-improvement assertion (fewer iters to a target gap) is a
+  natural follow-up but is omitted here to avoid a flaky test.
 - **Coverage harness:** add `mpisppy/tests/test_w_oscillation.py` to
   `run_coverage.bash` **and** `.github/workflows/test_pr_and_main.yml` in the
   **same commit** (else codecov/patch reports 0%).
@@ -493,10 +501,14 @@ CSV writer (rank 0), unit + reduction + end-to-end + MPI tests, and a user-doc
 page cross-referencing wtracker. Pure observation ⇒ green on its own,
 backward compatible.
 
-**PR2 — interruption.**
+**PR2 — interruption (implemented).**
 `--interrupt-W-oscillations` flag and JSON, the rho-reduction action, the
-slam action (calling the Slammer action layer), the trigger layer, the
-`both` = apply-both rule (§9), and an improvement test. Builds on PR1's engine.
+slam action (calling the Slammer action layer via a small new public
+`Slammer.slam_nonant(ndn_i)` entry point — the action layer §7 anticipated),
+the trigger layer, and the `both` = apply-both rule (§9). Builds on PR1's
+engine: the detectors now also return the rank-identical flagged set the
+interrupter acts on. Backward compatible — with neither flag the extension is
+never built, and a detect-only run is byte-identical to PR1.
 
 Each PR is review-sized and green independently (per the project's
 phased-PR-for-redesigns practice).

--- a/doc/designs/w_oscillation_design.md
+++ b/doc/designs/w_oscillation_design.md
@@ -92,11 +92,18 @@ Two flags on the generic driver (and any Config-based driver), each taking a
 | Flag | Effect |
 |---|---|
 | `--detect-W-oscillations PATH` | Activates the extension in **detect+report** mode; controls in the JSON at `PATH`. |
-| `--interrupt-W-oscillations PATH` | (PR2) Activates **interruption**; controls in the JSON at `PATH`. Implies detection — if `--detect-W-oscillations` is absent, a default detector config is used (or the interrupt JSON may carry a `detect` block, see §9). |
+| `--interrupt-W-oscillations PATH` | (PR2) Activates **interruption**; controls in the JSON at `PATH`. Runs the detection *engine* to find the cycling nonants, but **does not write the report** unless detection is *also* requested — via `--detect-W-oscillations` or a `detect` block in the interrupt JSON. With neither, a default detector config drives the actions and **no CSV is written** (each interruption is announced with a `global_toc` line instead). |
 
 Presence of a flag activates the extension (mirroring how
 `--slamming-directives-file` activates the Slammer). Neither flag ⇒ extension
 never constructed ⇒ identical behavior to today.
+
+**Reporting is opt-in.** Interruption *implies the detection engine* (it must
+know which nonants are cycling), but it does **not** imply the *report*: the
+CSV is written only when the user explicitly asks for detection. A pure
+`--interrupt-W-oscillations` run produces only a per-event `global_toc`
+("`W-oscillation interruption [iter k]: …`"); to also get the cycling CSV, add
+`--detect-W-oscillations` or a `detect` block.
 
 ### 2.1 Detection JSON schema (PR1)
 
@@ -479,13 +486,16 @@ Following the Slammer wiring precisely:
 - **PR2 — action layers fire end-to-end:** the shipped tests cover the
   interrupt-config validators (action / factor-range / positive-`min_rho` /
   slam-needs-a-file / trigger defaults), the `reduced_rho` floor, and an
-  end-to-end farmer run with `--interrupt-W-oscillations` asserting that **both**
-  the rho-reduction and the slam action actually execute through a real PH loop
-  (and the detection CSV is still written). The slam path's per-node min/max
-  `Allreduce` was exercised under `mpiexec -np 2` to confirm it is reached
-  symmetrically (no deadlock; slam value = the global per-scenario max). A
-  cycle-tuned *numeric*-improvement assertion (fewer iters to a target gap) is a
-  natural follow-up but is omitted here to avoid a flaky test.
+  end-to-end farmer run with `--interrupt-W-oscillations` (with a `detect`
+  block, so the report *is* requested) asserting that **both** the
+  rho-reduction and the slam action actually execute through a real PH loop and
+  the detection CSV is written. A second end-to-end run with **no** detection
+  request asserts the **opt-in** rule: the engine still drives the actions but
+  **no report CSV is written**. The slam path's per-node min/max `Allreduce`
+  was exercised under `mpiexec -np 2` to confirm it is reached symmetrically
+  (no deadlock; slam value = the global per-scenario max). A cycle-tuned
+  *numeric*-improvement assertion (fewer iters to a target gap) is a natural
+  follow-up but is omitted here to avoid a flaky test.
 - **Coverage harness:** add `mpisppy/tests/test_w_oscillation.py` to
   `run_coverage.bash` **and** `.github/workflows/test_pr_and_main.yml` in the
   **same commit** (else codecov/patch reports 0%).

--- a/doc/designs/w_oscillation_design.md
+++ b/doc/designs/w_oscillation_design.md
@@ -485,7 +485,8 @@ rho-updating extensions rely on).
 
 Invoke the **Slammer action layer** (`slammer.py` §7), but slam **at most one**
 nonant per slam event even when many are flagged: fixing is drastic and
-near-irreversible, and fixing the single worst oscillator often re-settles the
+permanent (a slammed variable stays fixed for the rest of the run, even after
+its flag clears), and fixing the single worst oscillator often re-settles the
 others for free (WW §2.1: changes in one integer variable induce changes in
 others). The intended pace is: fix one, re-solve, re-detect, fix the next *if
 it is still cycling*.

--- a/doc/designs/w_oscillation_design.md
+++ b/doc/designs/w_oscillation_design.md
@@ -1,12 +1,15 @@
 # W-oscillation detection and interruption — design
 
-**Status:** both PRs implemented in ``mpisppy/extensions/w_oscillation.py``.
-PR1 *detection + reporting* is pure observation (no behavior change); PR2
-*interruption* (``--interrupt-W-oscillations``: rho reduction and/or slamming,
-the latter via the existing Slammer action layer) acts on the detector to
-break the oscillation. Shipped as **two review-sized PRs**.
+**Status:** PR1 *detection + reporting* is implemented in
+``mpisppy/extensions/w_oscillation.py`` (pure observation, no behavior change).
+PR2 *interruption* (``--interrupt-W-oscillations``: **W-damping** and/or
+slamming, the latter via the existing Slammer action layer) acts on the detector
+to break the oscillation. **PR2's action set is being revised on this branch**:
+the original rho-reduction action is replaced by **W-damping** (§9.1) and slam
+now fixes **one** nonant per iteration (§9.2); the design below is the target,
+ahead of the code. Shipped as **two review-sized PRs**.
 **Author:** dlw (captured with Claude Code assistance)
-**Last updated:** 2026-06-30
+**Last updated:** 2026-07-02
 
 Related work:
 
@@ -23,8 +26,9 @@ Related work:
   Mixed-Integer Resource Allocation Problems"** (Computational Management
   Science, 2011; optimization-online 2089), §2.4 "Detecting Cyclic Behavior" —
   the W-vector-hashing cycle detector this design adopts as method B (§5.2).
-  Its §2.1 (SEP / cost-proportional rho) motivates the rho-reduction action
-  (§9).
+  Its §2.1 — oscillation is `w` "shoot[ing] past its optimal value" —
+  motivates the **W-damping** action (§9.1), which damps the dual (`w`) step
+  directly.
 - **slammer** (`mpisppy/extensions/slammer.py`, `doc/designs/slamming_design.md`)
   — the slamming *mechanism* whose action layer (its §7) PR2's "slam" action
   invokes. The slamming design explicitly anticipated "a separate future
@@ -60,7 +64,7 @@ value." Detection is **per (scenario, nonant)**; a nonant is *reported* /
    Each row names the **full variable name** and the oscillation evidence
    relative to the JSON's control parameters (e.g. how many crossings, in how
    many scenarios).
-3. (PR2) Optionally **interrupt** detected oscillation, via **rho reduction**
+3. (PR2) Optionally **interrupt** detected oscillation, via **W-damping**
    and/or **slamming**, configured from a second JSON control file.
 4. **Pluggable detection methods.** The JSON selects which method(s) run and
    parameterizes each, so methods can be added without touching the CLI.
@@ -145,16 +149,18 @@ with that method (§5).
 
 ```jsonc
 {
-  "action": "rho_reduction",      // "rho_reduction" | "slam" | "both"
+  "action": "w_damping",          // "w_damping" | "slam" | "both"
                                   // docs encourage one or the other; "both"
                                   // simply applies both, no coordination (§9)
   "trigger": {
     "min_scenarios_flagged": 1,   // act when >= this many scenarios flag a nonant
-    "start_iter": 5,
-    "iters_between_actions": 3
+    "start_iter": 5               // first acting iteration; then every iteration
+                                  // a nonant is still flagged (no cadence, §9)
   },
-  "rho_reduction": { "factor": 0.5, "min_rho": 1e-3 },
-  "slam": { "directives_file": "slam_directives.csv" }  // feeds the Slammer
+  "w_damping": { "factor": 0.5 },  // retained fraction of each dual (W) step on
+                                   // a flagged nonant; 0 <= factor < 1
+  "slam": { "directives_file": "slam_directives.csv" }  // priority column ranks
+                                   // which single nonant is slammed (§9.2)
 }
 ```
 
@@ -180,8 +186,10 @@ with that method (§5).
 
 The PH per-iteration order around the extension hooks is: *xbar computed →
 W updated →* `miditer()` *→* `solve_loop()` *→* `enditer()`. So at
-`miditer(k)` the freshest **post-update** `W^k` is in place, and any change we
-make (rho, slam) takes effect for that iteration's `solve_loop`.
+`miditer(k)` the freshest **post-update** `W^k` is in place, so any change we
+make (W-damping, slam) takes effect for that iteration's `solve_loop` — and
+because `Update_W` has already run, W-damping can *correct the very increment it
+just applied* (§9.1).
 
 | Hook | Action |
 |---|---|
@@ -401,38 +409,105 @@ large, so the file is **off by default**.
 
 ## 9. Interruption (PR2)
 
-When a nonant is flagged (and the trigger in §2.2 fires), act in `miditer`
-before the solve:
+When a nonant is flagged, act in `miditer` (after `Update_W`, before the
+solve). The trigger is simply `phiter >= start_iter`: once past the start
+iteration the detector is evaluated **every** iteration, and an action lands on
+a nonant **exactly on the iterations it is still flagged** (§4). There is no
+inter-action cadence — a nonant is regulated for as long as it keeps
+oscillating and left alone once it settles.
 
-- **`rho_reduction`** — multiply that nonant's `rho` by `factor (<1)` in every
-  local scenario, floored at `min_rho > 0` (consistent with the merged rho>0
-  enforcement, #767). Reducing rho relaxes the proximal pull that is driving
-  the overshoot/cycle. The motivation is in Watson–Woodruff §2.1: the update is
-  `w_s += ρ(x_s − x̄)`, so a too-large ρ is exactly what lets `w` "shoot past"
-  its optimum and thrash; their SEP rho is designed to approach `w*` "from
-  below" to avoid this. Reducing ρ on a *detected-cycling* nonant is the
-  dynamic analogue. Which nonants to touch comes from the rank-identical
-  reduced set (§6), so the change is coherent with no extra communication; the
-  per-scenario rho write is local (push to persistent solver via
-  `update_var`).
-- **`slam`** — invoke the **Slammer action layer** (`slammer.py` §7) on the
-  flagged nonant: pick by the directives file's priority/direction and `fix()`
-  it across all scenarios. This is exactly the consumer the slamming design
-  anticipated; PR2 wires the detector's "this nonant is cycling" signal into
-  Slammer's `slam(ndn_i, direction)` rather than Slammer's built-in
-  iteration-count trigger. **Method B's paper-native remediation is precisely
-  this:** Watson–Woodruff §2.4 fixes the cycling `x(i)` to `max_s x_s(i)`,
-  which is the Slammer `max` direction — so a directives file of `*,1,max,…`
-  driven by the detector reproduces their §2.4 behavior exactly.
-- **`both`** — the user docs **encourage choosing one or the other**, but if
-  `action == "both"` we **simply apply both** with no coordination/escalation
-  logic: for each flagged nonant this event, run the `rho_reduction` action
-  *and* the `slam` action. (No special-casing of the interaction: a nonant the
-  slam directives `fix()` becomes `is_fixed()`, so the subsequent rho change on
-  it is inert — harmless; and a nonant slamming declines, e.g. not in the
-  directives file, still gets its rho reduced. The two mechanisms act on
-  whatever each is configured to act on.) Keep-it-simple was the explicit
-  decision (§13).
+The two actions are deliberately asymmetric: **W-damping nudges *every* flagged
+nonant this iteration** (it is gentle, reversible, and self-correcting), while
+**slam fixes at most *one*** (fixing is drastic, §9.2).
+
+### 9.1 `w_damping` — the dual-step damper (replaces rho reduction)
+
+Rather than weaken the proximal term, damp the **dual (`w`) step** that is
+overshooting. On each acting iteration `Update_W` has just applied, per
+(scenario, nonant),
+
+    W_s[j]  +=  rho[j] · (x_s[j] − x̄[j])            # phbase.py Update_W
+
+Had that step used `rho'[j] = factor · rho[j]` (`factor ∈ [0, 1)`) instead of
+`rho[j]`, W would be smaller by `(rho[j] − rho'[j])·(x_s[j] − x̄[j])`. So on
+**every** flagged nonant, in every local scenario, we **retroactively rescale
+the increment just applied**:
+
+    W_s[j]  −=  (1 − factor) · rho[j] · (x_s[j] − x̄[j])
+
+recomputing `x_s[j] − x̄[j]` from the live values (robust to the check
+cadence). Equivalently it is an under-relaxation of W toward its previous
+value, `W ← factor·W_new + (1−factor)·W_old`; applied every flagged iteration it
+damps the W swing by `factor` per step. This is the "simulate a lower rho on the
+last iteration" idea made exact and O(1) per nonant.
+
+Why this instead of rho reduction:
+
+- **It decouples the two jobs `rho` does.** PH uses one `rho` for both the prox
+  penalty *and* the dual ascent step. `w_damping` keeps the prox at `rho` (so x
+  stays pinned near x̄) but takes a **smaller dual step** — the classic ADMM
+  move of separating the penalty parameter from the dual step-size
+  (Fortin–Glowinski / generalized ADMM; a dual step `γ·rho` with
+  `γ ∈ (0, (1+√5)/2)` preserves convergence). Rho reduction does the opposite:
+  it loosens the prox and lets x wander while leaving the overshooting W alone.
+- **It attacks the cause named in WW §2.1** — oscillation is `w` "shoot[ing]
+  past its optimal value"; damping the dual step targets that overshoot
+  directly.
+
+Correctness (all favorable, and simpler than rho reduction):
+
+- **Preserves dual feasibility.** `Σ_s p_s W_s = 0` is invariant under the
+  rescale exactly when the base `Update_W` preserves it (scenario-uniform
+  `rho[j]`): `Σ_s p_s (rho−rho')(x_s−x̄) = (rho−rho')(x̄−x̄) = 0`. No new
+  dual-infeasibility beyond what scenario-varying rho already introduces in
+  stock PH.
+- **Inert at a fixed point.** At convergence `x_s = x̄`, the increment is 0, so
+  `w_damping` cannot perturb a converged solution.
+- **No positivity floor.** W is sign/magnitude-unconstrained, so unlike rho
+  (which PH requires `> 0`, #767) there is no `min_rho`. Config is just
+  `{"factor": <0..1>}`; `factor = 1` is a no-op (rejected as a
+  misconfiguration), `factor = 0` fully cancels the flagged nonant's dual step
+  that iteration.
+
+The flagged set is rank-identical (§6), so the change is coherent with no extra
+communication; the per-scenario W write is local and picked up by the next
+`set_objective` (W is a mutable Param in the objective — the same mechanism the
+rho-updating extensions rely on).
+
+### 9.2 `slam` — one highest-priority nonant per iteration
+
+Invoke the **Slammer action layer** (`slammer.py` §7), but slam **at most one**
+nonant per iteration even when many are flagged: fixing is drastic and
+near-irreversible, and fixing the single worst oscillator often re-settles the
+others for free (WW §2.1: changes in one integer variable induce changes in
+others). This is the graceful pace that dropping the cadence enables — fix one,
+re-solve, re-detect, fix the next if it is still cycling.
+
+Selection reuses Slammer's existing `_slam_one`, restricted to the flagged set:
+among the flagged nonants it ranks by the directives file's **`priority`**
+column (largest first; ties by name — deterministic and rank-identical),
+skips any that are not slammable (already fixed/slammed/surrogate, or with no
+applicable direction), and picks the highest-priority one that *can* be slammed
+— i.e. it walks down the priority order until it finds one to slam, and fixes
+nothing if none of the flagged nonants qualify. So the interrupter supplies only
+the directives file and the flagged set; the priority ranking and
+one-per-iteration semantics are already Slammer's.
+
+**Method B's paper-native remediation is precisely a slam:** WW §2.4 fixes the
+cycling `x(i)` to `max_s x_s(i)`, the Slammer `max` direction — so a directives
+file of `*,1,max,…` driven by the detector reproduces their §2.4 behavior (now
+one nonant at a time).
+
+### 9.3 `both`
+
+The user docs **encourage choosing one or the other**, but if `action ==
+"both"` we **simply apply both**, no coordination/escalation: this iteration
+`w_damping` nudges *all* flagged nonants and `slam` fixes the *one*
+highest-priority flagged nonant that can be slammed. No special-casing of the
+interaction — a slammed nonant becomes `is_fixed()`, so W-damping of it is inert
+(harmless), and its `x_s = x̄` afterward zeroes its future W increments, so it
+leaves the flagged set on its own. Keep-it-simple was the explicit decision
+(§13).
 
 PR2 must demonstrate interruption **helps** (§11): on a model tuned to cycle,
 the interrupted run reaches a better gap / converges in fewer iterations than
@@ -483,19 +558,23 @@ Following the Slammer wiring precisely:
 - **MPI (`mpiexec -np 2`/`3`):** the same induced-oscillation run; assert the
   rank-0 CSV is **independent of scenario→rank distribution** (the reduction
   is correct).
-- **PR2 — action layers fire end-to-end:** the shipped tests cover the
-  interrupt-config validators (action / factor-range / positive-`min_rho` /
-  slam-needs-a-file / trigger defaults), the `reduced_rho` floor, and an
-  end-to-end farmer run with `--interrupt-W-oscillations` (with a `detect`
-  block, so the report *is* requested) asserting that **both** the
-  rho-reduction and the slam action actually execute through a real PH loop and
-  the detection CSV is written. A second end-to-end run with **no** detection
+- **PR2 — action layers fire end-to-end:** tests cover the interrupt-config
+  validators (action ∈ `{w_damping, slam, both}`, `factor` in `[0,1)`,
+  slam-needs-a-file, trigger defaults with no `iters_between_actions`), a pure
+  arithmetic check of the W-damping rescale (a `w_damped(...)` helper, no MPI),
+  and an end-to-end farmer run with `--interrupt-W-oscillations` (with a
+  `detect` block, so the report *is* requested) asserting that both the
+  W-damping and the slam action execute through a real PH loop and the detection
+  CSV is written. The W-damping assertion checks a flagged nonant's post-action
+  W equals its pre-action W minus `(1−factor)·rho·(x−x̄)`; the slam assertion
+  checks **exactly one** nonant is fixed per acting iteration (the
+  highest-priority flagged one). A second end-to-end run with **no** detection
   request asserts the **opt-in** rule: the engine still drives the actions but
-  **no report CSV is written**. The slam path's per-node min/max `Allreduce`
-  was exercised under `mpiexec -np 2` to confirm it is reached symmetrically
-  (no deadlock; slam value = the global per-scenario max). A cycle-tuned
+  **no report CSV is written**. The slam path's per-node min/max `Allreduce` is
+  exercised under `mpiexec -np 2` to confirm it is reached symmetrically (no
+  deadlock; slam value = the global per-scenario max). A cycle-tuned
   *numeric*-improvement assertion (fewer iters to a target gap) is a natural
-  follow-up but is omitted here to avoid a flaky test.
+  follow-up, omitted to avoid a flaky test.
 - **Coverage harness:** add `mpisppy/tests/test_w_oscillation.py` to
   `run_coverage.bash` **and** `.github/workflows/test_pr_and_main.yml` in the
   **same commit** (else codecov/patch reports 0%).
@@ -511,14 +590,15 @@ CSV writer (rank 0), unit + reduction + end-to-end + MPI tests, and a user-doc
 page cross-referencing wtracker. Pure observation ⇒ green on its own,
 backward compatible.
 
-**PR2 — interruption (implemented).**
-`--interrupt-W-oscillations` flag and JSON, the rho-reduction action, the
-slam action (calling the Slammer action layer via a small new public
-`Slammer.slam_nonant(ndn_i)` entry point — the action layer §7 anticipated),
-the trigger layer, and the `both` = apply-both rule (§9). Builds on PR1's
-engine: the detectors now also return the rank-identical flagged set the
-interrupter acts on. Backward compatible — with neither flag the extension is
-never built, and a detect-only run is byte-identical to PR1.
+**PR2 — interruption.**
+`--interrupt-W-oscillations` flag and JSON, the **W-damping** action (§9.1), the
+**slam** action (one highest-priority nonant per iteration via Slammer's
+`_slam_one` restricted to the flagged set, §9.2), the trigger layer (no
+cadence), and the `both` = apply-both rule (§9.3). Builds on PR1's engine: the
+detectors also return the rank-identical flagged set the interrupter acts on.
+Backward compatible — with neither flag the extension is never built, and a
+detect-only run is byte-identical to PR1. (Supersedes the earlier
+rho-reduction-based PR2 draft on this branch.)
 
 Each PR is review-sized and green independently (per the project's
 phased-PR-for-redesigns practice).
@@ -535,13 +615,32 @@ Settled in review (DLW, 2026-06-27); recorded for provenance.
    *Confirmed* ("I like the idea"). Background/keywords for the technique are in
    §5.2.1 (incremental/multiset hashing; state-hash cycle detection).
 2. **`both` interruption (Q2)** — docs **encourage one or the other**; if both
-   are configured, **just apply both**, no coordination/escalation logic (§9).
+   are configured, **just apply both**, no coordination/escalation logic (§9.3).
 3. **Per-scenario reporting (Q3)** — **yes**, an optional `per_scenario_csv`
    detail file (gather-based, off by default) is in scope for PR1 (§7.1).
 4. **Capture hook (Q4)** — **`miditer`** (post-update W), §4. (Differs from
    `Wtracker_extension`, which grabs in `enditer`.)
 
+Revised (DLW, 2026-07-02), superseding the rho-reduction action of the first
+PR2 draft:
+
+5. **Drop rho reduction; add `w_damping`.** The interruption action formerly
+   `rho_reduction` is replaced by `w_damping` (§9.1): a one-step retroactive
+   rescale of the dual (`w`) step, `W −= (1−factor)·rho·(x−x̄)`, leaving the
+   prox `rho` untouched. Simpler (no `min_rho` floor), targets the WW §2.1
+   overshoot directly, and preserves `Σ_s p_s W_s = 0`. It applies to **every**
+   flagged nonant each acting iteration. `action ∈ {w_damping, slam, both}`.
+6. **One slam per iteration.** Slam fixes **at most one** nonant per iteration
+   — the highest-priority flagged one that can be slammed, via Slammer's
+   `_slam_one` restricted to the flagged set (priority from the directives file,
+   ties by name) — not every flagged nonant (§9.2).
+7. **No `iters_between_actions`.** Drop the inter-action cadence: once past
+   `start_iter`, act every iteration a nonant is still flagged (§9). Trigger is
+   `{min_scenarios_flagged, start_iter}`.
+
 ### Still open
 
 - **`quantum` / `min_period` / `window` defaults** for method B — proposed
   `1e-6 / 2 / 20`; tune against the induced-oscillation test once it exists.
+- **`w_damping` default `factor`** — proposed `0.5`; tune against the
+  induced-oscillation test.

--- a/doc/src/extensions.rst
+++ b/doc/src/extensions.rst
@@ -27,8 +27,7 @@ command-line flags:
 - ``--detect-W-oscillations <file>`` -- activates W-oscillation detection
   (see :ref:`w_oscillation`)
 - ``--interrupt-W-oscillations <file>`` -- activates W-oscillation
-  interruption (W-damping and/or slamming; implies detection;
-  see :ref:`w_oscillation`)
+  interruption (slamming; implies detection; see :ref:`w_oscillation`)
 - ``--mipgaps-json <file>`` -- activates the mipgapper extension
 - ``--user-defined-extensions <module>`` -- loads a custom extension
 - ``--grad-rho`` -- activates gradient-based rho (see :ref:`rho_setting`)
@@ -359,7 +358,7 @@ w_oscillation
 
 The ``w_oscillation`` extension (``mpisppy.extensions.w_oscillation``)
 *detects* oscillation / cycling in the PH dual weight (W) vector and can
-optionally *interrupt* it (by damping W and/or slamming). Because both
+optionally *interrupt* it (by slamming). Because both
 detection and interruption have a fair amount of configuration, they have
 their own page: :doc:`w_oscillation`. It is activated with
 ``--detect-W-oscillations`` and/or ``--interrupt-W-oscillations``.

--- a/doc/src/extensions.rst
+++ b/doc/src/extensions.rst
@@ -26,6 +26,9 @@ command-line flags:
 - ``--slamming-directives-file <file>`` -- activates the slammer extension
 - ``--detect-W-oscillations <file>`` -- activates W-oscillation detection
   (see :ref:`w_oscillation`)
+- ``--interrupt-W-oscillations <file>`` -- activates W-oscillation
+  interruption (rho reduction and/or slamming; implies detection;
+  see :ref:`w_oscillation`)
 - ``--mipgaps-json <file>`` -- activates the mipgapper extension
 - ``--user-defined-extensions <module>`` -- loads a custom extension
 - ``--grad-rho`` -- activates gradient-based rho (see :ref:`rho_setting`)
@@ -357,12 +360,14 @@ w_oscillation
 ^^^^^^^^^^^^^
 
 The ``w_oscillation`` extension (``mpisppy.extensions.w_oscillation``)
-*detects* oscillation / cycling in the PH dual weight (W) vector and
-reports it to a CSV. Oscillating (sign-flipping, non-damping) weights are
-a common, convergence-killing symptom for mixed-integer problems. The
-extension is **pure observation**: it changes no rho values and fixes no
-variables, so a run with detection enabled follows exactly the same
-optimization trajectory as one without.
+*detects* oscillation / cycling in the PH dual weight (W) vector, reports
+it to a CSV, and can optionally *interrupt* it. Oscillating (sign-flipping,
+non-damping) weights are a common, convergence-killing symptom for
+mixed-integer problems. With only ``--detect-W-oscillations`` the extension
+is **pure observation**: it changes no rho values and fixes no variables, so
+a run with detection enabled follows exactly the same optimization trajectory
+as one without. With ``--interrupt-W-oscillations`` it additionally acts on
+the detected oscillation (see `Interrupting oscillation`_ below).
 
 For a broader view of how W evolves -- moving means, standard deviations,
 and coefficient of variation across all nonant/scenario traces -- use the
@@ -441,6 +446,47 @@ detection event, with columns ``iteration, node, variable, method,
 num_scenarios_total, num_scenarios_flagged, max_w_crossings,
 max_diff_crossings, max_diffs_ratio, cycle_period``. The report is
 independent of how scenarios are distributed across MPI ranks.
+
+Interrupting oscillation
+""""""""""""""""""""""""
+
+Passing ``--interrupt-W-oscillations <file>`` makes the extension *act* on
+the nonants it flags, to break the cycle. Interruption implies detection, so
+the detection report is still written; if ``--detect-W-oscillations`` is not
+also given, the detection configuration is taken from an optional ``detect``
+block inside the interrupt file, otherwise a default detector is used. The
+interrupt JSON keys are:
+
+- ``action`` (required) -- ``rho_reduction``, ``slam``, or ``both``. The
+  recommendation is to choose one; ``both`` simply applies each in turn (a
+  nonant slamming has fixed is unaffected by a subsequent rho change).
+- ``trigger`` -- when to act: ``start_iter`` (default 5), then every
+  ``iters_between_actions`` iterations (default 3); a nonant is acted on once
+  at least ``min_scenarios_flagged`` (default 1) scenarios flag it.
+- ``rho_reduction`` (for ``rho_reduction`` / ``both``) -- multiply each
+  flagged nonant's rho by ``factor`` (default 0.5, must be in ``(0, 1)``),
+  floored at ``min_rho`` (default 1e-3, must be ``> 0`` since PH requires a
+  positive rho). Reducing rho relaxes the proximal pull that drives the
+  overshoot.
+- ``slam`` (for ``slam`` / ``both``) -- ``directives_file``, a
+  :ref:`slammer <slammer>`-style directives CSV. The extension drives the
+  slammer's action layer directly on the flagged nonants (rather than the
+  slammer's own iteration-count trigger). Watson-Woodruff §2.4's native
+  remedy -- fixing a cycling variable to its per-scenario maximum -- is just a
+  directives file of ``...,max,...``.
+
+An example is shipped at
+``examples/sizes/config/w_oscillation_interrupt.json``; pair it with the
+detection example, e.g.::
+
+  --detect-W-oscillations examples/sizes/config/w_oscillation.json
+  --interrupt-W-oscillations examples/sizes/config/w_oscillation_interrupt.json
+
+.. literalinclude:: ../../examples/sizes/config/w_oscillation_interrupt.json
+   :language: json
+
+Interruption is for synchronous PH; like detection it is a hub extension and
+leaves the spokes untouched.
 
 See ``doc/designs/w_oscillation_design.md`` for the full design.
 

--- a/doc/src/extensions.rst
+++ b/doc/src/extensions.rst
@@ -27,7 +27,7 @@ command-line flags:
 - ``--detect-W-oscillations <file>`` -- activates W-oscillation detection
   (see :ref:`w_oscillation`)
 - ``--interrupt-W-oscillations <file>`` -- activates W-oscillation
-  interruption (rho reduction and/or slamming; implies detection;
+  interruption (W-damping and/or slamming; implies detection;
   see :ref:`w_oscillation`)
 - ``--mipgaps-json <file>`` -- activates the mipgapper extension
 - ``--user-defined-extensions <module>`` -- loads a custom extension
@@ -359,7 +359,7 @@ w_oscillation
 
 The ``w_oscillation`` extension (``mpisppy.extensions.w_oscillation``)
 *detects* oscillation / cycling in the PH dual weight (W) vector and can
-optionally *interrupt* it (by reducing rho and/or slamming). Because both
+optionally *interrupt* it (by damping W and/or slamming). Because both
 detection and interruption have a fair amount of configuration, they have
 their own page: :doc:`w_oscillation`. It is activated with
 ``--detect-W-oscillations`` and/or ``--interrupt-W-oscillations``.

--- a/doc/src/extensions.rst
+++ b/doc/src/extensions.rst
@@ -461,8 +461,8 @@ Without either, a built-in default detector drives the actions silently. The
 interrupt JSON keys are:
 
 - ``action`` (required) -- ``rho_reduction``, ``slam``, or ``both``. The
-  recommendation is to choose one; ``both`` simply applies each in turn (a
-  nonant slamming has fixed is unaffected by a subsequent rho change).
+  recommendation is to choose one; ``both`` simply applies each in turn (once
+  slamming has fixed a nonant, a subsequent rho change on it is inert).
 - ``trigger`` -- when to act: ``start_iter`` (default 5), then every
   ``iters_between_actions`` iterations (default 3); a nonant is acted on once
   at least ``min_scenarios_flagged`` (default 1) scenarios flag it.

--- a/doc/src/extensions.rst
+++ b/doc/src/extensions.rst
@@ -354,144 +354,15 @@ diagnostic tool intended for tuning rho and convergence behavior; it
 adds time and memory and is not recommended for production runs.
 
 
-.. _w_oscillation:
-
 w_oscillation
 ^^^^^^^^^^^^^
 
 The ``w_oscillation`` extension (``mpisppy.extensions.w_oscillation``)
-*detects* oscillation / cycling in the PH dual weight (W) vector, reports
-it to a CSV, and can optionally *interrupt* it. Oscillating (sign-flipping,
-non-damping) weights are a common, convergence-killing symptom for
-mixed-integer problems. With only ``--detect-W-oscillations`` the extension
-is **pure observation**: it changes no rho values and fixes no variables, so
-a run with detection enabled follows exactly the same optimization trajectory
-as one without. With ``--interrupt-W-oscillations`` it additionally acts on
-the detected oscillation (see `Interrupting oscillation`_ below).
-
-For a broader view of how W evolves -- moving means, standard deviations,
-and coefficient of variation across all nonant/scenario traces -- use the
-:ref:`wtracker_extension`; ``w_oscillation`` is the focused layer that
-flags the specific traces that are *cycling*.
-
-From ``generic_cylinders.py``, enable it with::
-
-  --detect-W-oscillations <control.json>
-
-The JSON control file selects and parameterizes the detection methods and
-controls the output. Keys:
-
-- ``output_csv`` (required) -- the per-nonant aggregate report; written by
-  cylinder rank 0.
-- ``per_scenario_csv`` (optional) -- a per-(scenario, nonant) detail file
-  (gathered to rank 0); off by default.
-- ``warmup_iters`` -- do not evaluate until this many W samples exist
-  (default 5).
-- ``check_every`` -- evaluate the detectors every this many iterations
-  after warm-up (default 1).
-- ``report_mode`` -- ``on_detect`` (a row the first time a nonant is
-  flagged; the default), ``every_check``, or ``final`` (one report at the
-  end).
-- ``min_scenarios_to_report`` / ``min_frac_to_report`` -- a nonant is
-  reported once at least this many scenarios (or this fraction of them)
-  flag it.
-- ``methods`` -- a (non-empty) object selecting one or both detectors;
-  per-method keys override documented defaults.
-
-Two detection methods are available:
-
-- ``zero_crossings`` -- a port of PySP's ``sorgw`` plugin: per
-  (scenario, nonant) it counts sign changes of W and of the consecutive
-  differences, plus a back-half/front-half damping ratio of ``|ΔW|``, and
-  flags a trace when any of ``thresh_w_crossings`` (default 2),
-  ``thresh_diff_crossings`` (default 3), or ``thresh_diffs_ratio``
-  (default 0.2) is met.
-- ``w_hash_recurrence`` -- the Watson-Woodruff "Progressive Hedging
-  Innovations" (Computational Management Science, 2011) §2.4 cycle
-  detector: it hashes the per-scenario W vector for each nonant and flags
-  a *recurrence* of that vector (a genuine cycle of period
-  ``min_period`` or more, so convergence is not mistaken for a cycle).
-  Keys: ``window`` (default 20), ``quantum`` (default 1e-6),
-  ``min_period`` (default 2).
-
-An example control file is shipped at
-``examples/sizes/config/w_oscillation.json``. It enables both detectors,
-keeps a 20-iteration window, and reports a nonant once at least half of the
-scenarios (``min_frac_to_report``) flag it:
-
-.. literalinclude:: ../../examples/sizes/config/w_oscillation.json
-   :language: json
-
-That example leaves ``per_scenario_csv`` at ``null``, so only the aggregate
-report is written. To also emit the per-(scenario, nonant) detail file --
-one row per flagged trace per check, gathered to rank 0 -- set
-``per_scenario_csv`` to a path (other keys fall back to their defaults):
-
-.. code-block:: json
-
-    {
-        "output_csv": "w_oscillations.csv",
-        "per_scenario_csv": "w_oscillations_per_scenario.csv",
-        "report_mode": "every_check",
-        "methods": {
-            "zero_crossings": {}
-        }
-    }
-
-The detail file has columns ``iteration, node, scenario, variable, method,
-w_crossings, diff_crossings, diffs_ratio, w_value``.
-
-The aggregate CSV has a header row and one row per flagged nonant per
-detection event, with columns ``iteration, node, variable, method,
-num_scenarios_total, num_scenarios_flagged, max_w_crossings,
-max_diff_crossings, max_diffs_ratio, cycle_period``. The report is
-independent of how scenarios are distributed across MPI ranks.
-
-Interrupting oscillation
-""""""""""""""""""""""""
-
-Passing ``--interrupt-W-oscillations <file>`` makes the extension *act* on
-the nonants it flags, to break the cycle. Interruption needs the detection
-*engine* to find the cycling nonants, but writing the cycling *report* (CSV)
-is **opt-in**: a pure ``--interrupt-W-oscillations`` run announces each
-interruption with a log line and writes **no** report. The report is written
-only when you *also* ask for detection -- via ``--detect-W-oscillations`` or a
-``detect`` block in the interrupt file (which then also configures the engine).
-Without either, a built-in default detector drives the actions silently. The
-interrupt JSON keys are:
-
-- ``action`` (required) -- ``rho_reduction``, ``slam``, or ``both``. The
-  recommendation is to choose one; ``both`` simply applies each in turn (once
-  slamming has fixed a nonant, a subsequent rho change on it is inert).
-- ``trigger`` -- when to act: ``start_iter`` (default 5), then every
-  ``iters_between_actions`` iterations (default 3); a nonant is acted on once
-  at least ``min_scenarios_flagged`` (default 1) scenarios flag it.
-- ``rho_reduction`` (for ``rho_reduction`` / ``both``) -- multiply each
-  flagged nonant's rho by ``factor`` (default 0.5, must be in ``(0, 1)``),
-  floored at ``min_rho`` (default 1e-3, must be ``> 0`` since PH requires a
-  positive rho). Reducing rho relaxes the proximal pull that drives the
-  overshoot.
-- ``slam`` (for ``slam`` / ``both``) -- ``directives_file``, a
-  :ref:`slammer <slammer>`-style directives CSV. The extension drives the
-  slammer's action layer directly on the flagged nonants (rather than the
-  slammer's own iteration-count trigger). Watson-Woodruff §2.4's native
-  remedy -- fixing a cycling variable to its per-scenario maximum -- is just a
-  directives file of ``...,max,...``.
-
-An example is shipped at
-``examples/sizes/config/w_oscillation_interrupt.json``; pair it with the
-detection example, e.g.::
-
-  --detect-W-oscillations examples/sizes/config/w_oscillation.json
-  --interrupt-W-oscillations examples/sizes/config/w_oscillation_interrupt.json
-
-.. literalinclude:: ../../examples/sizes/config/w_oscillation_interrupt.json
-   :language: json
-
-Interruption is for synchronous PH; like detection it is a hub extension and
-leaves the spokes untouched.
-
-See ``doc/designs/w_oscillation_design.md`` for the full design.
+*detects* oscillation / cycling in the PH dual weight (W) vector and can
+optionally *interrupt* it (by reducing rho and/or slamming). Because both
+detection and interruption have a fair amount of configuration, they have
+their own page: :doc:`w_oscillation`. It is activated with
+``--detect-W-oscillations`` and/or ``--interrupt-W-oscillations``.
 
 
 gradient_extension

--- a/doc/src/extensions.rst
+++ b/doc/src/extensions.rst
@@ -451,10 +451,13 @@ Interrupting oscillation
 """"""""""""""""""""""""
 
 Passing ``--interrupt-W-oscillations <file>`` makes the extension *act* on
-the nonants it flags, to break the cycle. Interruption implies detection, so
-the detection report is still written; if ``--detect-W-oscillations`` is not
-also given, the detection configuration is taken from an optional ``detect``
-block inside the interrupt file, otherwise a default detector is used. The
+the nonants it flags, to break the cycle. Interruption needs the detection
+*engine* to find the cycling nonants, but writing the cycling *report* (CSV)
+is **opt-in**: a pure ``--interrupt-W-oscillations`` run announces each
+interruption with a log line and writes **no** report. The report is written
+only when you *also* ask for detection -- via ``--detect-W-oscillations`` or a
+``detect`` block in the interrupt file (which then also configures the engine).
+Without either, a built-in default detector drives the actions silently. The
 interrupt JSON keys are:
 
 - ``action`` (required) -- ``rho_reduction``, ``slam``, or ``both``. The

--- a/doc/src/generic_cylinders.rst
+++ b/doc/src/generic_cylinders.rst
@@ -220,8 +220,9 @@ Some extensions can be activated directly from the command line:
 - ``--detect-W-oscillations <file>`` -- Detect oscillation/cycling in the
   W vector and report it to a CSV (see :ref:`w_oscillation`)
 - ``--interrupt-W-oscillations <file>`` -- Act on detected W oscillation
-  (slamming) to break the cycle; implies detection
-  (see :ref:`w_oscillation`)
+  (slamming) to break the cycle; runs the detection engine to drive the
+  action, but CSV reporting stays opt-in (via ``--detect-W-oscillations``
+  or a ``detect`` block) (see :ref:`w_oscillation`)
 
 See :ref:`Extensions` for details on available extensions.
 

--- a/doc/src/generic_cylinders.rst
+++ b/doc/src/generic_cylinders.rst
@@ -220,7 +220,7 @@ Some extensions can be activated directly from the command line:
 - ``--detect-W-oscillations <file>`` -- Detect oscillation/cycling in the
   W vector and report it to a CSV (see :ref:`w_oscillation`)
 - ``--interrupt-W-oscillations <file>`` -- Act on detected W oscillation
-  (rho reduction and/or slamming) to break the cycle; implies detection
+  (W-damping and/or slamming) to break the cycle; implies detection
   (see :ref:`w_oscillation`)
 
 See :ref:`Extensions` for details on available extensions.

--- a/doc/src/generic_cylinders.rst
+++ b/doc/src/generic_cylinders.rst
@@ -219,6 +219,9 @@ Some extensions can be activated directly from the command line:
   (see :ref:`wtracker_extension`)
 - ``--detect-W-oscillations <file>`` -- Detect oscillation/cycling in the
   W vector and report it to a CSV (see :ref:`w_oscillation`)
+- ``--interrupt-W-oscillations <file>`` -- Act on detected W oscillation
+  (rho reduction and/or slamming) to break the cycle; implies detection
+  (see :ref:`w_oscillation`)
 
 See :ref:`Extensions` for details on available extensions.
 

--- a/doc/src/generic_cylinders.rst
+++ b/doc/src/generic_cylinders.rst
@@ -220,7 +220,7 @@ Some extensions can be activated directly from the command line:
 - ``--detect-W-oscillations <file>`` -- Detect oscillation/cycling in the
   W vector and report it to a CSV (see :ref:`w_oscillation`)
 - ``--interrupt-W-oscillations <file>`` -- Act on detected W oscillation
-  (W-damping and/or slamming) to break the cycle; implies detection
+  (slamming) to break the cycle; implies detection
   (see :ref:`w_oscillation`)
 
 See :ref:`Extensions` for details on available extensions.

--- a/doc/src/index.rst
+++ b/doc/src/index.rst
@@ -37,6 +37,7 @@ MPI is used.
    hubs.rst
    spokes.rst
    extensions.rst
+   w_oscillation.rst
    rho_setting.rst
 
 .. toctree::

--- a/doc/src/w_oscillation.rst
+++ b/doc/src/w_oscillation.rst
@@ -186,6 +186,13 @@ Passing ``--interrupt-W-oscillations <file>`` makes the extension *act* on the
 nonants it flags, in ``miditer`` before that iteration's solve, so the change
 takes effect immediately.
 
+Actions are strictly detection-gated: on an iteration where the detectors flag
+no nonant (or none reaches ``min_scenarios_flagged`` scenarios), nothing is
+damped and nothing is slammed -- the run is untouched. W-damping applies only
+to the specific nonants flagged at that iteration. A slam, however, is
+one-way: the variable it fixes *stays* fixed for the remainder of the run,
+even after its oscillation flag clears (there is no unfix path).
+
 Reporting is opt-in
 ^^^^^^^^^^^^^^^^^^^
 
@@ -224,9 +231,10 @@ Actions
    can actually be slammed -- via the existing :ref:`slammer <slammer>` action
    layer, with successive slams separated by a cooldown of at least
    ``iters_between_slams`` iterations (default ``3``). Fixing is drastic and
-   near-irreversible, and fixing the single worst oscillator often re-settles
-   the others, so even when many nonants are flagged only one is slammed per
-   event. The cooldown matters because the detectors judge a trailing history
+   permanent -- a slammed variable stays fixed for the rest of the run, even
+   after its oscillation flag clears -- and fixing the single worst oscillator
+   often re-settles the others, so even when many nonants are flagged only one
+   is slammed per event. The cooldown matters because the detectors judge a trailing history
    window: a nonant that is re-settling after a fix keeps its flag until the
    old oscillation ages out of the window, so "still flagged" is *not* yet
    evidence of "still cycling" -- the cooldown gives each fix time to work

--- a/doc/src/w_oscillation.rst
+++ b/doc/src/w_oscillation.rst
@@ -7,8 +7,8 @@ The ``w_oscillation`` extension (``mpisppy.extensions.w_oscillation``,
 class ``WOscillationMonitor``) watches the Progressive Hedging dual weight
 (``W``) vector while a synchronous PH hub runs. It can **detect** oscillation /
 cycling in ``W`` and report it, and it can optionally **interrupt** the
-oscillation -- reducing rho and/or slamming the offending variables -- to break
-the cycle.
+oscillation -- damping the dual weight and/or slamming the offending variables
+-- to break the cycle.
 
 Oscillating weights -- a ``W`` trajectory that flips sign repeatedly or whose
 swings fail to damp out -- are a common and convergence-killing symptom for
@@ -27,7 +27,7 @@ Flag                           Effect
 ============================== =================================================
 ``--detect-W-oscillations``    Detect and **report** oscillation (pure
                                observation; no change to the optimization).
-``--interrupt-W-oscillations`` **Act** on detected oscillation (rho reduction
+``--interrupt-W-oscillations`` **Act** on detected oscillation (W-damping
                                and/or slamming). Runs the detection engine, but
                                the report is opt-in (see below).
 ============================== =================================================
@@ -204,30 +204,41 @@ Actions
 
 ``action`` (**required**) is one of:
 
-``rho_reduction``
-   Multiply each flagged nonant's rho by ``factor`` (default ``0.5``; must be in
-   ``(0, 1)`` so it actually reduces), floored at ``min_rho`` (default
-   ``1e-3``; must be ``> 0`` because PH requires a strictly positive rho).
-   Reducing rho relaxes the proximal pull that is driving the overshoot -- the
-   dynamic analogue of Watson-Woodruff §2.1's SEP rho, which is designed to
-   approach the optimal weight "from below." rho is a mutable parameter in the
-   proximal term, so the reduced value is picked up by the per-iteration
-   objective refresh that persistent solvers already perform.
+``w_damping``
+   Damp the dual (``W``) step on **every** flagged nonant. The weight update
+   ``Update_W`` just applied ``W += rho * (x - xbar)``; W-damping rescales that
+   increment to what a lower rho would have produced,
+   ``W -= (1 - factor) * rho * (x - xbar)``, leaving the *proximal* rho
+   untouched. ``factor`` (default ``0.5``; must be in ``[0, 1)`` -- ``1`` is a
+   no-op) is the retained fraction of the step; applied every flagged iteration
+   it damps the W swing by ``factor`` per step. This decouples the dual step
+   from the penalty and targets the Watson-Woodruff §2.1 overshoot (``w``
+   "shooting past" its optimum) directly, without loosening the proximal pull;
+   it preserves the dual-feasibility identity ``sum_s p_s W_s = 0`` and is inert
+   once the nonant settles (``x = xbar``). ``W`` is a mutable parameter in the
+   objective, so the change is picked up by the per-iteration objective refresh
+   that persistent solvers already perform.
 
 ``slam``
-   Fix each flagged nonant via the existing :ref:`slammer <slammer>` action
-   layer. The ``slam`` block names a ``directives_file`` -- a slammer-style
-   directives CSV (by-name patterns, a direction such as ``lb`` / ``ub`` /
-   ``nearest`` / ``max``, and a priority). The extension drives the slammer
-   directly on the nonants the detector flagged, rather than using the
-   slammer's own iteration-count trigger. Watson-Woodruff §2.4's native remedy
-   -- fixing a cycling variable to its per-scenario maximum -- is exactly a
-   directives file of ``...,max,...``.
+   Fix **one** flagged nonant per iteration -- the highest-priority one that can
+   actually be slammed -- via the existing :ref:`slammer <slammer>` action
+   layer. Fixing is drastic and near-irreversible, and fixing the single worst
+   oscillator often re-settles the others, so even when many nonants are flagged
+   only one is slammed each iteration; the next iteration re-detects and fixes
+   the next if it is still cycling. The ``slam`` block names a
+   ``directives_file`` -- a slammer-style directives CSV (by-name patterns, a
+   direction such as ``lb`` / ``ub`` / ``nearest`` / ``max``, and a
+   ``priority``). Among the flagged nonants the slammer picks by that
+   ``priority`` column (largest first, ties by name), so the priority ranking
+   decides which one is fixed. Watson-Woodruff §2.4's native remedy -- fixing a
+   cycling variable to its per-scenario maximum -- is exactly a directives file
+   of ``...,max,...``.
 
 ``both``
-   Apply each in turn. The recommendation is to choose one; ``both`` performs
-   no coordination -- once slamming has fixed a nonant, a subsequent rho change
-   on it is simply inert.
+   Apply each: W-damping nudges *all* flagged nonants and slam fixes the *one*
+   highest-priority flagged nonant. The recommendation is to choose one;
+   ``both`` performs no coordination -- once slamming has fixed a nonant, any
+   W-damping of it is simply inert.
 
 Trigger
 ^^^^^^^
@@ -235,8 +246,8 @@ Trigger
 The ``trigger`` block controls *when* and *which* nonants are acted on:
 
 - ``start_iter`` (``5``) -- the first iteration at which interruption may occur.
-- ``iters_between_actions`` (``3``) -- once started, act at most once every
-  this many iterations.
+  Once past it, the extension acts every iteration a nonant is still flagged
+  (there is no inter-action cadence).
 - ``min_scenarios_flagged`` (``1``) -- a nonant is acted on once at least this
   many scenarios flag it.
 
@@ -263,7 +274,7 @@ What you will see
 Every time the extension acts, it prints one rank-0 progress line, for
 example::
 
-  [   12.34] W-oscillation interruption [iter 7]: 3 nonant(s) flagged; reduced rho on 3 nonant(s); slammed 1 nonant(s)
+  [   12.34] W-oscillation interruption [iter 7]: 3 nonant(s) flagged; damped W on 3 nonant(s); slammed 1 nonant(s)
 
 This line is always emitted (it does not require ``--verbose``); it is the only
 output of a report-less interrupt run. Detailed per-slam reporting comes from

--- a/doc/src/w_oscillation.rst
+++ b/doc/src/w_oscillation.rst
@@ -220,19 +220,26 @@ Actions
    that persistent solvers already perform.
 
 ``slam``
-   Fix **one** flagged nonant per iteration -- the highest-priority one that can
-   actually be slammed -- via the existing :ref:`slammer <slammer>` action
-   layer. Fixing is drastic and near-irreversible, and fixing the single worst
-   oscillator often re-settles the others, so even when many nonants are flagged
-   only one is slammed each iteration; the next iteration re-detects and fixes
-   the next if it is still cycling. The ``slam`` block names a
-   ``directives_file`` -- a slammer-style directives CSV (by-name patterns, a
-   direction such as ``lb`` / ``ub`` / ``nearest`` / ``max``, and a
-   ``priority``). Among the flagged nonants the slammer picks by that
-   ``priority`` column (largest first, ties by name), so the priority ranking
-   decides which one is fixed. Watson-Woodruff §2.4's native remedy -- fixing a
-   cycling variable to its per-scenario maximum -- is exactly a directives file
-   of ``...,max,...``.
+   Fix **one** flagged nonant per slam event -- the highest-priority one that
+   can actually be slammed -- via the existing :ref:`slammer <slammer>` action
+   layer, with successive slams separated by a cooldown of at least
+   ``iters_between_slams`` iterations (default ``3``). Fixing is drastic and
+   near-irreversible, and fixing the single worst oscillator often re-settles
+   the others, so even when many nonants are flagged only one is slammed per
+   event. The cooldown matters because the detectors judge a trailing history
+   window: a nonant that is re-settling after a fix keeps its flag until the
+   old oscillation ages out of the window, so "still flagged" is *not* yet
+   evidence of "still cycling" -- the cooldown gives each fix time to work
+   before the next variable is fixed (set it to ``1`` to slam on every flagged
+   iteration). The cooldown starts only when a slam actually lands; an event
+   where nothing was slammable retries on the next flagged iteration. The
+   ``slam`` block also names a ``directives_file`` -- a slammer-style
+   directives CSV (by-name patterns, a direction such as ``lb`` / ``ub`` /
+   ``nearest`` / ``max``, and a ``priority``). Among the flagged nonants the
+   slammer picks by that ``priority`` column (largest first, ties by name), so
+   the priority ranking decides which one is fixed. Watson-Woodruff §2.4's
+   native remedy -- fixing a cycling variable to its per-scenario maximum -- is
+   exactly a directives file of ``...,max,...``.
 
 ``both``
    Apply each: W-damping nudges *all* flagged nonants and slam fixes the *one*
@@ -246,8 +253,9 @@ Trigger
 The ``trigger`` block controls *when* and *which* nonants are acted on:
 
 - ``start_iter`` (``5``) -- the first iteration at which interruption may occur.
-  Once past it, the extension acts every iteration a nonant is still flagged
-  (there is no inter-action cadence).
+  Once past it, W-damping acts every iteration a nonant is still flagged (it
+  has no inter-action cadence); slamming is additionally paced by its own
+  ``iters_between_slams`` cooldown (see the ``slam`` action above).
 - ``min_scenarios_flagged`` (``1``) -- a nonant is acted on once at least this
   many scenarios flag it.
 
@@ -277,8 +285,10 @@ example::
   [   12.34] W-oscillation interruption [iter 7]: 3 nonant(s) flagged; damped W on 3 nonant(s); slammed 1 nonant(s)
 
 This line is always emitted (it does not require ``--verbose``); it is the only
-output of a report-less interrupt run. Detailed per-slam reporting comes from
-the slammer itself under ``--verbose``.
+output of a report-less interrupt run. Under ``action: both``, iterations on
+which the slam cooldown suppresses a slam say ``slam cooling down`` in place of
+the slam count (a slam-only action prints nothing while cooling down).
+Detailed per-slam reporting comes from the slammer itself under ``--verbose``.
 
 
 Scope, MPI, and limitations

--- a/doc/src/w_oscillation.rst
+++ b/doc/src/w_oscillation.rst
@@ -232,9 +232,10 @@ Actions
    layer, with successive slams separated by a cooldown of at least
    ``iters_between_slams`` iterations (default ``3``). Fixing is drastic and
    permanent -- a slammed variable stays fixed for the rest of the run, even
-   after its oscillation flag clears -- and fixing the single worst oscillator
+   after its oscillation flag clears -- and fixing just one cycling variable
    often re-settles the others, so even when many nonants are flagged only one
-   is slammed per event. The cooldown matters because the detectors judge a trailing history
+   is slammed per event (which one is decided by the directives file's
+   ``priority`` column, not by any measure of oscillation severity). The cooldown matters because the detectors judge a trailing history
    window: a nonant that is re-settling after a fix keeps its flag until the
    old oscillation ages out of the window, so "still flagged" is *not* yet
    evidence of "still cycling" -- the cooldown gives each fix time to work

--- a/doc/src/w_oscillation.rst
+++ b/doc/src/w_oscillation.rst
@@ -1,0 +1,290 @@
+.. _w_oscillation:
+
+W-vector oscillation: detection and interruption
+=================================================
+
+The ``w_oscillation`` extension (``mpisppy.extensions.w_oscillation``,
+class ``WOscillationMonitor``) watches the Progressive Hedging dual weight
+(``W``) vector while a synchronous PH hub runs. It can **detect** oscillation /
+cycling in ``W`` and report it, and it can optionally **interrupt** the
+oscillation -- reducing rho and/or slamming the offending variables -- to break
+the cycle.
+
+Oscillating weights -- a ``W`` trajectory that flips sign repeatedly or whose
+swings fail to damp out -- are a common and convergence-killing symptom for
+mixed-integer problems. Watson and Woodruff (*"Progressive Hedging Innovations
+for a Class of Stochastic Mixed-Integer Resource Allocation Problems"*,
+Computational Management Science, 2011) describe the mechanism in their §2.1:
+the weight update is ``w += rho * (x - xbar)``, so a too-large rho lets ``w``
+"shoot past" its optimal value and thrash, especially in MIPs where a change in
+one integer variable induces changes in others that are then reversed.
+
+The extension is activated entirely by command-line flags on
+``generic_cylinders.py`` (and any ``Config``-based driver):
+
+============================== =================================================
+Flag                           Effect
+============================== =================================================
+``--detect-W-oscillations``    Detect and **report** oscillation (pure
+                               observation; no change to the optimization).
+``--interrupt-W-oscillations`` **Act** on detected oscillation (rho reduction
+                               and/or slamming). Runs the detection engine, but
+                               the report is opt-in (see below).
+============================== =================================================
+
+With **neither** flag the extension is never constructed and a run behaves
+exactly as it does today. Both flags take the path to a JSON control file.
+
+.. note::
+
+   This is a **hub** extension for **synchronous PH**. The hooks run under any
+   ``PHBase`` hub, but the oscillation and cadence notions assume synchronous
+   iterations; APH is not specially wired. Outer/inner-bound spokes are
+   untouched.
+
+Relationship to wtracker
+------------------------
+
+For a broad view of how ``W`` evolves -- moving means, standard deviations, and
+coefficient of variation across every nonant/scenario trace -- use the
+:ref:`wtracker_extension`. ``wtracker`` keeps the full history and is a general
+diagnostic; ``w_oscillation`` is the focused layer that flags the specific
+traces that are *cycling* and (optionally) acts on them, and it keeps only a
+small bounded ring buffer rather than the whole history.
+
+
+Detection
+---------
+
+How it works
+^^^^^^^^^^^^
+
+Each PH iteration, in the ``miditer`` hook (so the freshest *post-update*
+``W`` is in place), the extension captures the ``W`` vector for every local
+scenario into a bounded ring buffer. After ``warmup_iters`` samples exist, and
+then every ``check_every`` iterations, it runs the selected detectors.
+
+Detection is **per (scenario, nonant)**, but reporting and acting are **per
+nonant**, so the per-scenario verdicts are reduced across scenarios with the
+same per-node communicators that x-bar uses: a ``SUM`` of the number of
+scenarios that flagged each nonant and a ``MAX`` of the per-trace statistics.
+Cylinder **rank 0** then writes the report. Because the inputs are reduced to
+be identical on every rank, **the report does not depend on how scenarios are
+distributed across MPI ranks**.
+
+Detection methods
+^^^^^^^^^^^^^^^^^^
+
+The ``methods`` block of the control file selects one or both detectors and
+overrides their per-method defaults. New detectors can be added without any CLI
+change.
+
+``zero_crossings``
+""""""""""""""""""
+
+A port of PySP's ``sorgw`` plugin. For each (scenario, nonant) ``W`` trajectory
+(optionally only the last ``window`` samples) it computes:
+
+- ``WZeroCrossings`` -- the number of sign changes of ``W`` (ignoring entries
+  with ``|W| < tol``);
+- ``DiffZeroCrossings`` -- the number of sign changes of the consecutive
+  differences ``ΔW``;
+- ``diffs_ratio`` -- a damping ratio: the mean of ``|ΔW|`` over the back
+  (newer) half of the trace divided by the mean over the front (older) half. A
+  ratio well below 1 means the swings are shrinking (converging); a ratio near
+  or above 1 means they are not damping.
+
+The trace is **flagged** if *any* threshold is met. Keys (defaults in
+parentheses): ``tol`` (``1e-6``), ``window`` (``null`` = whole retained
+history), ``thresh_w_crossings`` (``2``), ``thresh_diff_crossings`` (``3``),
+``thresh_diffs_ratio`` (``0.2``).
+
+``w_hash_recurrence``
+"""""""""""""""""""""
+
+The Watson-Woodruff §2.4 ("Detecting Cyclic Behavior") cycle detector. For each
+nonant it hashes the **per-scenario** ``W`` vector and flags a *recurrence* of
+that vector -- the same hash seen again within a look-back window -- which
+signals a genuine cycle. ``min_period`` excludes period-1 "recurrence" so a
+*constant* ``W`` (i.e. convergence) is never mistaken for a cycle.
+
+In the distributed setting the hashed vector spans scenarios on different
+ranks, so the extension forms a **distribution-independent signature**: each
+rank sums identity-mixed 64-bit hashes of its local scenarios' values, and the
+partial sums are combined with an ``MPI.SUM`` reduction. Because addition is
+commutative, the signature is independent of the scenario-to-rank mapping. (This
+is an additive / multiset hash; see Bellare & Micciancio, EUROCRYPT 1997, and
+Clarke et al., ASIACRYPT 2003.) Keys: ``window`` (``20``), ``quantum``
+(``1e-6``; ``W`` is quantized to this before hashing), ``min_period`` (``2``).
+
+Detection control file
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Keys (besides ``methods``):
+
+- ``output_csv`` (**required**) -- path for the per-nonant aggregate report;
+  written by cylinder rank 0.
+- ``per_scenario_csv`` (optional, default ``null``) -- path for a
+  per-(scenario, nonant) detail file; off by default.
+- ``warmup_iters`` (``5``) -- do not evaluate until this many ``W`` samples
+  exist.
+- ``check_every`` (``1``) -- evaluate the detectors every this many iterations
+  after warm-up.
+- ``report_mode`` -- ``on_detect`` (a row the first time a nonant becomes
+  flagged; the default), ``every_check`` (a row at every check), or ``final``
+  (one report at the end of the run).
+- ``min_scenarios_to_report`` (``1``) / ``min_frac_to_report`` (``null``) -- a
+  nonant is reported once at least this many scenarios (or this fraction of the
+  scenarios at its node) flag it.
+
+An example is shipped at ``examples/sizes/config/w_oscillation.json``. It
+enables both detectors, keeps a 20-iteration window, and reports a nonant once
+at least half of the scenarios (``min_frac_to_report``) flag it:
+
+.. literalinclude:: ../../examples/sizes/config/w_oscillation.json
+   :language: json
+
+Detection output
+^^^^^^^^^^^^^^^^
+
+The **aggregate** CSV has a header row and one row per flagged nonant per
+detection event, with columns::
+
+  iteration, node, variable, method, num_scenarios_total,
+  num_scenarios_flagged, max_w_crossings, max_diff_crossings,
+  max_diffs_ratio, cycle_period
+
+Method-specific columns are blank for the other method (e.g. ``cycle_period``
+is populated only for ``w_hash_recurrence``).
+
+The example above leaves ``per_scenario_csv`` at ``null``, so only the
+aggregate report is written. To also emit the per-(scenario, nonant) detail
+file -- one row per flagged trace per check, gathered to rank 0 -- set
+``per_scenario_csv`` to a path (other keys fall back to their defaults):
+
+.. code-block:: json
+
+    {
+        "output_csv": "w_oscillations.csv",
+        "per_scenario_csv": "w_oscillations_per_scenario.csv",
+        "report_mode": "every_check",
+        "methods": {
+            "zero_crossings": {}
+        }
+    }
+
+The detail file has columns ``iteration, node, scenario, variable, method,
+w_crossings, diff_crossings, diffs_ratio, w_value``. Only flagged rows are
+gathered, so the volume is bounded by what is actually oscillating; on a badly
+thrashing problem it can still be large, which is why it is off by default.
+
+
+Interrupting oscillation
+------------------------
+
+Passing ``--interrupt-W-oscillations <file>`` makes the extension *act* on the
+nonants it flags, in ``miditer`` before that iteration's solve, so the change
+takes effect immediately.
+
+Reporting is opt-in
+^^^^^^^^^^^^^^^^^^^
+
+Interruption needs the detection **engine** to know which nonants are cycling,
+but it does **not** automatically write the cycling **report**. A pure
+``--interrupt-W-oscillations`` run drives the engine to act and announces each
+interruption with a log line (see `What you will see`_), and writes **no** CSV.
+
+To also get the report, ask for detection explicitly -- either add
+``--detect-W-oscillations``, or include a ``detect`` block (a full detection
+control object) inside the interrupt file, which then *also* configures the
+engine. With neither, a built-in default detector drives the actions silently.
+
+Actions
+^^^^^^^
+
+``action`` (**required**) is one of:
+
+``rho_reduction``
+   Multiply each flagged nonant's rho by ``factor`` (default ``0.5``; must be in
+   ``(0, 1)`` so it actually reduces), floored at ``min_rho`` (default
+   ``1e-3``; must be ``> 0`` because PH requires a strictly positive rho).
+   Reducing rho relaxes the proximal pull that is driving the overshoot -- the
+   dynamic analogue of Watson-Woodruff §2.1's SEP rho, which is designed to
+   approach the optimal weight "from below." rho is a mutable parameter in the
+   proximal term, so the reduced value is picked up by the per-iteration
+   objective refresh that persistent solvers already perform.
+
+``slam``
+   Fix each flagged nonant via the existing :ref:`slammer <slammer>` action
+   layer. The ``slam`` block names a ``directives_file`` -- a slammer-style
+   directives CSV (by-name patterns, a direction such as ``lb`` / ``ub`` /
+   ``nearest`` / ``max``, and a priority). The extension drives the slammer
+   directly on the nonants the detector flagged, rather than using the
+   slammer's own iteration-count trigger. Watson-Woodruff §2.4's native remedy
+   -- fixing a cycling variable to its per-scenario maximum -- is exactly a
+   directives file of ``...,max,...``.
+
+``both``
+   Apply each in turn. The recommendation is to choose one; ``both`` performs
+   no coordination -- once slamming has fixed a nonant, a subsequent rho change
+   on it is simply inert.
+
+Trigger
+^^^^^^^
+
+The ``trigger`` block controls *when* and *which* nonants are acted on:
+
+- ``start_iter`` (``5``) -- the first iteration at which interruption may occur.
+- ``iters_between_actions`` (``3``) -- once started, act at most once every
+  this many iterations.
+- ``min_scenarios_flagged`` (``1``) -- a nonant is acted on once at least this
+  many scenarios flag it.
+
+The trigger is independent of the detector's ``warmup_iters`` / ``check_every``
+(which govern *reporting*). If you want to avoid acting on early noise, set
+``start_iter`` no smaller than ``warmup_iters``.
+
+Interrupt control file
+^^^^^^^^^^^^^^^^^^^^^^^
+
+An example is shipped at
+``examples/sizes/config/w_oscillation_interrupt.json``. Pair it with the
+detection example to also get the report, e.g.::
+
+  --detect-W-oscillations examples/sizes/config/w_oscillation.json
+  --interrupt-W-oscillations examples/sizes/config/w_oscillation_interrupt.json
+
+.. literalinclude:: ../../examples/sizes/config/w_oscillation_interrupt.json
+   :language: json
+
+What you will see
+^^^^^^^^^^^^^^^^^
+
+Every time the extension acts, it prints one rank-0 progress line, for
+example::
+
+  [   12.34] W-oscillation interruption [iter 7]: 3 nonant(s) flagged; reduced rho on 3 nonant(s); slammed 1 nonant(s)
+
+This line is always emitted (it does not require ``--verbose``); it is the only
+output of a report-less interrupt run. Detailed per-slam reporting comes from
+the slammer itself under ``--verbose``.
+
+
+Scope, MPI, and limitations
+---------------------------
+
+- **Synchronous PH only.** See the note at the top of this page.
+- **MPI / distribution independence.** The aggregate report and the
+  per-nonant flagged set are computed with per-node ``SUM`` / ``MAX``
+  reductions (and, for ``w_hash_recurrence``, a distribution-independent
+  additive signature), so they are identical on every rank regardless of the
+  scenario-to-rank mapping. The interrupter acts on that rank-identical flagged
+  set in a fixed order, so the slammer's per-node ``min`` / ``max`` reduction is
+  reached symmetrically on every rank.
+- **Multistage.** Detection and reporting iterate the scenario tree node by
+  node and are multistage-clean. The action selection is rank-coherent for
+  two-stage problems and single-rank-per-node multistage; a node split across
+  ranks would need an extra reduction to agree on the action, which is not done
+  (the same limitation the slammer documents).
+
+See ``doc/designs/w_oscillation_design.md`` for the full design and rationale.

--- a/doc/src/w_oscillation.rst
+++ b/doc/src/w_oscillation.rst
@@ -7,8 +7,7 @@ The ``w_oscillation`` extension (``mpisppy.extensions.w_oscillation``,
 class ``WOscillationMonitor``) watches the Progressive Hedging dual weight
 (``W``) vector while a synchronous PH hub runs. It can **detect** oscillation /
 cycling in ``W`` and report it, and it can optionally **interrupt** the
-oscillation -- damping the dual weight and/or slamming the offending variables
--- to break the cycle.
+oscillation -- slamming (fixing) the offending variables -- to break the cycle.
 
 Oscillating weights -- a ``W`` trajectory that flips sign repeatedly or whose
 swings fail to damp out -- are a common and convergence-killing symptom for
@@ -27,9 +26,9 @@ Flag                           Effect
 ============================== =================================================
 ``--detect-W-oscillations``    Detect and **report** oscillation (pure
                                observation; no change to the optimization).
-``--interrupt-W-oscillations`` **Act** on detected oscillation (W-damping
-                               and/or slamming). Runs the detection engine, but
-                               the report is opt-in (see below).
+``--interrupt-W-oscillations`` **Act** on detected oscillation (slamming).
+                               Runs the detection engine, but the report is
+                               opt-in (see below).
 ============================== =================================================
 
 With **neither** flag the extension is never constructed and a run behaves
@@ -188,10 +187,9 @@ takes effect immediately.
 
 Actions are strictly detection-gated: on an iteration where the detectors flag
 no nonant (or none reaches ``min_scenarios_flagged`` scenarios), nothing is
-damped and nothing is slammed -- the run is untouched. W-damping applies only
-to the specific nonants flagged at that iteration. A slam, however, is
-one-way: the variable it fixes *stays* fixed for the remainder of the run,
-even after its oscillation flag clears (there is no unfix path).
+slammed -- the run is untouched. A slam is one-way: the variable it fixes
+*stays* fixed for the remainder of the run, even after its oscillation flag
+clears (there is no unfix path).
 
 Reporting is opt-in
 ^^^^^^^^^^^^^^^^^^^
@@ -209,22 +207,7 @@ engine. With neither, a built-in default detector drives the actions silently.
 Actions
 ^^^^^^^
 
-``action`` (**required**) is one of:
-
-``w_damping``
-   Damp the dual (``W``) step on **every** flagged nonant. The weight update
-   ``Update_W`` just applied ``W += rho * (x - xbar)``; W-damping rescales that
-   increment to what a lower rho would have produced,
-   ``W -= (1 - factor) * rho * (x - xbar)``, leaving the *proximal* rho
-   untouched. ``factor`` (default ``0.5``; must be in ``[0, 1)`` -- ``1`` is a
-   no-op) is the retained fraction of the step; applied every flagged iteration
-   it damps the W swing by ``factor`` per step. This decouples the dual step
-   from the penalty and targets the Watson-Woodruff §2.1 overshoot (``w``
-   "shooting past" its optimum) directly, without loosening the proximal pull;
-   it preserves the dual-feasibility identity ``sum_s p_s W_s = 0`` and is inert
-   once the nonant settles (``x = xbar``). ``W`` is a mutable parameter in the
-   objective, so the change is picked up by the per-iteration objective refresh
-   that persistent solvers already perform.
+``action`` (**required**) must be ``slam``:
 
 ``slam``
    Fix **one** flagged nonant per slam event -- the highest-priority one that
@@ -250,21 +233,14 @@ Actions
    native remedy -- fixing a cycling variable to its per-scenario maximum -- is
    exactly a directives file of ``...,max,...``.
 
-``both``
-   Apply each: W-damping nudges *all* flagged nonants and slam fixes the *one*
-   highest-priority flagged nonant. The recommendation is to choose one;
-   ``both`` performs no coordination -- once slamming has fixed a nonant, any
-   W-damping of it is simply inert.
-
 Trigger
 ^^^^^^^
 
 The ``trigger`` block controls *when* and *which* nonants are acted on:
 
 - ``start_iter`` (``5``) -- the first iteration at which interruption may occur.
-  Once past it, W-damping acts every iteration a nonant is still flagged (it
-  has no inter-action cadence); slamming is additionally paced by its own
-  ``iters_between_slams`` cooldown (see the ``slam`` action above).
+  Once past it, slamming is paced by its own ``iters_between_slams`` cooldown
+  (see the ``slam`` action above).
 - ``min_scenarios_flagged`` (``1``) -- a nonant is acted on once at least this
   many scenarios flag it.
 
@@ -291,13 +267,12 @@ What you will see
 Every time the extension acts, it prints one rank-0 progress line, for
 example::
 
-  [   12.34] W-oscillation interruption [iter 7]: 3 nonant(s) flagged; damped W on 3 nonant(s); slammed 1 nonant(s)
+  [   12.34] W-oscillation interruption [iter 7]: 3 nonant(s) flagged; slammed 1 nonant(s)
 
 This line is always emitted (it does not require ``--verbose``); it is the only
-output of a report-less interrupt run. Under ``action: both``, iterations on
-which the slam cooldown suppresses a slam say ``slam cooling down`` in place of
-the slam count (a slam-only action prints nothing while cooling down).
-Detailed per-slam reporting comes from the slammer itself under ``--verbose``.
+output of a report-less interrupt run. On iterations where the slam cooldown
+suppresses a slam, nothing is printed. Detailed per-slam reporting comes from
+the slammer itself under ``--verbose``.
 
 
 Scope, MPI, and limitations

--- a/doc/src/w_oscillation.rst
+++ b/doc/src/w_oscillation.rst
@@ -17,6 +17,8 @@ Computational Management Science, 2011) describe the mechanism in their §2.1:
 the weight update is ``w += rho * (x - xbar)``, so a too-large rho lets ``w``
 "shoot past" its optimal value and thrash, especially in MIPs where a change in
 one integer variable induces changes in others that are then reversed.
+(As an aside, we note that for MIPs a rho that is too small can also result in
+oscillation.)
 
 The extension is activated entirely by command-line flags on
 ``generic_cylinders.py`` (and any ``Config``-based driver):
@@ -31,8 +33,7 @@ Flag                           Effect
                                opt-in (see below).
 ============================== =================================================
 
-With **neither** flag the extension is never constructed and a run behaves
-exactly as it does today. Both flags take the path to a JSON control file.
+With **neither** flag the extension is never constructed. Both flags take the path to a JSON control file.
 
 .. note::
 
@@ -137,8 +138,9 @@ Keys (besides ``methods``):
   scenarios at its node) flag it.
 
 An example is shipped at ``examples/sizes/config/w_oscillation.json``. It
-enables both detectors, keeps a 20-iteration window, and reports a nonant once
-at least half of the scenarios (``min_frac_to_report``) flag it:
+enables both detectors, keeps a 20-iteration window, and (via
+``min_frac_to_report`` of ``0.5``) reports a nonant once at least half of the
+scenarios at its node flag it:
 
 .. literalinclude:: ../../examples/sizes/config/w_oscillation.json
    :language: json
@@ -199,10 +201,30 @@ but it does **not** automatically write the cycling **report**. A pure
 ``--interrupt-W-oscillations`` run drives the engine to act and announces each
 interruption with a log line (see `What you will see`_), and writes **no** CSV.
 
-To also get the report, ask for detection explicitly -- either add
-``--detect-W-oscillations``, or include a ``detect`` block (a full detection
-control object) inside the interrupt file, which then *also* configures the
-engine. With neither, a built-in default detector drives the actions silently.
+To also get the report, ask for detection explicitly, in either of two ways:
+add ``--detect-W-oscillations <file>`` alongside the interrupt flag, or embed a
+``detect`` block inside the interrupt JSON. The ``detect`` block takes the same
+keys as a standalone `Detection control file`_ (so ``output_csv`` is still
+required, and ``methods`` selects the detectors). Either way the detection
+settings you supply serve double duty -- they produce the report *and* become
+the engine the interrupter acts on. With neither, a built-in default detector
+drives the actions silently.
+
+For example, an interrupt file that also writes the report:
+
+.. code-block:: json
+
+    {
+        "action": "slam",
+        "trigger": { "start_iter": 100 },
+        "slam": {
+            "directives_file": "examples/sizes/config/slamming_directives.csv"
+        },
+        "detect": {
+            "output_csv": "w_oscillations.csv",
+            "methods": { "zero_crossings": {} }
+        }
+    }
 
 Actions
 ^^^^^^^
@@ -287,7 +309,7 @@ Scope, MPI, and limitations
   set in a fixed order, so the slammer's per-node ``min`` / ``max`` reduction is
   reached symmetrically on every rank.
 - **Multistage.** Detection and reporting iterate the scenario tree node by
-  node and are multistage-clean. The action selection is rank-coherent for
+  node and support multistage problems. The action selection is rank-coherent for
   two-stage problems and single-rank-per-node multistage; a node split across
   ranks would need an extra reduction to agree on the action, which is not done
   (the same limitation the slammer documents).

--- a/examples/sizes/config/w_oscillation_interrupt.json
+++ b/examples/sizes/config/w_oscillation_interrupt.json
@@ -1,11 +1,8 @@
 {
-    "action": "both",
+    "action": "slam",
     "trigger": {
         "min_scenarios_flagged": 1,
         "start_iter": 100
-    },
-    "w_damping": {
-        "factor": 0.5
     },
     "slam": {
         "directives_file": "examples/sizes/config/slamming_directives.csv",

--- a/examples/sizes/config/w_oscillation_interrupt.json
+++ b/examples/sizes/config/w_oscillation_interrupt.json
@@ -2,12 +2,10 @@
     "action": "both",
     "trigger": {
         "min_scenarios_flagged": 1,
-        "start_iter": 100,
-        "iters_between_actions": 5
+        "start_iter": 100
     },
-    "rho_reduction": {
-        "factor": 0.5,
-        "min_rho": 1e-3
+    "w_damping": {
+        "factor": 0.5
     },
     "slam": {
         "directives_file": "examples/sizes/config/slamming_directives.csv"

--- a/examples/sizes/config/w_oscillation_interrupt.json
+++ b/examples/sizes/config/w_oscillation_interrupt.json
@@ -8,6 +8,7 @@
         "factor": 0.5
     },
     "slam": {
-        "directives_file": "examples/sizes/config/slamming_directives.csv"
+        "directives_file": "examples/sizes/config/slamming_directives.csv",
+        "iters_between_slams": 3
     }
 }

--- a/examples/sizes/config/w_oscillation_interrupt.json
+++ b/examples/sizes/config/w_oscillation_interrupt.json
@@ -1,0 +1,15 @@
+{
+    "action": "both",
+    "trigger": {
+        "min_scenarios_flagged": 1,
+        "start_iter": 100,
+        "iters_between_actions": 5
+    },
+    "rho_reduction": {
+        "factor": 0.5,
+        "min_rho": 1e-3
+    },
+    "slam": {
+        "directives_file": "examples/sizes/config/slamming_directives.csv"
+    }
+}

--- a/mpisppy/extensions/slammer.py
+++ b/mpisppy/extensions/slammer.py
@@ -327,7 +327,7 @@ class Slammer(Extension):
 
         When ``candidates`` is given (a set/collection of ``(ndn, i)`` keys),
         only those nonants are considered -- the entry point a stall/cycle
-        detector uses to slam the worst of *its* flagged nonants while still
+        detector uses to slam one of *its* flagged nonants while still
         honoring the directives file's priority ranking.  Ineligible or
         no-applicable-direction candidates are skipped, so this effectively
         walks the priority order until it finds one it can slam.

--- a/mpisppy/extensions/slammer.py
+++ b/mpisppy/extensions/slammer.py
@@ -321,12 +321,21 @@ class Slammer(Extension):
             return
         self._slam_one()
 
-    def _slam_one(self):
-        """Select the highest-priority eligible nonant and slam it.
+    def _slam_one(self, candidates=None):
+        """Select the highest-priority eligible nonant and slam it; return 1 if
+        one was slammed, else 0.
+
+        When ``candidates`` is given (a set/collection of ``(ndn, i)`` keys),
+        only those nonants are considered -- the entry point a stall/cycle
+        detector uses to slam the worst of *its* flagged nonants while still
+        honoring the directives file's priority ranking.  Ineligible or
+        no-applicable-direction candidates are skipped, so this effectively
+        walks the priority order until it finds one it can slam.
 
         Selection uses only globally-consistent inputs (file-supplied priority
         and name; the fixed mask, which is coherent because slamming/fixing is
-        applied to all scenarios on all ranks), so every rank picks the same
+        applied to all scenarios on all ranks; and, for the detector-driven
+        path, a rank-identical ``candidates`` set), so every rank picks the same
         nonant with no communication.  This holds when the nonant catalog is
         rank-coherent (two-stage, or single-rank multistage); node-split
         multistage would need a cross-rank reduction to agree on the selection,
@@ -338,6 +347,8 @@ class Slammer(Extension):
         best_ndn_i = None
         best_key = None    # (priority, name) for max-priority, name-tiebreak
         for ndn_i, d in self._directive_of.items():
+            if candidates is not None and ndn_i not in candidates:
+                continue
             if not self._slam_eligible(rep, ndn_i, surrogates):
                 continue
             if self._first_applicable_direction(rep, ndn_i, d.directions) is None:
@@ -352,8 +363,8 @@ class Slammer(Extension):
                 best_key = key
 
         if best_ndn_i is None:
-            return  # nothing eligible this event
-        self.slam_nonant(best_ndn_i)
+            return 0  # nothing eligible this event
+        return 1 if self.slam_nonant(best_ndn_i) else 0
 
     def _slam_eligible(self, rep, ndn_i, surrogates):
         """Whether ``ndn_i`` may be slammed: it is in the directive map (checked

--- a/mpisppy/extensions/slammer.py
+++ b/mpisppy/extensions/slammer.py
@@ -222,11 +222,18 @@ class Slammer(Extension):
         added before rounding integer variables (matches the slam spokes).
     ``verbose`` (bool, default False)
         report each slam on rank 0.
+
+    ``options`` may be passed directly to the constructor by a *consumer* that
+    drives the action layer itself (e.g. a stall/cycle detector calling
+    :meth:`slam_nonant`); when given it is used in place of
+    ``spobj.options["slammer_options"]``, so such a consumer can run its own
+    Slammer without disturbing a separately-configured one.
     """
 
-    def __init__(self, spobj):
+    def __init__(self, spobj, options=None):
         super().__init__(spobj)
-        opts = spobj.options.get("slammer_options", {})
+        opts = options if options is not None \
+            else spobj.options.get("slammer_options", {})
         # Kept for error messages; None when directives are passed in directly.
         self._directives_file = opts.get("directives_file")
         if "directives" in opts:
@@ -328,18 +335,12 @@ class Slammer(Extension):
         rep = self.opt.local_scenarios[self.opt.local_scenario_names[0]]
         surrogates = rep._mpisppy_data.all_surrogate_nonants
 
-        best = None        # (ndn_i, direction, value)
+        best_ndn_i = None
         best_key = None    # (priority, name) for max-priority, name-tiebreak
         for ndn_i, d in self._directive_of.items():
-            if ndn_i in self._slammed:
+            if not self._slam_eligible(rep, ndn_i, surrogates):
                 continue
-            xvar = rep._mpisppy_data.nonant_indices[ndn_i]
-            if xvar.fixed:
-                continue
-            if xvar in surrogates:
-                continue
-            choice = self._first_applicable_direction(rep, ndn_i, d.directions)
-            if choice is None:
+            if self._first_applicable_direction(rep, ndn_i, d.directions) is None:
                 continue  # no applicable direction -> not eligible this event
             name = self._name_of[ndn_i]
             # Largest priority wins; ties broken by name (ascending) so the
@@ -347,13 +348,62 @@ class Slammer(Extension):
             key = (d.priority, name)
             if best_key is None or key[0] > best_key[0] \
                or (key[0] == best_key[0] and key[1] < best_key[1]):
-                best = (ndn_i, choice[0], choice[1])
+                best_ndn_i = ndn_i
                 best_key = key
 
-        if best is None:
+        if best_ndn_i is None:
             return  # nothing eligible this event
+        self.slam_nonant(best_ndn_i)
 
-        ndn_i, direction, value = best
+    def _slam_eligible(self, rep, ndn_i, surrogates):
+        """Whether ``ndn_i`` may be slammed: it is in the directive map (checked
+        by the caller / :meth:`slam_nonant`), not already slammed, not
+        modeler-/fixer-fixed, and not a surrogate nonant (§7.1 of the design).
+        Every input is rank-coherent, so the verdict is identical on every rank.
+        """
+        if ndn_i in self._slammed:
+            return False
+        xvar = rep._mpisppy_data.nonant_indices[ndn_i]
+        if xvar.fixed:
+            return False
+        if xvar in surrogates:
+            return False
+        return True
+
+    def slam_nonant(self, ndn_i):
+        """Action layer: slam the specific nonant ``ndn_i`` per its directive.
+
+        This is the reusable action entry the slamming design (§7) anticipated
+        for an external stall/cycle detector: rather than the built-in
+        iteration trigger choosing *which* nonant, a caller that has already
+        decided ``ndn_i`` is stuck invokes this directly.  The nonant is slammed
+        in the first applicable direction of its directive (so a detector need
+        only supply the directives file and the cycling nonant).
+
+        Returns ``True`` if the nonant was slammed, ``False`` if it is not in
+        the directive map, is not eligible (already fixed/slammed/surrogate), or
+        no direction applies this event.
+
+        **Collective safety:** a ``min``/``max`` direction triggers a per-node
+        ``Allreduce`` (:meth:`_node_extremum`); a caller iterating several
+        nonants must therefore call this for the *same* nonants in the *same
+        order on every rank*.  That holds when the caller's target set comes
+        from a rank-identical reduction (as the W-oscillation interrupter's
+        does) and the nonant catalog is rank-coherent (two-stage / single-rank
+        multistage), matching :meth:`_slam_one`'s own assumption.
+        """
+        d = self._directive_of.get(ndn_i)
+        if d is None:
+            return False
+        rep = self.opt.local_scenarios[self.opt.local_scenario_names[0]]
+        surrogates = rep._mpisppy_data.all_surrogate_nonants
+        if not self._slam_eligible(rep, ndn_i, surrogates):
+            return False
+        choice = self._first_applicable_direction(rep, ndn_i, d.directions)
+        if choice is None:
+            return False
+
+        direction, value = choice
         if direction in ("min", "max"):
             value = self._node_extremum(ndn_i, direction)
             xvar = rep._mpisppy_data.nonant_indices[ndn_i]
@@ -362,7 +412,8 @@ class Slammer(Extension):
 
         self._fix_everywhere(ndn_i, value)
         self._slammed[ndn_i] = value
-        self._report(self._name_of[ndn_i], value, direction, best_key[0])
+        self._report(self._name_of[ndn_i], value, direction, d.priority)
+        return True
 
     def _first_applicable_direction(self, scenario, ndn_i, directions):
         """Return ``(direction, value)`` for the first applicable direction, or

--- a/mpisppy/extensions/w_oscillation.py
+++ b/mpisppy/extensions/w_oscillation.py
@@ -51,6 +51,7 @@ import numpy as np
 import pyomo.environ as pyo
 
 import mpisppy.MPI as MPI
+from mpisppy import global_toc
 from mpisppy.extensions.extension import Extension
 from mpisppy.extensions.slammer import Slammer
 
@@ -438,6 +439,16 @@ class WOscillationMonitor(Extension):
         elif opts.get("interrupt_json"):
             self._interrupt_cfg = parse_interrupt_config(opts["interrupt_json"])
 
+        # Interruption needs the detection *engine* to know which nonants are
+        # cycling, but writing the cycling *report* (CSV) is opt-in.  The report
+        # is written only when detection was explicitly requested -- via
+        # --detect-W-oscillations / a detect_config, or a "detect" block in the
+        # interrupt file.  A pure --interrupt-W-oscillations run runs the engine
+        # (to drive the actions) but writes no report; its activity is announced
+        # with a global_toc instead (see _apply_interruption).
+        self._report_enabled = self.cfg is not None or (
+            self._interrupt_cfg is not None and "detect" in self._interrupt_cfg)
+
         # Interruption implies detection: derive a detection config if none was
         # supplied directly.
         if self.cfg is None:
@@ -538,7 +549,7 @@ class WOscillationMonitor(Extension):
             })
             self._slammer.pre_iter0()
 
-        if self._is_writer:
+        if self._is_writer and self._report_enabled:
             self._agg_file = open(self.cfg["output_csv"], "w", newline="")
             self._agg_writer = csv.writer(self._agg_file)
             self._agg_writer.writerow(_AGG_COLUMNS)
@@ -583,15 +594,18 @@ class WOscillationMonitor(Extension):
     def miditer(self):
         self._capture()
         phiter = self.opt._PHIter
-        detect_due = self._detect_due(phiter)
+        # The report is opt-in (self._report_enabled); a detection check only
+        # matters when reporting is on.  The engine still runs whenever an
+        # interruption action is due, to find the cycling nonants to act on.
+        report_due = self._report_enabled and self._detect_due(phiter)
         act_due = self._interrupt_cfg is not None and self._act_due(phiter)
-        if not (detect_due or act_due):
+        if not (report_due or act_due):
             return
         # Evaluate the detectors (always populates the rank-identical flagged
-        # counts the interrupter reads; emits report rows only on a detection
-        # check).  The decision to evaluate is a pure function of phiter, so the
+        # counts the interrupter reads; emits report rows only when a report is
+        # due).  The decision to evaluate is a pure function of phiter, so the
         # collective reductions inside fire symmetrically on every rank.
-        flagged = self._evaluate(phiter, emit=detect_due)
+        flagged = self._evaluate(phiter, emit=report_due)
         if act_due:
             self._apply_interruption(phiter, flagged)
 
@@ -725,14 +739,18 @@ class WOscillationMonitor(Extension):
         n_slam = self._slam_targets(targets) if action in ("slam", "both") \
             else 0
         self._n_action_events += 1
-        if self.verbose and self.opt.cylinder_rank == 0:
-            bits = []
-            if action in ("rho_reduction", "both"):
-                bits.append(f"reduced rho on {n_rho} nonant(s)")
-            if action in ("slam", "both"):
-                bits.append(f"slammed {n_slam} nonant(s)")
-            print(f"(rank0) WOscillationMonitor[iter {phiter}]: "
-                  f"{len(targets)} flagged; " + "; ".join(bits))
+        # Announce the interruption activity unconditionally (rank-0 gated) --
+        # this is the only output a pure --interrupt-W-oscillations run produces;
+        # the cycling report (CSV) is opt-in (self._report_enabled).
+        bits = []
+        if action in ("rho_reduction", "both"):
+            bits.append(f"reduced rho on {n_rho} nonant(s)")
+        if action in ("slam", "both"):
+            bits.append(f"slammed {n_slam} nonant(s)")
+        global_toc(
+            f"W-oscillation interruption [iter {phiter}]: {len(targets)} "
+            f"nonant(s) flagged; " + "; ".join(bits),
+            self.opt.cylinder_rank == 0)
 
     def _reduce_rho(self, targets):
         """Multiply each flagged nonant's rho by ``factor`` (floored at
@@ -840,7 +858,7 @@ class WOscillationMonitor(Extension):
 
     # ------------------------------------------------------------------ #
     def post_everything(self):
-        if self.cfg["report_mode"] == "final":
+        if self._report_enabled and self.cfg["report_mode"] == "final":
             self._evaluate(self.opt._PHIter)
         if self._is_writer:
             if self._agg_file is not None:
@@ -848,8 +866,12 @@ class WOscillationMonitor(Extension):
             if self._scen_file is not None:
                 self._scen_file.close()
         if self.verbose and self.opt.cylinder_rank == 0:
-            msg = (f"(rank0) WOscillationMonitor: {self._n_flag_events} "
-                   f"oscillation report event(s); see {self.cfg['output_csv']}")
+            if self._report_enabled:
+                msg = (f"(rank0) WOscillationMonitor: {self._n_flag_events} "
+                       f"oscillation report event(s); see "
+                       f"{self.cfg['output_csv']}")
+            else:
+                msg = "(rank0) WOscillationMonitor: report disabled"
             if self._interrupt_cfg is not None:
                 msg += (f"; {self._n_action_events} interruption action "
                         f"event(s) [{self._interrupt_cfg['action']}]")

--- a/mpisppy/extensions/w_oscillation.py
+++ b/mpisppy/extensions/w_oscillation.py
@@ -16,7 +16,8 @@ fixing changes, so the optimization trajectory is identical to a run without
 the flag.  With ``--interrupt-W-oscillations`` it additionally *acts* on the
 detected oscillation to break it -- by **damping W** (rescaling the dual-weight
 step) on every cycling nonant and/or **slamming** one of them (fixing it via the
-existing :class:`Slammer <mpisppy.extensions.slammer.Slammer>` action layer).
+existing :class:`Slammer <mpisppy.extensions.slammer.Slammer>` action layer,
+with at least ``iters_between_slams`` iterations between successive slams).
 Interruption implies detection; see :func:`parse_interrupt_config`.
 
 Two detection methods are available, selected and parameterized from a JSON
@@ -95,6 +96,10 @@ _TRIGGER_DEFAULTS = {
 _W_DAMPING_DEFAULTS = {
     "factor": 0.5,                  # retained fraction of each dual (W) step on a
                                     # flagged nonant; 0 <= factor < 1
+}
+_SLAM_DEFAULTS = {
+    "iters_between_slams": 3,       # cooldown: iterations that must pass after a
+                                    # successful slam before the next one
 }
 
 
@@ -314,13 +319,14 @@ def validate_interrupt_config(cfg, where="<interrupt config>"):
           "action": "w_damping" | "slam" | "both",
           "trigger": {min_scenarios_flagged, start_iter},
           "w_damping": {"factor": <0..1>},      # if w_damping/both
-          "slam": {"directives_file": <path>},  # if slam/both
+          "slam": {"directives_file": <path>,   # if slam/both
+                   "iters_between_slams": <int >= 1>},
           "detect": { ... }   # optional detection config (else a default is used)
         }
 
     Raises ``ValueError`` on an unknown/missing ``action``, a ``factor`` not in
-    ``[0, 1)``, a ``slam`` action with no ``directives_file``, or a bad trigger
-    value.
+    ``[0, 1)``, a ``slam`` action with no ``directives_file``, a
+    non-positive ``iters_between_slams``, or a bad trigger value.
     """
     if not isinstance(cfg, dict):
         raise ValueError(f"{where}: top level must be a JSON object")
@@ -351,18 +357,40 @@ def validate_interrupt_config(cfg, where="<interrupt config>"):
         out["w_damping"] = wd
 
     if action in ("slam", "both"):
-        slam = cfg.get("slam") or {}
+        slam = dict(_SLAM_DEFAULTS)
+        slam.update(cfg.get("slam") or {})
         directives_file = slam.get("directives_file")
         if not directives_file:
             raise ValueError(
                 f"{where}: action {action!r} requires "
                 "'slam': {{'directives_file': <path>}}")
-        out["slam"] = {"directives_file": directives_file}
+        iters_between = int(slam["iters_between_slams"])
+        if iters_between < 1:
+            raise ValueError(
+                f"{where}: slam.iters_between_slams must be >= 1 "
+                f"(got {iters_between}; 1 means a slam may occur every "
+                "iteration)")
+        out["slam"] = {"directives_file": directives_file,
+                       "iters_between_slams": iters_between}
 
     if "detect" in cfg:
         out["detect"] = validate_detect_config(
             cfg["detect"], where=f"{where} (detect block)")
     return out
+
+
+def slam_due(phiter, last_slam_iter, iters_between_slams):
+    """Whether a slam may occur at ``phiter`` given the cooldown: true when no
+    slam has happened yet (``last_slam_iter`` is None) or at least
+    ``iters_between_slams`` iterations have passed since the last successful
+    one.  The cooldown exists because the detectors judge a trailing history
+    window, which keeps signaling oscillation for a while after a fix -- this
+    gives the fix time to re-settle the others (WW §2.1) before concluding that
+    another variable must also be fixed.  A pure function of rank-identical
+    inputs, so the verdict is identical on every rank."""
+    if last_slam_iter is None:
+        return True
+    return phiter - last_slam_iter >= iters_between_slams
 
 
 def w_damped(w, rho, xdiff, factor):
@@ -484,6 +512,8 @@ class WOscillationMonitor(Extension):
 
         # Interruption state (PR2), built in pre_iter0() / updated in miditer().
         self._slammer = None        # internal Slammer for the slam action
+        self._last_slam_iter = None # iteration of the last successful slam
+                                    # (rank-identical; drives the slam cooldown)
         self._n_action_events = 0
         # j -> max scenarios flagging nonant j on the most recent evaluation
         # (rank-identical; the interrupter reads this).
@@ -579,8 +609,10 @@ class WOscillationMonitor(Extension):
 
     def _act_due(self, phiter):
         """Whether to *interrupt* at ``phiter`` (interruption configured): at or
-        after the trigger's ``start_iter``.  There is no inter-action cadence --
-        once started, act every iteration a nonant is still flagged.  Pure
+        after the trigger's ``start_iter``.  W-damping has no inter-action
+        cadence -- once started, it acts every iteration a nonant is still
+        flagged; the slam action is additionally throttled by its own cooldown
+        (:func:`slam_due`, applied in :meth:`_apply_interruption`).  Pure
         function of the counter -> identical on every rank."""
         return phiter >= self._interrupt_cfg["trigger"]["start_iter"]
 
@@ -716,31 +748,45 @@ class WOscillationMonitor(Extension):
     def _apply_interruption(self, phiter, flagged):
         """Act on the nonants flagged by at least ``min_scenarios_flagged``
         scenarios: damp W on **every** such nonant and/or slam **one** of them,
-        per the configured action.
+        per the configured action.  Slamming is additionally throttled by the
+        ``iters_between_slams`` cooldown (:func:`slam_due`) -- the detectors'
+        trailing-history flags outlive a fix, so without the cooldown a slam
+        would land every iteration until the history flushes.
 
-        ``flagged`` and the eligibility tests are rank-identical, so all ranks
-        act on the same nonants in the same order -- this matters because the
-        slam action may trigger a per-node ``Allreduce`` (the min/max extremum),
-        which must be reached symmetrically."""
+        ``flagged``, the eligibility tests, and the cooldown state are
+        rank-identical, so all ranks act on the same nonants in the same order
+        -- this matters because the slam action may trigger a per-node
+        ``Allreduce`` (the min/max extremum), which must be reached
+        symmetrically."""
         thresh = self._interrupt_cfg["trigger"]["min_scenarios_flagged"]
         targets = [j for j in range(len(self._ndn_i))
                    if flagged.get(j, 0) >= thresh]
         if not targets:
             return
         action = self._interrupt_cfg["action"]
-        n_damp = self._damp_w(targets) if action in ("w_damping", "both") \
-            else 0
-        n_slam = self._slam_targets(targets) if action in ("slam", "both") \
-            else 0
+        damp = action in ("w_damping", "both")
+        slam = action in ("slam", "both") and slam_due(
+            phiter, self._last_slam_iter,
+            self._interrupt_cfg["slam"]["iters_between_slams"])
+        if not (damp or slam):
+            return  # slam-only action, cooling down: nothing to do or announce
+        n_damp = self._damp_w(targets) if damp else 0
+        n_slam = self._slam_targets(targets) if slam else 0
+        if n_slam:
+            # Start the cooldown only on a *successful* slam; a no-candidate
+            # attempt (n_slam == 0) retries on the next flagged iteration.
+            self._last_slam_iter = phiter
         self._n_action_events += 1
         # Announce the interruption activity unconditionally (rank-0 gated) --
         # this is the only output a pure --interrupt-W-oscillations run produces;
         # the cycling report (CSV) is opt-in (self._report_enabled).
         bits = []
-        if action in ("w_damping", "both"):
+        if damp:
             bits.append(f"damped W on {n_damp} nonant(s)")
-        if action in ("slam", "both"):
+        if slam:
             bits.append(f"slammed {n_slam} nonant(s)")
+        elif action == "both":
+            bits.append("slam cooling down")
         global_toc(
             f"W-oscillation interruption [iter {phiter}]: {len(targets)} "
             f"nonant(s) flagged; " + "; ".join(bits),

--- a/mpisppy/extensions/w_oscillation.py
+++ b/mpisppy/extensions/w_oscillation.py
@@ -824,7 +824,7 @@ class WOscillationMonitor(Extension):
     def _slam_targets(self, targets):
         """Slam **at most one** flagged nonant this iteration -- the
         highest-priority one that can actually be slammed -- via the Slammer
-        action layer.  Fixing is drastic, and fixing the single worst oscillator
+        action layer.  Fixing is drastic, and fixing just one cycling variable
         often re-settles the others (WW §2.1), so we reuse Slammer's own
         priority-ranked, one-per-call :meth:`~mpisppy.extensions.slammer.Slammer._slam_one`
         restricted to the flagged set.  Return the number slammed (0 or 1)."""

--- a/mpisppy/extensions/w_oscillation.py
+++ b/mpisppy/extensions/w_oscillation.py
@@ -14,10 +14,10 @@ runs and reports detected oscillation to a CSV.  With only
 ``--detect-W-oscillations`` it is **pure observation**: it attaches no rho or
 fixing changes, so the optimization trajectory is identical to a run without
 the flag.  With ``--interrupt-W-oscillations`` it additionally *acts* on the
-detected oscillation to break it -- by **reducing rho** on the cycling nonant
-and/or **slamming** it (fixing it via the existing :class:`Slammer
-<mpisppy.extensions.slammer.Slammer>` action layer).  Interruption implies
-detection; see :func:`parse_interrupt_config`.
+detected oscillation to break it -- by **damping W** (rescaling the dual-weight
+step) on every cycling nonant and/or **slamming** one of them (fixing it via the
+existing :class:`Slammer <mpisppy.extensions.slammer.Slammer>` action layer).
+Interruption implies detection; see :func:`parse_interrupt_config`.
 
 Two detection methods are available, selected and parameterized from a JSON
 control file (see :func:`parse_detect_config`):
@@ -60,7 +60,7 @@ from mpisppy.extensions.slammer import Slammer
 VALID_METHODS = ("zero_crossings", "w_hash_recurrence")
 VALID_REPORT_MODES = ("on_detect", "final", "every_check")
 # Interruption actions recognized in the interrupt JSON "action" field.
-VALID_ACTIONS = ("rho_reduction", "slam", "both")
+VALID_ACTIONS = ("w_damping", "slam", "both")
 
 _MASK64 = (1 << 64) - 1
 
@@ -89,12 +89,12 @@ _W_HASH_DEFAULTS = {
 # Interruption (PR2) defaults; an interrupt file's omitted keys fall back here.
 _TRIGGER_DEFAULTS = {
     "min_scenarios_flagged": 1,     # act when >= this many scenarios flag a nonant
-    "start_iter": 5,                # first iteration at which to act
-    "iters_between_actions": 3,     # cadence once started
+    "start_iter": 5,                # first iteration at which to act; then every
+                                    # iteration a nonant is still flagged
 }
-_RHO_REDUCTION_DEFAULTS = {
-    "factor": 0.5,                  # multiply the cycling nonant's rho by this
-    "min_rho": 1e-3,                # floor; rho stays > 0 (PH requires it, #767)
+_W_DAMPING_DEFAULTS = {
+    "factor": 0.5,                  # retained fraction of each dual (W) step on a
+                                    # flagged nonant; 0 <= factor < 1
 }
 
 
@@ -311,16 +311,16 @@ def validate_interrupt_config(cfg, where="<interrupt config>"):
     Schema (see ``doc/designs/w_oscillation_design.md`` §2.2)::
 
         {
-          "action": "rho_reduction" | "slam" | "both",
-          "trigger": {min_scenarios_flagged, start_iter, iters_between_actions},
-          "rho_reduction": {"factor": <0..1>, "min_rho": <>0>},  # if rho_reduction/both
-          "slam": {"directives_file": <path>},                   # if slam/both
+          "action": "w_damping" | "slam" | "both",
+          "trigger": {min_scenarios_flagged, start_iter},
+          "w_damping": {"factor": <0..1>},      # if w_damping/both
+          "slam": {"directives_file": <path>},  # if slam/both
           "detect": { ... }   # optional detection config (else a default is used)
         }
 
     Raises ``ValueError`` on an unknown/missing ``action``, a ``factor`` not in
-    ``(0, 1)``, a non-positive ``min_rho``, a ``slam`` action with no
-    ``directives_file``, or a bad trigger value.
+    ``[0, 1)``, a ``slam`` action with no ``directives_file``, or a bad trigger
+    value.
     """
     if not isinstance(cfg, dict):
         raise ValueError(f"{where}: top level must be a JSON object")
@@ -334,29 +334,21 @@ def validate_interrupt_config(cfg, where="<interrupt config>"):
     trigger = {
         "min_scenarios_flagged": int(trig["min_scenarios_flagged"]),
         "start_iter": int(trig["start_iter"]),
-        "iters_between_actions": int(trig["iters_between_actions"]),
     }
-    if trigger["iters_between_actions"] < 1:
-        raise ValueError(f"{where}: trigger.iters_between_actions must be >= 1")
     if trigger["min_scenarios_flagged"] < 1:
         raise ValueError(f"{where}: trigger.min_scenarios_flagged must be >= 1")
 
     out = {"action": action, "trigger": trigger}
 
-    if action in ("rho_reduction", "both"):
-        rr = dict(_RHO_REDUCTION_DEFAULTS)
-        rr.update(cfg.get("rho_reduction") or {})
-        rr["factor"] = float(rr["factor"])
-        rr["min_rho"] = float(rr["min_rho"])
-        if not (0.0 < rr["factor"] < 1.0):
+    if action in ("w_damping", "both"):
+        wd = dict(_W_DAMPING_DEFAULTS)
+        wd.update(cfg.get("w_damping") or {})
+        wd["factor"] = float(wd["factor"])
+        if not (0.0 <= wd["factor"] < 1.0):
             raise ValueError(
-                f"{where}: rho_reduction.factor must be in (0, 1) to reduce "
-                f"rho (got {rr['factor']})")
-        if rr["min_rho"] <= 0.0:
-            raise ValueError(
-                f"{where}: rho_reduction.min_rho must be > 0 (PH requires "
-                f"rho > 0; got {rr['min_rho']})")
-        out["rho_reduction"] = rr
+                f"{where}: w_damping.factor must be in [0, 1) to damp the W "
+                f"step (1.0 is a no-op; got {wd['factor']})")
+        out["w_damping"] = wd
 
     if action in ("slam", "both"):
         slam = cfg.get("slam") or {}
@@ -373,14 +365,17 @@ def validate_interrupt_config(cfg, where="<interrupt config>"):
     return out
 
 
-def reduced_rho(old, factor, min_rho):
-    """Rho after one reduction event: ``old * factor`` floored at ``min_rho``.
+def w_damped(w, rho, xdiff, factor):
+    """W after one damping event: undo the fraction ``1 - factor`` of the dual
+    step ``rho * xdiff`` that ``Update_W`` just applied.
 
-    The floor keeps rho strictly positive, which PH requires (see issue #560 /
-    the rho>0 enforcement); reducing rho relaxes the proximal pull that drives
-    the overshoot, the dynamic analogue of Watson--Woodruff §2.1's SEP rho that
-    approaches the optimal weight "from below"."""
-    return max(min_rho, old * factor)
+    ``Update_W`` set ``W += rho * (x - xbar)``; had it used ``factor * rho``
+    instead, ``W`` would be smaller by ``(1 - factor) * rho * xdiff``.  This
+    rescales that most recent increment to what a lower rho would have produced,
+    leaving the proximal rho untouched -- damping the dual (``w``) step that
+    Watson--Woodruff §2.1 identifies as "shoot[ing] past" the optimal weight.
+    ``factor`` is in ``[0, 1)``: 0 fully cancels the step, near 1 barely damps."""
+    return w - (1.0 - factor) * rho * xdiff
 
 
 # --------------------------------------------------------------------------- #
@@ -584,12 +579,10 @@ class WOscillationMonitor(Extension):
 
     def _act_due(self, phiter):
         """Whether to *interrupt* at ``phiter`` (interruption configured): at or
-        after the trigger's ``start_iter``, then every ``iters_between_actions``.
-        Pure function of the counter -> identical on every rank."""
-        t = self._interrupt_cfg["trigger"]
-        if phiter < t["start_iter"]:
-            return False
-        return (phiter - t["start_iter"]) % t["iters_between_actions"] == 0
+        after the trigger's ``start_iter``.  There is no inter-action cadence --
+        once started, act every iteration a nonant is still flagged.  Pure
+        function of the counter -> identical on every rank."""
+        return phiter >= self._interrupt_cfg["trigger"]["start_iter"]
 
     def miditer(self):
         self._capture()
@@ -721,8 +714,9 @@ class WOscillationMonitor(Extension):
     # Interruption (PR2): act on the flagged nonants to break the oscillation.
     # ------------------------------------------------------------------ #
     def _apply_interruption(self, phiter, flagged):
-        """Act on every nonant flagged by at least ``min_scenarios_flagged``
-        scenarios: reduce its rho and/or slam it, per the configured action.
+        """Act on the nonants flagged by at least ``min_scenarios_flagged``
+        scenarios: damp W on **every** such nonant and/or slam **one** of them,
+        per the configured action.
 
         ``flagged`` and the eligibility tests are rank-identical, so all ranks
         act on the same nonants in the same order -- this matters because the
@@ -734,7 +728,7 @@ class WOscillationMonitor(Extension):
         if not targets:
             return
         action = self._interrupt_cfg["action"]
-        n_rho = self._reduce_rho(targets) if action in ("rho_reduction", "both") \
+        n_damp = self._damp_w(targets) if action in ("w_damping", "both") \
             else 0
         n_slam = self._slam_targets(targets) if action in ("slam", "both") \
             else 0
@@ -743,8 +737,8 @@ class WOscillationMonitor(Extension):
         # this is the only output a pure --interrupt-W-oscillations run produces;
         # the cycling report (CSV) is opt-in (self._report_enabled).
         bits = []
-        if action in ("rho_reduction", "both"):
-            bits.append(f"reduced rho on {n_rho} nonant(s)")
+        if action in ("w_damping", "both"):
+            bits.append(f"damped W on {n_damp} nonant(s)")
         if action in ("slam", "both"):
             bits.append(f"slammed {n_slam} nonant(s)")
         global_toc(
@@ -752,43 +746,44 @@ class WOscillationMonitor(Extension):
             f"nonant(s) flagged; " + "; ".join(bits),
             self.opt.cylinder_rank == 0)
 
-    def _reduce_rho(self, targets):
-        """Multiply each flagged nonant's rho by ``factor`` (floored at
-        ``min_rho``) in every local scenario; return the number of nonants
-        whose rho was actually lowered.
+    def _damp_w(self, targets):
+        """Damp the dual weight on **every** flagged nonant, in every local
+        scenario, by rescaling the increment ``Update_W`` just applied:
+        ``W -= (1 - factor) * rho * (x - xbar)`` (see :func:`w_damped`).  Return
+        the number of nonants touched.
 
-        rho is a mutable Pyomo Param in the prox term, so changing its value is
+        W is a mutable Pyomo Param in the objective, so changing its value is
         picked up by the per-iteration ``set_objective`` that ``solve_one``
         issues for persistent solvers -- no explicit solver push is needed (the
-        same mechanism the rho-updating extensions rely on)."""
-        rr = self._interrupt_cfg["rho_reduction"]
-        factor, min_rho = rr["factor"], rr["min_rho"]
+        same mechanism the rho-updating extensions rely on).  The proximal rho
+        is left unchanged; only the dual step is damped."""
+        factor = self._interrupt_cfg["w_damping"]["factor"]
         touched = 0
         for j in targets:
             ndn_i = self._ndn_i[j]
             changed = False
             for s in self.opt.local_scenarios.values():
-                rho = s._mpisppy_model.rho
-                if ndn_i not in rho:
+                W = s._mpisppy_model.W
+                if ndn_i not in W:
                     continue  # scenario does not pass through this node
-                r = rho[ndn_i]
-                new = reduced_rho(pyo.value(r), factor, min_rho)
-                if new < pyo.value(r):
-                    r._value = new
-                    changed = True
+                rho = pyo.value(s._mpisppy_model.rho[ndn_i])
+                xdiff = s._mpisppy_data.nonant_indices[ndn_i]._value \
+                    - s._mpisppy_model.xbars[ndn_i]._value
+                W[ndn_i]._value = w_damped(W[ndn_i]._value, rho, xdiff, factor)
+                changed = True
             if changed:
                 touched += 1
         return touched
 
     def _slam_targets(self, targets):
-        """Slam each flagged nonant via the Slammer action layer; return the
-        number actually slammed (others are not in the directives, already
-        fixed, or have no applicable direction this event)."""
-        n = 0
-        for j in targets:
-            if self._slammer.slam_nonant(self._ndn_i[j]):
-                n += 1
-        return n
+        """Slam **at most one** flagged nonant this iteration -- the
+        highest-priority one that can actually be slammed -- via the Slammer
+        action layer.  Fixing is drastic, and fixing the single worst oscillator
+        often re-settles the others (WW §2.1), so we reuse Slammer's own
+        priority-ranked, one-per-call :meth:`~mpisppy.extensions.slammer.Slammer._slam_one`
+        restricted to the flagged set.  Return the number slammed (0 or 1)."""
+        candidates = {self._ndn_i[j] for j in targets}
+        return self._slammer._slam_one(candidates=candidates)
 
     # ------------------------------------------------------------------ #
     def _reduce_per_node(self, nJ, arrays_and_ops):

--- a/mpisppy/extensions/w_oscillation.py
+++ b/mpisppy/extensions/w_oscillation.py
@@ -310,6 +310,21 @@ def parse_interrupt_config(path):
     return validate_interrupt_config(cfg, where=path)
 
 
+def _as_json_object(cfg, key, where):
+    """Return ``cfg[key]`` as a dict to merge over defaults, treating an absent
+    or null value as an empty object.  Raise a clear ``ValueError`` when the
+    value is present but not a JSON object, rather than letting the subsequent
+    ``dict.update`` fail later with a low-level ``TypeError``."""
+    val = cfg.get(key)
+    if val is None:
+        return {}
+    if not isinstance(val, dict):
+        raise ValueError(
+            f"{where}: {key!r} must be a JSON object (got "
+            f"{type(val).__name__})")
+    return val
+
+
 def validate_interrupt_config(cfg, where="<interrupt config>"):
     """Validate an interruption control dict and fill in defaults.
 
@@ -335,12 +350,8 @@ def validate_interrupt_config(cfg, where="<interrupt config>"):
         raise ValueError(
             f"{where}: 'action' {action!r} not in {VALID_ACTIONS}")
 
-    trigger_block = cfg.get("trigger")
-    if trigger_block is not None and not isinstance(trigger_block, dict):
-        raise ValueError(f"{where}: 'trigger' must be a JSON object")
-
     trig = dict(_TRIGGER_DEFAULTS)
-    trig.update(trigger_block or {})
+    trig.update(_as_json_object(cfg, "trigger", where))
     trigger = {
         "min_scenarios_flagged": int(trig["min_scenarios_flagged"]),
         "start_iter": int(trig["start_iter"]),
@@ -352,7 +363,7 @@ def validate_interrupt_config(cfg, where="<interrupt config>"):
 
     if action in ("w_damping", "both"):
         wd = dict(_W_DAMPING_DEFAULTS)
-        wd.update(cfg.get("w_damping") or {})
+        wd.update(_as_json_object(cfg, "w_damping", where))
         wd["factor"] = float(wd["factor"])
         if not (0.0 <= wd["factor"] < 1.0):
             raise ValueError(
@@ -362,7 +373,7 @@ def validate_interrupt_config(cfg, where="<interrupt config>"):
 
     if action in ("slam", "both"):
         slam = dict(_SLAM_DEFAULTS)
-        slam.update(cfg.get("slam") or {})
+        slam.update(_as_json_object(cfg, "slam", where))
         directives_file = slam.get("directives_file")
         if not directives_file:
             raise ValueError(

--- a/mpisppy/extensions/w_oscillation.py
+++ b/mpisppy/extensions/w_oscillation.py
@@ -335,8 +335,12 @@ def validate_interrupt_config(cfg, where="<interrupt config>"):
         raise ValueError(
             f"{where}: 'action' {action!r} not in {VALID_ACTIONS}")
 
+    trigger_block = cfg.get("trigger")
+    if trigger_block is not None and not isinstance(trigger_block, dict):
+        raise ValueError(f"{where}: 'trigger' must be a JSON object")
+
     trig = dict(_TRIGGER_DEFAULTS)
-    trig.update(cfg.get("trigger") or {})
+    trig.update(trigger_block or {})
     trigger = {
         "min_scenarios_flagged": int(trig["min_scenarios_flagged"]),
         "start_iter": int(trig["start_iter"]),

--- a/mpisppy/extensions/w_oscillation.py
+++ b/mpisppy/extensions/w_oscillation.py
@@ -352,6 +352,11 @@ def validate_interrupt_config(cfg, where="<interrupt config>"):
     }
     if trigger["min_scenarios_flagged"] < 1:
         raise ValueError(f"{where}: trigger.min_scenarios_flagged must be >= 1")
+    if trigger["start_iter"] < 0:
+        raise ValueError(
+            f"{where}: trigger.start_iter must be >= 0 "
+            f"(got {trigger['start_iter']}; a negative value would make "
+            "interruption eligible from iteration 0)")
 
     out = {"action": action, "trigger": trigger}
 

--- a/mpisppy/extensions/w_oscillation.py
+++ b/mpisppy/extensions/w_oscillation.py
@@ -14,11 +14,10 @@ runs and reports detected oscillation to a CSV.  With only
 ``--detect-W-oscillations`` it is **pure observation**: it attaches no rho or
 fixing changes, so the optimization trajectory is identical to a run without
 the flag.  With ``--interrupt-W-oscillations`` it additionally *acts* on the
-detected oscillation to break it -- by **damping W** (rescaling the dual-weight
-step) on every cycling nonant and/or **slamming** one of them (fixing it via the
-existing :class:`Slammer <mpisppy.extensions.slammer.Slammer>` action layer,
-with at least ``iters_between_slams`` iterations between successive slams).
-Interruption implies detection; see :func:`parse_interrupt_config`.
+detected oscillation to break it -- by **slamming** a cycling nonant (fixing it
+via the existing :class:`Slammer <mpisppy.extensions.slammer.Slammer>` action
+layer, with at least ``iters_between_slams`` iterations between successive
+slams).  Interruption implies detection; see :func:`parse_interrupt_config`.
 
 Two detection methods are available, selected and parameterized from a JSON
 control file (see :func:`parse_detect_config`):
@@ -49,7 +48,6 @@ import csv
 import json
 
 import numpy as np
-import pyomo.environ as pyo
 
 import mpisppy.MPI as MPI
 from mpisppy import global_toc
@@ -60,8 +58,9 @@ from mpisppy.extensions.slammer import Slammer
 # Method names recognized in the JSON "methods" block.
 VALID_METHODS = ("zero_crossings", "w_hash_recurrence")
 VALID_REPORT_MODES = ("on_detect", "final", "every_check")
-# Interruption actions recognized in the interrupt JSON "action" field.
-VALID_ACTIONS = ("w_damping", "slam", "both")
+# Interruption actions recognized in the interrupt JSON "action" field. Slamming
+# is the only remedy; the field is retained so a future remedy could be added.
+VALID_ACTIONS = ("slam",)
 
 _MASK64 = (1 << 64) - 1
 
@@ -92,10 +91,6 @@ _TRIGGER_DEFAULTS = {
     "min_scenarios_flagged": 1,     # act when >= this many scenarios flag a nonant
     "start_iter": 5,                # first iteration at which to act; then every
                                     # iteration a nonant is still flagged
-}
-_W_DAMPING_DEFAULTS = {
-    "factor": 0.5,                  # retained fraction of each dual (W) step on a
-                                    # flagged nonant; 0 <= factor < 1
 }
 _SLAM_DEFAULTS = {
     "iters_between_slams": 3,       # cooldown: iterations that must pass after a
@@ -331,17 +326,16 @@ def validate_interrupt_config(cfg, where="<interrupt config>"):
     Schema (see ``doc/designs/w_oscillation_design.md`` §2.2)::
 
         {
-          "action": "w_damping" | "slam" | "both",
+          "action": "slam",
           "trigger": {min_scenarios_flagged, start_iter},
-          "w_damping": {"factor": <0..1>},      # if w_damping/both
-          "slam": {"directives_file": <path>,   # if slam/both
+          "slam": {"directives_file": <path>,
                    "iters_between_slams": <int >= 1>},
           "detect": { ... }   # optional detection config (else a default is used)
         }
 
-    Raises ``ValueError`` on an unknown/missing ``action``, a ``factor`` not in
-    ``[0, 1)``, a ``slam`` action with no ``directives_file``, a
-    non-positive ``iters_between_slams``, or a bad trigger value.
+    Raises ``ValueError`` on an unknown/missing ``action``, a ``slam`` action
+    with no ``directives_file``, a non-positive ``iters_between_slams``, or a bad
+    trigger value.
     """
     if not isinstance(cfg, dict):
         raise ValueError(f"{where}: top level must be a JSON object")
@@ -361,17 +355,7 @@ def validate_interrupt_config(cfg, where="<interrupt config>"):
 
     out = {"action": action, "trigger": trigger}
 
-    if action in ("w_damping", "both"):
-        wd = dict(_W_DAMPING_DEFAULTS)
-        wd.update(_as_json_object(cfg, "w_damping", where))
-        wd["factor"] = float(wd["factor"])
-        if not (0.0 <= wd["factor"] < 1.0):
-            raise ValueError(
-                f"{where}: w_damping.factor must be in [0, 1) to damp the W "
-                f"step (1.0 is a no-op; got {wd['factor']})")
-        out["w_damping"] = wd
-
-    if action in ("slam", "both"):
+    if action == "slam":
         slam = dict(_SLAM_DEFAULTS)
         slam.update(_as_json_object(cfg, "slam", where))
         directives_file = slam.get("directives_file")
@@ -406,19 +390,6 @@ def slam_due(phiter, last_slam_iter, iters_between_slams):
     if last_slam_iter is None:
         return True
     return phiter - last_slam_iter >= iters_between_slams
-
-
-def w_damped(w, rho, xdiff, factor):
-    """W after one damping event: undo the fraction ``1 - factor`` of the dual
-    step ``rho * xdiff`` that ``Update_W`` just applied.
-
-    ``Update_W`` set ``W += rho * (x - xbar)``; had it used ``factor * rho``
-    instead, ``W`` would be smaller by ``(1 - factor) * rho * xdiff``.  This
-    rescales that most recent increment to what a lower rho would have produced,
-    leaving the proximal rho untouched -- damping the dual (``w``) step that
-    Watson--Woodruff §2.1 identifies as "shoot[ing] past" the optimal weight.
-    ``factor`` is in ``[0, 1)``: 0 fully cancels the step, near 1 barely damps."""
-    return w - (1.0 - factor) * rho * xdiff
 
 
 # --------------------------------------------------------------------------- #
@@ -582,7 +553,7 @@ class WOscillationMonitor(Extension):
         # rank symmetrically; its iteration-count trigger is never used -- the
         # interrupter calls slam_nonant() on exactly the flagged nonants.
         if self._interrupt_cfg is not None \
-                and self._interrupt_cfg["action"] in ("slam", "both"):
+                and self._interrupt_cfg["action"] == "slam":
             self._slammer = Slammer(self.opt, options={
                 "directives_file": self._interrupt_cfg["slam"]["directives_file"],
                 "verbose": self.verbose,
@@ -624,11 +595,10 @@ class WOscillationMonitor(Extension):
 
     def _act_due(self, phiter):
         """Whether to *interrupt* at ``phiter`` (interruption configured): at or
-        after the trigger's ``start_iter``.  W-damping has no inter-action
-        cadence -- once started, it acts every iteration a nonant is still
-        flagged; the slam action is additionally throttled by its own cooldown
-        (:func:`slam_due`, applied in :meth:`_apply_interruption`).  Pure
-        function of the counter -> identical on every rank."""
+        after the trigger's ``start_iter``.  The slam action is additionally
+        throttled by its own cooldown (:func:`slam_due`, applied in
+        :meth:`_apply_interruption`).  Pure function of the counter -> identical
+        on every rank."""
         return phiter >= self._interrupt_cfg["trigger"]["start_iter"]
 
     def miditer(self):
@@ -766,11 +736,11 @@ class WOscillationMonitor(Extension):
     # ------------------------------------------------------------------ #
     def _apply_interruption(self, phiter, flagged):
         """Act on the nonants flagged by at least ``min_scenarios_flagged``
-        scenarios: damp W on **every** such nonant and/or slam **one** of them,
-        per the configured action.  Slamming is additionally throttled by the
-        ``iters_between_slams`` cooldown (:func:`slam_due`) -- the detectors'
-        trailing-history flags outlive a fix, so without the cooldown a slam
-        would land every iteration until the history flushes.
+        scenarios: slam **one** of them (the highest-priority slammable nonant).
+        Slamming is throttled by the ``iters_between_slams`` cooldown
+        (:func:`slam_due`) -- the detectors' trailing-history flags outlive a
+        fix, so without the cooldown a slam would land every iteration until the
+        history flushes.
 
         ``flagged``, the eligibility tests, and the cooldown state are
         rank-identical, so all ranks act on the same nonants in the same order
@@ -782,59 +752,22 @@ class WOscillationMonitor(Extension):
                    if flagged.get(j, 0) >= thresh]
         if not targets:
             return
-        action = self._interrupt_cfg["action"]
-        damp = action in ("w_damping", "both")
-        slam = action in ("slam", "both") and slam_due(
-            phiter, self._last_slam_iter,
-            self._interrupt_cfg["slam"]["iters_between_slams"])
-        if not (damp or slam):
-            return  # slam-only action, cooling down: nothing to do or announce
-        if damp:
-            self._damp_w(targets)
-        n_slam = self._slam_targets(targets) if slam else 0
+        if not slam_due(phiter, self._last_slam_iter,
+                        self._interrupt_cfg["slam"]["iters_between_slams"]):
+            return  # cooling down: nothing to do or announce
+        n_slam = self._slam_targets(targets)
         if n_slam:
             # Start the cooldown only on a *successful* slam; a no-candidate
             # attempt (n_slam == 0) retries on the next flagged iteration.
             self._last_slam_iter = phiter
         self._n_action_events += 1
-        # Announce the interruption activity unconditionally (rank-0 gated) --
-        # this is the only output a pure --interrupt-W-oscillations run produces;
-        # the cycling report (CSV) is opt-in (self._report_enabled).
-        bits = []
-        if damp:
-            # len(targets) is rank-identical (a rank's *local* touched count
-            # can be smaller under node-split multistage distributions).
-            bits.append(f"damped W on {len(targets)} nonant(s)")
-        if slam:
-            bits.append(f"slammed {n_slam} nonant(s)")
-        elif action == "both":
-            bits.append("slam cooling down")
+        # Announce the interruption activity (rank-0 gated) -- this is the only
+        # output a pure --interrupt-W-oscillations run produces; the cycling
+        # report (CSV) is opt-in (self._report_enabled).
         global_toc(
             f"W-oscillation interruption [iter {phiter}]: {len(targets)} "
-            f"nonant(s) flagged; " + "; ".join(bits),
+            f"nonant(s) flagged; slammed {n_slam} nonant(s)",
             self.opt.cylinder_rank == 0)
-
-    def _damp_w(self, targets):
-        """Damp the dual weight on **every** flagged nonant, in every local
-        scenario, by rescaling the increment ``Update_W`` just applied:
-        ``W -= (1 - factor) * rho * (x - xbar)`` (see :func:`w_damped`).
-
-        W is a mutable Pyomo Param in the objective, so changing its value is
-        picked up by the per-iteration ``set_objective`` that ``solve_one``
-        issues for persistent solvers -- no explicit solver push is needed (the
-        same mechanism the rho-updating extensions rely on).  The proximal rho
-        is left unchanged; only the dual step is damped."""
-        factor = self._interrupt_cfg["w_damping"]["factor"]
-        for j in targets:
-            ndn_i = self._ndn_i[j]
-            for s in self.opt.local_scenarios.values():
-                W = s._mpisppy_model.W
-                if ndn_i not in W:
-                    continue  # scenario does not pass through this node
-                rho = pyo.value(s._mpisppy_model.rho[ndn_i])
-                xdiff = s._mpisppy_data.nonant_indices[ndn_i]._value \
-                    - s._mpisppy_model.xbars[ndn_i]._value
-                W[ndn_i]._value = w_damped(W[ndn_i]._value, rho, xdiff, factor)
 
     def _slam_targets(self, targets):
         """Slam **at most one** flagged nonant this iteration -- the

--- a/mpisppy/extensions/w_oscillation.py
+++ b/mpisppy/extensions/w_oscillation.py
@@ -620,9 +620,13 @@ class WOscillationMonitor(Extension):
         self._capture()
         phiter = self.opt._PHIter
         # The report is opt-in (self._report_enabled); a detection check only
-        # matters when reporting is on.  The engine still runs whenever an
-        # interruption action is due, to find the cycling nonants to act on.
-        report_due = self._report_enabled and self._detect_due(phiter)
+        # matters when reporting is on.  In "final" report mode all rows are
+        # deferred to the single end-of-run evaluation in post_everything.
+        # The engine still runs whenever an interruption action is due, to
+        # find the cycling nonants to act on.
+        report_due = (self._report_enabled
+                      and self.cfg["report_mode"] != "final"
+                      and self._detect_due(phiter))
         act_due = self._interrupt_cfg is not None and self._act_due(phiter)
         if not (report_due or act_due):
             return
@@ -770,7 +774,8 @@ class WOscillationMonitor(Extension):
             self._interrupt_cfg["slam"]["iters_between_slams"])
         if not (damp or slam):
             return  # slam-only action, cooling down: nothing to do or announce
-        n_damp = self._damp_w(targets) if damp else 0
+        if damp:
+            self._damp_w(targets)
         n_slam = self._slam_targets(targets) if slam else 0
         if n_slam:
             # Start the cooldown only on a *successful* slam; a no-candidate
@@ -782,7 +787,9 @@ class WOscillationMonitor(Extension):
         # the cycling report (CSV) is opt-in (self._report_enabled).
         bits = []
         if damp:
-            bits.append(f"damped W on {n_damp} nonant(s)")
+            # len(targets) is rank-identical (a rank's *local* touched count
+            # can be smaller under node-split multistage distributions).
+            bits.append(f"damped W on {len(targets)} nonant(s)")
         if slam:
             bits.append(f"slammed {n_slam} nonant(s)")
         elif action == "both":
@@ -795,8 +802,7 @@ class WOscillationMonitor(Extension):
     def _damp_w(self, targets):
         """Damp the dual weight on **every** flagged nonant, in every local
         scenario, by rescaling the increment ``Update_W`` just applied:
-        ``W -= (1 - factor) * rho * (x - xbar)`` (see :func:`w_damped`).  Return
-        the number of nonants touched.
+        ``W -= (1 - factor) * rho * (x - xbar)`` (see :func:`w_damped`).
 
         W is a mutable Pyomo Param in the objective, so changing its value is
         picked up by the per-iteration ``set_objective`` that ``solve_one``
@@ -804,10 +810,8 @@ class WOscillationMonitor(Extension):
         same mechanism the rho-updating extensions rely on).  The proximal rho
         is left unchanged; only the dual step is damped."""
         factor = self._interrupt_cfg["w_damping"]["factor"]
-        touched = 0
         for j in targets:
             ndn_i = self._ndn_i[j]
-            changed = False
             for s in self.opt.local_scenarios.values():
                 W = s._mpisppy_model.W
                 if ndn_i not in W:
@@ -816,10 +820,6 @@ class WOscillationMonitor(Extension):
                 xdiff = s._mpisppy_data.nonant_indices[ndn_i]._value \
                     - s._mpisppy_model.xbars[ndn_i]._value
                 W[ndn_i]._value = w_damped(W[ndn_i]._value, rho, xdiff, factor)
-                changed = True
-            if changed:
-                touched += 1
-        return touched
 
     def _slam_targets(self, targets):
         """Slam **at most one** flagged nonant this iteration -- the

--- a/mpisppy/extensions/w_oscillation.py
+++ b/mpisppy/extensions/w_oscillation.py
@@ -6,13 +6,18 @@
 # All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
 # full copyright and license information.
 ###############################################################################
-"""Detect oscillation / cycling in the PH dual weight (W) vector.
+"""Detect (and optionally interrupt) oscillation / cycling in the PH dual
+weight (W) vector.
 
 This is a *hub* extension that observes the W vector while a synchronous PH hub
-runs and reports detected oscillation to a CSV.  It is **pure observation**: it
-attaches no rho or fixing changes, so a run with ``--detect-W-oscillations``
-produces the same optimization trajectory as one without.  Interrupting the
-oscillation (rho reduction / slamming) is a separate piece of work.
+runs and reports detected oscillation to a CSV.  With only
+``--detect-W-oscillations`` it is **pure observation**: it attaches no rho or
+fixing changes, so the optimization trajectory is identical to a run without
+the flag.  With ``--interrupt-W-oscillations`` it additionally *acts* on the
+detected oscillation to break it -- by **reducing rho** on the cycling nonant
+and/or **slamming** it (fixing it via the existing :class:`Slammer
+<mpisppy.extensions.slammer.Slammer>` action layer).  Interruption implies
+detection; see :func:`parse_interrupt_config`.
 
 Two detection methods are available, selected and parameterized from a JSON
 control file (see :func:`parse_detect_config`):
@@ -43,14 +48,18 @@ import csv
 import json
 
 import numpy as np
+import pyomo.environ as pyo
 
 import mpisppy.MPI as MPI
 from mpisppy.extensions.extension import Extension
+from mpisppy.extensions.slammer import Slammer
 
 
 # Method names recognized in the JSON "methods" block.
 VALID_METHODS = ("zero_crossings", "w_hash_recurrence")
 VALID_REPORT_MODES = ("on_detect", "final", "every_check")
+# Interruption actions recognized in the interrupt JSON "action" field.
+VALID_ACTIONS = ("rho_reduction", "slam", "both")
 
 _MASK64 = (1 << 64) - 1
 
@@ -74,6 +83,17 @@ _W_HASH_DEFAULTS = {
     "window": 20,                   # look back this many checks for a repeat
     "quantum": 1e-6,                # W quantized to this before hashing
     "min_period": 2,                # >=2 so constant W (convergence) is ignored
+}
+
+# Interruption (PR2) defaults; an interrupt file's omitted keys fall back here.
+_TRIGGER_DEFAULTS = {
+    "min_scenarios_flagged": 1,     # act when >= this many scenarios flag a nonant
+    "start_iter": 5,                # first iteration at which to act
+    "iters_between_actions": 3,     # cadence once started
+}
+_RHO_REDUCTION_DEFAULTS = {
+    "factor": 0.5,                  # multiply the cycling nonant's rho by this
+    "min_rho": 1e-3,                # floor; rho stays > 0 (PH requires it, #767)
 }
 
 
@@ -266,6 +286,102 @@ def validate_detect_config(cfg, where="<detect config>"):
     return out
 
 
+def default_detect_config():
+    """A sensible default detection config for a run that supplies only
+    ``--interrupt-W-oscillations`` (interruption implies detection): both
+    methods at their defaults, reporting to ``w_oscillations.csv``."""
+    return validate_detect_config({
+        "output_csv": "w_oscillations.csv",
+        "methods": {"zero_crossings": {}, "w_hash_recurrence": {}},
+    })
+
+
+def parse_interrupt_config(path):
+    """Load and validate an ``--interrupt-W-oscillations`` JSON control file
+    (see :func:`validate_interrupt_config`)."""
+    with open(path, "r") as f:
+        cfg = json.load(f)
+    return validate_interrupt_config(cfg, where=path)
+
+
+def validate_interrupt_config(cfg, where="<interrupt config>"):
+    """Validate an interruption control dict and fill in defaults.
+
+    Schema (see ``doc/designs/w_oscillation_design.md`` §2.2)::
+
+        {
+          "action": "rho_reduction" | "slam" | "both",
+          "trigger": {min_scenarios_flagged, start_iter, iters_between_actions},
+          "rho_reduction": {"factor": <0..1>, "min_rho": <>0>},  # if rho_reduction/both
+          "slam": {"directives_file": <path>},                   # if slam/both
+          "detect": { ... }   # optional detection config (else a default is used)
+        }
+
+    Raises ``ValueError`` on an unknown/missing ``action``, a ``factor`` not in
+    ``(0, 1)``, a non-positive ``min_rho``, a ``slam`` action with no
+    ``directives_file``, or a bad trigger value.
+    """
+    if not isinstance(cfg, dict):
+        raise ValueError(f"{where}: top level must be a JSON object")
+    action = cfg.get("action")
+    if action not in VALID_ACTIONS:
+        raise ValueError(
+            f"{where}: 'action' {action!r} not in {VALID_ACTIONS}")
+
+    trig = dict(_TRIGGER_DEFAULTS)
+    trig.update(cfg.get("trigger") or {})
+    trigger = {
+        "min_scenarios_flagged": int(trig["min_scenarios_flagged"]),
+        "start_iter": int(trig["start_iter"]),
+        "iters_between_actions": int(trig["iters_between_actions"]),
+    }
+    if trigger["iters_between_actions"] < 1:
+        raise ValueError(f"{where}: trigger.iters_between_actions must be >= 1")
+    if trigger["min_scenarios_flagged"] < 1:
+        raise ValueError(f"{where}: trigger.min_scenarios_flagged must be >= 1")
+
+    out = {"action": action, "trigger": trigger}
+
+    if action in ("rho_reduction", "both"):
+        rr = dict(_RHO_REDUCTION_DEFAULTS)
+        rr.update(cfg.get("rho_reduction") or {})
+        rr["factor"] = float(rr["factor"])
+        rr["min_rho"] = float(rr["min_rho"])
+        if not (0.0 < rr["factor"] < 1.0):
+            raise ValueError(
+                f"{where}: rho_reduction.factor must be in (0, 1) to reduce "
+                f"rho (got {rr['factor']})")
+        if rr["min_rho"] <= 0.0:
+            raise ValueError(
+                f"{where}: rho_reduction.min_rho must be > 0 (PH requires "
+                f"rho > 0; got {rr['min_rho']})")
+        out["rho_reduction"] = rr
+
+    if action in ("slam", "both"):
+        slam = cfg.get("slam") or {}
+        directives_file = slam.get("directives_file")
+        if not directives_file:
+            raise ValueError(
+                f"{where}: action {action!r} requires "
+                "'slam': {{'directives_file': <path>}}")
+        out["slam"] = {"directives_file": directives_file}
+
+    if "detect" in cfg:
+        out["detect"] = validate_detect_config(
+            cfg["detect"], where=f"{where} (detect block)")
+    return out
+
+
+def reduced_rho(old, factor, min_rho):
+    """Rho after one reduction event: ``old * factor`` floored at ``min_rho``.
+
+    The floor keeps rho strictly positive, which PH requires (see issue #560 /
+    the rho>0 enforcement); reducing rho relaxes the proximal pull that drives
+    the overshoot, the dynamic analogue of Watson--Woodruff §2.1's SEP rho that
+    approaches the optimal weight "from below"."""
+    return max(min_rho, old * factor)
+
+
 # --------------------------------------------------------------------------- #
 # The extension
 # --------------------------------------------------------------------------- #
@@ -282,24 +398,58 @@ _PER_SCEN_COLUMNS = [
 
 
 class WOscillationMonitor(Extension):
-    """Detect (and report) oscillation in the W vector; see the module docstring.
+    """Detect, report, and optionally interrupt W-vector oscillation; see the
+    module docstring.
 
     Constructed from ``opt.options["w_oscillation_options"]``, a dict with:
 
     ``detect_config`` (dict) or ``detect_json`` (path)
-        the parsed control dict, or a path parsed with
+        the parsed detection control dict, or a path parsed with
         :func:`parse_detect_config`.
+    ``interrupt_config`` (dict) or ``interrupt_json`` (path)
+        (optional) the parsed interruption control dict, or a path parsed with
+        :func:`parse_interrupt_config`.  Its presence turns on interruption.
     ``verbose`` (bool, default False)
-        print a rank-0 summary line at the end.
+        print rank-0 summary lines.
+
+    At least one of detection / interruption must be configured.  When only
+    interruption is configured, the detection config is taken from the
+    interrupt file's optional ``detect`` block, else a default
+    (:func:`default_detect_config`).
     """
 
     def __init__(self, spobj):
         super().__init__(spobj)
         opts = spobj.options.get("w_oscillation_options", {})
+
+        # Detection config (direct dict, by path, or -- below -- derived from
+        # the interrupt config).
+        self.cfg = None
         if "detect_config" in opts:
             self.cfg = validate_detect_config(opts["detect_config"])
-        else:
+        elif opts.get("detect_json"):
             self.cfg = parse_detect_config(opts["detect_json"])
+
+        # Interruption config (PR2); None when only detecting.
+        self._interrupt_cfg = None
+        if "interrupt_config" in opts:
+            self._interrupt_cfg = validate_interrupt_config(
+                opts["interrupt_config"])
+        elif opts.get("interrupt_json"):
+            self._interrupt_cfg = parse_interrupt_config(opts["interrupt_json"])
+
+        # Interruption implies detection: derive a detection config if none was
+        # supplied directly.
+        if self.cfg is None:
+            if self._interrupt_cfg is not None and "detect" in self._interrupt_cfg:
+                self.cfg = self._interrupt_cfg["detect"]
+            elif self._interrupt_cfg is not None:
+                self.cfg = default_detect_config()
+            else:
+                raise ValueError(
+                    "WOscillationMonitor requires a detection or interruption "
+                    "control file (none supplied)")
+
         self.verbose = opts.get("verbose", False)
 
         self._methods = self.cfg["methods"]
@@ -325,6 +475,13 @@ class WOscillationMonitor(Extension):
         self._scen_writer = None
         self._scen_file = None
         self._n_flag_events = 0
+
+        # Interruption state (PR2), built in pre_iter0() / updated in miditer().
+        self._slammer = None        # internal Slammer for the slam action
+        self._n_action_events = 0
+        # j -> max scenarios flagging nonant j on the most recent evaluation
+        # (rank-identical; the interrupter reads this).
+        self._flagged_counts = {}
 
     @property
     def _is_writer(self):
@@ -368,6 +525,19 @@ class WOscillationMonitor(Extension):
                 self._recur[j] = RecurrenceTracker(window=hp["window"],
                                                    min_period=hp["min_period"])
 
+        # For the slam action, drive the existing Slammer action layer (the
+        # consumer the slamming design anticipated).  Construct it directly (not
+        # via the extension machinery) and call its pre_iter0() here, on every
+        # rank symmetrically; its iteration-count trigger is never used -- the
+        # interrupter calls slam_nonant() on exactly the flagged nonants.
+        if self._interrupt_cfg is not None \
+                and self._interrupt_cfg["action"] in ("slam", "both"):
+            self._slammer = Slammer(self.opt, options={
+                "directives_file": self._interrupt_cfg["slam"]["directives_file"],
+                "verbose": self.verbose,
+            })
+            self._slammer.pre_iter0()
+
         if self._is_writer:
             self._agg_file = open(self.cfg["output_csv"], "w", newline="")
             self._agg_writer = csv.writer(self._agg_file)
@@ -392,24 +562,59 @@ class WOscillationMonitor(Extension):
             if len(buf) > self._history:
                 buf.pop(0)
 
+    def _detect_due(self, phiter):
+        """Whether to run the detectors for *reporting* at ``phiter``: at or
+        after ``warmup_iters``, then every ``check_every`` iterations.  A pure
+        function of the iteration counter, so it is identical on every rank."""
+        w = self.cfg["warmup_iters"]
+        if phiter < w:
+            return False
+        return (phiter - w) % self.cfg["check_every"] == 0
+
+    def _act_due(self, phiter):
+        """Whether to *interrupt* at ``phiter`` (interruption configured): at or
+        after the trigger's ``start_iter``, then every ``iters_between_actions``.
+        Pure function of the counter -> identical on every rank."""
+        t = self._interrupt_cfg["trigger"]
+        if phiter < t["start_iter"]:
+            return False
+        return (phiter - t["start_iter"]) % t["iters_between_actions"] == 0
+
     def miditer(self):
         self._capture()
         phiter = self.opt._PHIter
-        if phiter < self.cfg["warmup_iters"]:
+        detect_due = self._detect_due(phiter)
+        act_due = self._interrupt_cfg is not None and self._act_due(phiter)
+        if not (detect_due or act_due):
             return
-        if (phiter - self.cfg["warmup_iters"]) % self.cfg["check_every"] != 0:
-            return
-        self._evaluate_and_report(phiter)
+        # Evaluate the detectors (always populates the rank-identical flagged
+        # counts the interrupter reads; emits report rows only on a detection
+        # check).  The decision to evaluate is a pure function of phiter, so the
+        # collective reductions inside fire symmetrically on every rank.
+        flagged = self._evaluate(phiter, emit=detect_due)
+        if act_due:
+            self._apply_interruption(phiter, flagged)
 
     # ------------------------------------------------------------------ #
-    def _evaluate_and_report(self, phiter):
-        """Run the active detectors, reduce across scenarios per node, and emit
-        rows for nonants that meet the reporting threshold."""
+    def _evaluate(self, phiter, emit=True):
+        """Run the active detectors, reduce across scenarios per node, and (if
+        ``emit``) write report rows for nonants meeting the reporting threshold.
+
+        Returns the per-nonant flagged-scenario counts ``{j: count}`` (the
+        rank-identical SUM reduction; for method B the participating scenario
+        count), regardless of ``emit``, for the interrupter's own threshold."""
         nJ = len(self._ndn_i)
+        self._flagged_counts = {}
         if "zero_crossings" in self._methods:
-            self._eval_zero_crossings(phiter, nJ)
+            self._eval_zero_crossings(phiter, nJ, emit)
         if "w_hash_recurrence" in self._methods:
-            self._eval_w_hash(phiter, nJ)
+            self._eval_w_hash(phiter, nJ, emit)
+        return self._flagged_counts
+
+    def _record_flagged(self, j, count):
+        """Record (max over methods) how many scenarios flagged nonant ``j``."""
+        if count > self._flagged_counts.get(j, 0):
+            self._flagged_counts[j] = count
 
     def _threshold(self, ndn):
         frac = self.cfg["min_frac_to_report"]
@@ -417,7 +622,7 @@ class WOscillationMonitor(Extension):
             return max(1, int(np.ceil(frac * self._n_scen_total[ndn])))
         return int(self.cfg["min_scenarios_to_report"])
 
-    def _eval_zero_crossings(self, phiter, nJ):
+    def _eval_zero_crossings(self, phiter, nJ, emit=True):
         p = self._methods["zero_crossings"]
         # local per-nonant accumulators
         n_flag = np.zeros(nJ, "i")
@@ -451,15 +656,17 @@ class WOscillationMonitor(Extension):
             nJ, [(n_flag, MPI.SUM), (mx_w, MPI.MAX),
                  (mx_d, MPI.MAX), (mx_r, MPI.MAX)])
         for j in range(nJ):
-            if g_flag[j] >= self._threshold(self._nodes[j]):
+            self._record_flagged(j, int(g_flag[j]))
+            if emit and g_flag[j] >= self._threshold(self._nodes[j]):
                 self._emit_agg(phiter, j, "zero_crossings",
                                int(g_flag[j]),
                                max_w_crossings=int(g_w[j]),
                                max_diff_crossings=int(g_d[j]),
                                max_diffs_ratio=round(float(g_r[j]), 6))
-        self._emit_scen(scen_rows)
+        if emit:
+            self._emit_scen(scen_rows)
 
-    def _eval_w_hash(self, phiter, nJ):
+    def _eval_w_hash(self, phiter, nJ, emit=True):
         p = self._methods["w_hash_recurrence"]
         q = p["quantum"]
         # local partial signature per nonant (sum of identity-mixed hashes)
@@ -476,20 +683,94 @@ class WOscillationMonitor(Extension):
         for j in range(nJ):
             flagged, period = self._recur[j].push(int(glob[j]))
             if flagged and period >= self._threshold_period():
-                self._emit_agg(phiter, j, "w_hash_recurrence",
-                               self._n_scen_total[self._nodes[j]],
-                               cycle_period=period)
-                if self.cfg["per_scenario_csv"]:
-                    for sname, s in self.opt.local_scenarios.items():
-                        scen_rows.append((
-                            phiter, self._nodes[j], sname, self._names[j],
-                            "w_hash_recurrence", "", "", "",
-                            round(float(s._mpisppy_model.W[self._ndn_i[j]]._value),
-                                  9)))
-        self._emit_scen(scen_rows)
+                # A recurring vector implicates every scenario at the node.
+                self._record_flagged(j, self._n_scen_total[self._nodes[j]])
+                if emit:
+                    self._emit_agg(phiter, j, "w_hash_recurrence",
+                                   self._n_scen_total[self._nodes[j]],
+                                   cycle_period=period)
+                    if self.cfg["per_scenario_csv"]:
+                        for sname, s in self.opt.local_scenarios.items():
+                            scen_rows.append((
+                                phiter, self._nodes[j], sname, self._names[j],
+                                "w_hash_recurrence", "", "", "",
+                                round(float(
+                                    s._mpisppy_model.W[self._ndn_i[j]]._value),
+                                    9)))
+        if emit:
+            self._emit_scen(scen_rows)
 
     def _threshold_period(self):
         return self._methods["w_hash_recurrence"]["min_period"]
+
+    # ------------------------------------------------------------------ #
+    # Interruption (PR2): act on the flagged nonants to break the oscillation.
+    # ------------------------------------------------------------------ #
+    def _apply_interruption(self, phiter, flagged):
+        """Act on every nonant flagged by at least ``min_scenarios_flagged``
+        scenarios: reduce its rho and/or slam it, per the configured action.
+
+        ``flagged`` and the eligibility tests are rank-identical, so all ranks
+        act on the same nonants in the same order -- this matters because the
+        slam action may trigger a per-node ``Allreduce`` (the min/max extremum),
+        which must be reached symmetrically."""
+        thresh = self._interrupt_cfg["trigger"]["min_scenarios_flagged"]
+        targets = [j for j in range(len(self._ndn_i))
+                   if flagged.get(j, 0) >= thresh]
+        if not targets:
+            return
+        action = self._interrupt_cfg["action"]
+        n_rho = self._reduce_rho(targets) if action in ("rho_reduction", "both") \
+            else 0
+        n_slam = self._slam_targets(targets) if action in ("slam", "both") \
+            else 0
+        self._n_action_events += 1
+        if self.verbose and self.opt.cylinder_rank == 0:
+            bits = []
+            if action in ("rho_reduction", "both"):
+                bits.append(f"reduced rho on {n_rho} nonant(s)")
+            if action in ("slam", "both"):
+                bits.append(f"slammed {n_slam} nonant(s)")
+            print(f"(rank0) WOscillationMonitor[iter {phiter}]: "
+                  f"{len(targets)} flagged; " + "; ".join(bits))
+
+    def _reduce_rho(self, targets):
+        """Multiply each flagged nonant's rho by ``factor`` (floored at
+        ``min_rho``) in every local scenario; return the number of nonants
+        whose rho was actually lowered.
+
+        rho is a mutable Pyomo Param in the prox term, so changing its value is
+        picked up by the per-iteration ``set_objective`` that ``solve_one``
+        issues for persistent solvers -- no explicit solver push is needed (the
+        same mechanism the rho-updating extensions rely on)."""
+        rr = self._interrupt_cfg["rho_reduction"]
+        factor, min_rho = rr["factor"], rr["min_rho"]
+        touched = 0
+        for j in targets:
+            ndn_i = self._ndn_i[j]
+            changed = False
+            for s in self.opt.local_scenarios.values():
+                rho = s._mpisppy_model.rho
+                if ndn_i not in rho:
+                    continue  # scenario does not pass through this node
+                r = rho[ndn_i]
+                new = reduced_rho(pyo.value(r), factor, min_rho)
+                if new < pyo.value(r):
+                    r._value = new
+                    changed = True
+            if changed:
+                touched += 1
+        return touched
+
+    def _slam_targets(self, targets):
+        """Slam each flagged nonant via the Slammer action layer; return the
+        number actually slammed (others are not in the directives, already
+        fixed, or have no applicable direction this event)."""
+        n = 0
+        for j in targets:
+            if self._slammer.slam_nonant(self._ndn_i[j]):
+                n += 1
+        return n
 
     # ------------------------------------------------------------------ #
     def _reduce_per_node(self, nJ, arrays_and_ops):
@@ -560,12 +841,16 @@ class WOscillationMonitor(Extension):
     # ------------------------------------------------------------------ #
     def post_everything(self):
         if self.cfg["report_mode"] == "final":
-            self._evaluate_and_report(self.opt._PHIter)
+            self._evaluate(self.opt._PHIter)
         if self._is_writer:
             if self._agg_file is not None:
                 self._agg_file.close()
             if self._scen_file is not None:
                 self._scen_file.close()
         if self.verbose and self.opt.cylinder_rank == 0:
-            print(f"(rank0) WOscillationMonitor: {self._n_flag_events} "
-                  f"oscillation report event(s); see {self.cfg['output_csv']}")
+            msg = (f"(rank0) WOscillationMonitor: {self._n_flag_events} "
+                   f"oscillation report event(s); see {self.cfg['output_csv']}")
+            if self._interrupt_cfg is not None:
+                msg += (f"; {self._n_action_events} interruption action "
+                        f"event(s) [{self._interrupt_cfg['action']}]")
+            print(msg)

--- a/mpisppy/generic/extensions.py
+++ b/mpisppy/generic/extensions.py
@@ -45,7 +45,8 @@ def configure_extensions(hub_dict, module, cfg):
     if cfg.slamming_directives_file is not None:
         vanilla.add_slammer(hub_dict, cfg)
 
-    if cfg.detect_W_oscillations is not None:
+    if cfg.detect_W_oscillations is not None \
+            or cfg.interrupt_W_oscillations is not None:
         vanilla.add_w_oscillation(hub_dict, cfg)
 
     if cfg.grad_rho:

--- a/mpisppy/tests/test_w_oscillation.py
+++ b/mpisppy/tests/test_w_oscillation.py
@@ -311,6 +311,19 @@ class TestInterruptConfigValidation(unittest.TestCase):
         self.assertIn("zero_crossings", d["methods"])
         self.assertIn("w_hash_recurrence", d["methods"])
 
+    def test_non_object_subblock_rejected(self):
+        # a sub-block supplied as something other than a JSON object must give a
+        # clear ValueError (naming the field), not a low-level TypeError from
+        # the subsequent dict.update()
+        for action, key, block in (
+            ("w_damping", "trigger", [1, 2]),
+            ("w_damping", "w_damping", "0.5"),
+            ("slam", "slam", ["file.txt"]),
+        ):
+            with self.assertRaises(ValueError) as ctx:
+                wosc.validate_interrupt_config({"action": action, key: block})
+            self.assertIn(key, str(ctx.exception))
+
 
 @unittest.skipIf(not solver_available, "no MIP solver available")
 class TestEndToEndInterrupt(unittest.TestCase):

--- a/mpisppy/tests/test_w_oscillation.py
+++ b/mpisppy/tests/test_w_oscillation.py
@@ -346,6 +346,50 @@ class TestEndToEndInterrupt(unittest.TestCase):
             self.assertIn("DevotedAcreage[SUGAR_BEETS", out)
             self.assertIn("reduced rho on", out)
 
+    def test_interrupt_without_request_writes_no_report(self):
+        """A pure --interrupt-W-oscillations run (no --detect flag, no detect
+        block) runs the detection engine to drive the actions but writes **no**
+        cycling report CSV; the report is opt-in."""
+        with tempfile.TemporaryDirectory() as tmp:
+            ctrl = os.path.join(tmp, "interrupt.json")
+            with open(ctrl, "w") as f:
+                json.dump({
+                    "action": "rho_reduction",
+                    "trigger": {"start_iter": 3, "iters_between_actions": 1},
+                    "rho_reduction": {"factor": 0.5, "min_rho": 1e-3},
+                }, f)
+
+            argv = [
+                "generic_cylinders",
+                "--module-name", "mpisppy.tests.examples.farmer",
+                "--num-scens", "3",
+                "--solver-name", solver_name,
+                "--max-solver-threads", "1",
+                "--max-iterations", "6",
+                "--default-rho", "1",
+                "--verbose",
+                "--interrupt-W-oscillations", ctrl,
+            ]
+            # The default detector's output_csv is a bare filename, so run from
+            # the temp dir and confirm no such file is created there.
+            cwd = os.getcwd()
+            buf = io.StringIO()
+            try:
+                os.chdir(tmp)
+                with patch.object(sys, "argv", argv), \
+                        contextlib.redirect_stdout(buf):
+                    runpy.run_module("mpisppy.generic_cylinders",
+                                     run_name="__main__")
+            finally:
+                os.chdir(cwd)
+            out = buf.getvalue()
+
+            self.assertFalse(
+                os.path.exists(os.path.join(tmp, "w_oscillations.csv")),
+                "report CSV was written without an explicit detection request")
+            # The opt-in report being off is reported in the verbose summary.
+            self.assertIn("report disabled", out)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/mpisppy/tests/test_w_oscillation.py
+++ b/mpisppy/tests/test_w_oscillation.py
@@ -6,13 +6,18 @@
 # All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
 # full copyright and license information.
 ###############################################################################
-"""Tests for the W-oscillation detection extension (PR1).
+"""Tests for the W-oscillation detection and interruption extension.
 
 The pure detector logic (zero-crossing counting, the W-vector signature, and the
-recurrence tracker) is tested directly with no MPI; an end-to-end test confirms
-the ``--detect-W-oscillations`` flag wires the extension in and writes the CSV.
+recurrence tracker) and the config validators (detection and interruption) are
+tested directly with no MPI; end-to-end tests confirm that
+``--detect-W-oscillations`` wires the extension in and writes the CSV (PR1) and
+that ``--interrupt-W-oscillations`` drives the rho-reduction and slam action
+layers through a real PH run (PR2).
 """
+import contextlib
 import csv
+import io
 import json
 import os
 import sys
@@ -196,6 +201,150 @@ class TestEndToEnd(unittest.TestCase):
                 self.assertIn(row[3], wosc.VALID_METHODS)
                 # full variable name, not an index tuple
                 self.assertIn("DevotedAcreage", row[2])
+
+
+class TestReducedRho(unittest.TestCase):
+    def test_multiplies(self):
+        self.assertEqual(wosc.reduced_rho(1.0, 0.5, 1e-3), 0.5)
+        self.assertAlmostEqual(wosc.reduced_rho(0.1, 0.1, 1e-3), 0.01)
+
+    def test_floors_at_min_rho(self):
+        # below the floor after scaling -> clamped to min_rho (stays > 0)
+        self.assertEqual(wosc.reduced_rho(1e-3, 0.5, 1e-3), 1e-3)
+        self.assertEqual(wosc.reduced_rho(1e-6, 0.5, 1e-3), 1e-3)
+
+
+class TestInterruptConfigValidation(unittest.TestCase):
+    def test_action_required_and_known(self):
+        with self.assertRaises(ValueError):
+            wosc.validate_interrupt_config({})
+        with self.assertRaises(ValueError):
+            wosc.validate_interrupt_config({"action": "bogus"})
+
+    def test_factor_must_reduce(self):
+        for bad in (0.0, 1.0, 1.5, -0.5):
+            with self.assertRaises(ValueError):
+                wosc.validate_interrupt_config(
+                    {"action": "rho_reduction",
+                     "rho_reduction": {"factor": bad, "min_rho": 1e-3}})
+
+    def test_min_rho_must_be_positive(self):
+        with self.assertRaises(ValueError):
+            wosc.validate_interrupt_config(
+                {"action": "rho_reduction",
+                 "rho_reduction": {"factor": 0.5, "min_rho": 0.0}})
+
+    def test_slam_requires_directives_file(self):
+        with self.assertRaises(ValueError):
+            wosc.validate_interrupt_config({"action": "slam"})
+        with self.assertRaises(ValueError):
+            wosc.validate_interrupt_config({"action": "slam", "slam": {}})
+
+    def test_both_requires_both_sections(self):
+        # 'both' needs a valid slam directives file even with rho defaults
+        with self.assertRaises(ValueError):
+            wosc.validate_interrupt_config({"action": "both"})
+        cfg = wosc.validate_interrupt_config(
+            {"action": "both", "slam": {"directives_file": "d.csv"}})
+        self.assertIn("rho_reduction", cfg)
+        self.assertIn("slam", cfg)
+
+    def test_trigger_defaults_and_validation(self):
+        cfg = wosc.validate_interrupt_config({"action": "rho_reduction"})
+        self.assertEqual(cfg["trigger"]["start_iter"], 5)
+        self.assertEqual(cfg["trigger"]["iters_between_actions"], 3)
+        self.assertEqual(cfg["rho_reduction"]["factor"], 0.5)
+        with self.assertRaises(ValueError):
+            wosc.validate_interrupt_config(
+                {"action": "rho_reduction",
+                 "trigger": {"iters_between_actions": 0}})
+
+    def test_detect_block_parsed(self):
+        cfg = wosc.validate_interrupt_config({
+            "action": "rho_reduction",
+            "detect": {"output_csv": "x.csv",
+                       "methods": {"zero_crossings": {}}},
+        })
+        self.assertIn("detect", cfg)
+        self.assertEqual(cfg["detect"]["output_csv"], "x.csv")
+
+    def test_default_detect_config(self):
+        d = wosc.default_detect_config()
+        self.assertEqual(d["output_csv"], "w_oscillations.csv")
+        self.assertIn("zero_crossings", d["methods"])
+        self.assertIn("w_hash_recurrence", d["methods"])
+
+
+@unittest.skipIf(not solver_available, "no MIP solver available")
+class TestEndToEndInterrupt(unittest.TestCase):
+    """--interrupt-W-oscillations drives the rho-reduction and slam actions.
+
+    Uses only the interrupt flag (no --detect-W-oscillations) with an inline
+    ``detect`` block, so it also exercises the "interruption implies detection"
+    path.  Thresholds are set low so the detector flags the acreage nonants
+    early; the slam directive targets a single crop and fixes it to its lower
+    bound (0 acres), which is always feasible for farmer."""
+
+    def test_interrupt_flag_reduces_rho_and_slams(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out_csv = os.path.join(tmp, "wosc.csv")
+            slam_csv = os.path.join(tmp, "slam.csv")
+            # farmer's crop names carry a group suffix (SUGAR_BEETS0, ...), so
+            # match with a wildcard ('[' / ']' are literal in slam globs).
+            with open(slam_csv, "w") as f:
+                f.write("name,can_slam,directions,priority\n")
+                f.write("DevotedAcreage[SUGAR_BEETS*],1,lb,1\n")
+            ctrl = os.path.join(tmp, "interrupt.json")
+            with open(ctrl, "w") as f:
+                json.dump({
+                    "action": "both",
+                    "trigger": {"min_scenarios_flagged": 1, "start_iter": 3,
+                                "iters_between_actions": 1},
+                    "rho_reduction": {"factor": 0.5, "min_rho": 1e-3},
+                    "slam": {"directives_file": slam_csv},
+                    "detect": {
+                        "output_csv": out_csv,
+                        "warmup_iters": 2,
+                        "report_mode": "every_check",
+                        "methods": {
+                            "zero_crossings": {"thresh_w_crossings": 1,
+                                               "thresh_diff_crossings": 1,
+                                               "thresh_diffs_ratio": 0.0},
+                        },
+                    },
+                }, f)
+
+            argv = [
+                "generic_cylinders",
+                "--module-name", "mpisppy.tests.examples.farmer",
+                "--num-scens", "3",
+                "--solver-name", solver_name,
+                "--max-solver-threads", "1",
+                "--max-iterations", "8",
+                "--default-rho", "1",
+                "--verbose",
+                "--interrupt-W-oscillations", ctrl,
+            ]
+            buf = io.StringIO()
+            with patch.object(sys, "argv", argv), \
+                    contextlib.redirect_stdout(buf):
+                runpy.run_module("mpisppy.generic_cylinders",
+                                 run_name="__main__")
+            out = buf.getvalue()
+
+            # Detection still happened (implied by interruption): CSV written.
+            self.assertTrue(os.path.exists(out_csv),
+                            "detection CSV not written under interrupt mode")
+            with open(out_csv) as f:
+                rows = list(csv.reader(f))
+            self.assertEqual(rows[0], wosc._AGG_COLUMNS)
+            self.assertTrue(any("DevotedAcreage" in r[2] for r in rows[1:]))
+
+            # Both action layers fired: the Slammer slammed the targeted crop
+            # and the monitor reduced rho on the flagged nonants.
+            self.assertIn("Slammer: slammed", out)
+            self.assertIn("DevotedAcreage[SUGAR_BEETS", out)
+            self.assertIn("reduced rho on", out)
 
 
 if __name__ == "__main__":

--- a/mpisppy/tests/test_w_oscillation.py
+++ b/mpisppy/tests/test_w_oscillation.py
@@ -12,7 +12,7 @@ The pure detector logic (zero-crossing counting, the W-vector signature, and the
 recurrence tracker) and the config validators (detection and interruption) are
 tested directly with no MPI; end-to-end tests confirm that
 ``--detect-W-oscillations`` wires the extension in and writes the CSV (PR1) and
-that ``--interrupt-W-oscillations`` drives the rho-reduction and slam action
+that ``--interrupt-W-oscillations`` drives the W-damping and slam action
 layers through a real PH run (PR2).
 """
 import contextlib
@@ -203,15 +203,26 @@ class TestEndToEnd(unittest.TestCase):
                 self.assertIn("DevotedAcreage", row[2])
 
 
-class TestReducedRho(unittest.TestCase):
-    def test_multiplies(self):
-        self.assertEqual(wosc.reduced_rho(1.0, 0.5, 1e-3), 0.5)
-        self.assertAlmostEqual(wosc.reduced_rho(0.1, 0.1, 1e-3), 0.01)
+class TestWDamped(unittest.TestCase):
+    def test_rescales_increment(self):
+        # Update_W applied W = w0 + rho*xdiff; damping to factor keeps only
+        # factor of that increment.
+        rho, xdiff, w0 = 2.0, 0.5, 10.0
+        w_after_update = w0 + rho * xdiff                  # 11.0
+        # factor=0.5 -> half the step -> w0 + 0.5*rho*xdiff = 10.5
+        self.assertAlmostEqual(
+            wosc.w_damped(w_after_update, rho, xdiff, 0.5), 10.5)
 
-    def test_floors_at_min_rho(self):
-        # below the floor after scaling -> clamped to min_rho (stays > 0)
-        self.assertEqual(wosc.reduced_rho(1e-3, 0.5, 1e-3), 1e-3)
-        self.assertEqual(wosc.reduced_rho(1e-6, 0.5, 1e-3), 1e-3)
+    def test_factor_zero_cancels_step(self):
+        rho, xdiff, w0 = 3.0, -0.4, 1.0
+        w_after_update = w0 + rho * xdiff
+        # factor=0 fully undoes the increment -> back to w0
+        self.assertAlmostEqual(
+            wosc.w_damped(w_after_update, rho, xdiff, 0.0), w0)
+
+    def test_zero_xdiff_is_inert(self):
+        # at a fixed point x == xbar -> no change regardless of factor
+        self.assertEqual(wosc.w_damped(5.0, 2.0, 0.0, 0.5), 5.0)
 
 
 class TestInterruptConfigValidation(unittest.TestCase):
@@ -221,18 +232,16 @@ class TestInterruptConfigValidation(unittest.TestCase):
         with self.assertRaises(ValueError):
             wosc.validate_interrupt_config({"action": "bogus"})
 
-    def test_factor_must_reduce(self):
-        for bad in (0.0, 1.0, 1.5, -0.5):
+    def test_factor_must_be_in_range(self):
+        # 1.0 is a no-op and >1 / <0 are nonsense: all rejected.
+        for bad in (1.0, 1.5, -0.5):
             with self.assertRaises(ValueError):
                 wosc.validate_interrupt_config(
-                    {"action": "rho_reduction",
-                     "rho_reduction": {"factor": bad, "min_rho": 1e-3}})
-
-    def test_min_rho_must_be_positive(self):
-        with self.assertRaises(ValueError):
-            wosc.validate_interrupt_config(
-                {"action": "rho_reduction",
-                 "rho_reduction": {"factor": 0.5, "min_rho": 0.0}})
+                    {"action": "w_damping", "w_damping": {"factor": bad}})
+        # 0.0 is allowed (fully cancels the dual step that iteration).
+        cfg = wosc.validate_interrupt_config(
+            {"action": "w_damping", "w_damping": {"factor": 0.0}})
+        self.assertEqual(cfg["w_damping"]["factor"], 0.0)
 
     def test_slam_requires_directives_file(self):
         with self.assertRaises(ValueError):
@@ -241,27 +250,28 @@ class TestInterruptConfigValidation(unittest.TestCase):
             wosc.validate_interrupt_config({"action": "slam", "slam": {}})
 
     def test_both_requires_both_sections(self):
-        # 'both' needs a valid slam directives file even with rho defaults
+        # 'both' needs a valid slam directives file even with w_damping defaults
         with self.assertRaises(ValueError):
             wosc.validate_interrupt_config({"action": "both"})
         cfg = wosc.validate_interrupt_config(
             {"action": "both", "slam": {"directives_file": "d.csv"}})
-        self.assertIn("rho_reduction", cfg)
+        self.assertIn("w_damping", cfg)
         self.assertIn("slam", cfg)
 
     def test_trigger_defaults_and_validation(self):
-        cfg = wosc.validate_interrupt_config({"action": "rho_reduction"})
+        cfg = wosc.validate_interrupt_config({"action": "w_damping"})
         self.assertEqual(cfg["trigger"]["start_iter"], 5)
-        self.assertEqual(cfg["trigger"]["iters_between_actions"], 3)
-        self.assertEqual(cfg["rho_reduction"]["factor"], 0.5)
+        # the inter-action cadence knob was dropped
+        self.assertNotIn("iters_between_actions", cfg["trigger"])
+        self.assertEqual(cfg["w_damping"]["factor"], 0.5)
         with self.assertRaises(ValueError):
             wosc.validate_interrupt_config(
-                {"action": "rho_reduction",
-                 "trigger": {"iters_between_actions": 0}})
+                {"action": "w_damping",
+                 "trigger": {"min_scenarios_flagged": 0}})
 
     def test_detect_block_parsed(self):
         cfg = wosc.validate_interrupt_config({
-            "action": "rho_reduction",
+            "action": "w_damping",
             "detect": {"output_csv": "x.csv",
                        "methods": {"zero_crossings": {}}},
         })
@@ -277,7 +287,7 @@ class TestInterruptConfigValidation(unittest.TestCase):
 
 @unittest.skipIf(not solver_available, "no MIP solver available")
 class TestEndToEndInterrupt(unittest.TestCase):
-    """--interrupt-W-oscillations drives the rho-reduction and slam actions.
+    """--interrupt-W-oscillations drives the W-damping and slam actions.
 
     Uses only the interrupt flag (no --detect-W-oscillations) with an inline
     ``detect`` block, so it also exercises the "interruption implies detection"
@@ -285,7 +295,7 @@ class TestEndToEndInterrupt(unittest.TestCase):
     early; the slam directive targets a single crop and fixes it to its lower
     bound (0 acres), which is always feasible for farmer."""
 
-    def test_interrupt_flag_reduces_rho_and_slams(self):
+    def test_interrupt_flag_damps_w_and_slams(self):
         with tempfile.TemporaryDirectory() as tmp:
             out_csv = os.path.join(tmp, "wosc.csv")
             slam_csv = os.path.join(tmp, "slam.csv")
@@ -298,9 +308,8 @@ class TestEndToEndInterrupt(unittest.TestCase):
             with open(ctrl, "w") as f:
                 json.dump({
                     "action": "both",
-                    "trigger": {"min_scenarios_flagged": 1, "start_iter": 3,
-                                "iters_between_actions": 1},
-                    "rho_reduction": {"factor": 0.5, "min_rho": 1e-3},
+                    "trigger": {"min_scenarios_flagged": 1, "start_iter": 3},
+                    "w_damping": {"factor": 0.5},
                     "slam": {"directives_file": slam_csv},
                     "detect": {
                         "output_csv": out_csv,
@@ -341,10 +350,12 @@ class TestEndToEndInterrupt(unittest.TestCase):
             self.assertTrue(any("DevotedAcreage" in r[2] for r in rows[1:]))
 
             # Both action layers fired: the Slammer slammed the targeted crop
-            # and the monitor reduced rho on the flagged nonants.
+            # and the monitor damped W on the flagged nonants.
             self.assertIn("Slammer: slammed", out)
             self.assertIn("DevotedAcreage[SUGAR_BEETS", out)
-            self.assertIn("reduced rho on", out)
+            self.assertIn("damped W on", out)
+            # slam fixes at most one nonant per acting iteration
+            self.assertIn("slammed 1 nonant(s)", out)
 
     def test_interrupt_without_request_writes_no_report(self):
         """A pure --interrupt-W-oscillations run (no --detect flag, no detect
@@ -354,9 +365,9 @@ class TestEndToEndInterrupt(unittest.TestCase):
             ctrl = os.path.join(tmp, "interrupt.json")
             with open(ctrl, "w") as f:
                 json.dump({
-                    "action": "rho_reduction",
-                    "trigger": {"start_iter": 3, "iters_between_actions": 1},
-                    "rho_reduction": {"factor": 0.5, "min_rho": 1e-3},
+                    "action": "w_damping",
+                    "trigger": {"start_iter": 3},
+                    "w_damping": {"factor": 0.5},
                 }, f)
 
             argv = [

--- a/mpisppy/tests/test_w_oscillation.py
+++ b/mpisppy/tests/test_w_oscillation.py
@@ -253,6 +253,12 @@ class TestInterruptConfigValidation(unittest.TestCase):
             wosc.validate_interrupt_config(
                 {"action": "slam", "slam": {"directives_file": "d.csv"},
                  "trigger": {"min_scenarios_flagged": 0}})
+        # a negative start_iter would make interruption eligible from
+        # iteration 0 (_act_due is phiter >= start_iter) -- reject it
+        with self.assertRaises(ValueError):
+            wosc.validate_interrupt_config(
+                {"action": "slam", "slam": {"directives_file": "d.csv"},
+                 "trigger": {"start_iter": -1}})
 
     def test_detect_block_parsed(self):
         cfg = wosc.validate_interrupt_config({

--- a/mpisppy/tests/test_w_oscillation.py
+++ b/mpisppy/tests/test_w_oscillation.py
@@ -249,6 +249,32 @@ class TestInterruptConfigValidation(unittest.TestCase):
         with self.assertRaises(ValueError):
             wosc.validate_interrupt_config({"action": "slam", "slam": {}})
 
+    def test_slam_cooldown_defaults_and_validation(self):
+        # default fills in; explicit value is kept; < 1 is rejected.
+        cfg = wosc.validate_interrupt_config(
+            {"action": "slam", "slam": {"directives_file": "d.csv"}})
+        self.assertEqual(cfg["slam"]["iters_between_slams"], 3)
+        cfg = wosc.validate_interrupt_config(
+            {"action": "slam",
+             "slam": {"directives_file": "d.csv", "iters_between_slams": 10}})
+        self.assertEqual(cfg["slam"]["iters_between_slams"], 10)
+        for bad in (0, -2):
+            with self.assertRaises(ValueError):
+                wosc.validate_interrupt_config(
+                    {"action": "slam",
+                     "slam": {"directives_file": "d.csv",
+                              "iters_between_slams": bad}})
+
+    def test_slam_due_cooldown(self):
+        # No slam yet: always due (start_iter alone gates the first slam).
+        self.assertTrue(wosc.slam_due(5, None, 3))
+        # Slammed at 7 with cooldown 3: not due at 8, 9; due again at 10.
+        self.assertFalse(wosc.slam_due(8, 7, 3))
+        self.assertFalse(wosc.slam_due(9, 7, 3))
+        self.assertTrue(wosc.slam_due(10, 7, 3))
+        # Cooldown 1 reproduces the every-iteration behavior.
+        self.assertTrue(wosc.slam_due(8, 7, 1))
+
     def test_both_requires_both_sections(self):
         # 'both' needs a valid slam directives file even with w_damping defaults
         with self.assertRaises(ValueError):
@@ -261,7 +287,8 @@ class TestInterruptConfigValidation(unittest.TestCase):
     def test_trigger_defaults_and_validation(self):
         cfg = wosc.validate_interrupt_config({"action": "w_damping"})
         self.assertEqual(cfg["trigger"]["start_iter"], 5)
-        # the inter-action cadence knob was dropped
+        # the global inter-action cadence knob was dropped (the slam-specific
+        # cooldown lives in the slam block as iters_between_slams)
         self.assertNotIn("iters_between_actions", cfg["trigger"])
         self.assertEqual(cfg["w_damping"]["factor"], 0.5)
         with self.assertRaises(ValueError):
@@ -310,7 +337,8 @@ class TestEndToEndInterrupt(unittest.TestCase):
                     "action": "both",
                     "trigger": {"min_scenarios_flagged": 1, "start_iter": 3},
                     "w_damping": {"factor": 0.5},
-                    "slam": {"directives_file": slam_csv},
+                    "slam": {"directives_file": slam_csv,
+                             "iters_between_slams": 5},
                     "detect": {
                         "output_csv": out_csv,
                         "warmup_iters": 2,
@@ -354,8 +382,13 @@ class TestEndToEndInterrupt(unittest.TestCase):
             self.assertIn("Slammer: slammed", out)
             self.assertIn("DevotedAcreage[SUGAR_BEETS", out)
             self.assertIn("damped W on", out)
-            # slam fixes at most one nonant per acting iteration
+            # slam fixes at most one nonant per slam event
             self.assertIn("slammed 1 nonant(s)", out)
+            # ... and the cooldown then suppresses further slams while damping
+            # continues (iters_between_slams=5 > the remaining iterations, so
+            # the run ends inside the cooldown).
+            self.assertIn("slam cooling down", out)
+            self.assertEqual(out.count("slammed 1 nonant(s)"), 1)
 
     def test_interrupt_without_request_writes_no_report(self):
         """A pure --interrupt-W-oscillations run (no --detect flag, no detect

--- a/mpisppy/tests/test_w_oscillation.py
+++ b/mpisppy/tests/test_w_oscillation.py
@@ -12,8 +12,8 @@ The pure detector logic (zero-crossing counting, the W-vector signature, and the
 recurrence tracker) and the config validators (detection and interruption) are
 tested directly with no MPI; end-to-end tests confirm that
 ``--detect-W-oscillations`` wires the extension in and writes the CSV (PR1) and
-that ``--interrupt-W-oscillations`` drives the W-damping and slam action
-layers through a real PH run (PR2).
+that ``--interrupt-W-oscillations`` drives the slam action through a real PH run
+(PR2).
 """
 import contextlib
 import csv
@@ -203,45 +203,12 @@ class TestEndToEnd(unittest.TestCase):
                 self.assertIn("DevotedAcreage", row[2])
 
 
-class TestWDamped(unittest.TestCase):
-    def test_rescales_increment(self):
-        # Update_W applied W = w0 + rho*xdiff; damping to factor keeps only
-        # factor of that increment.
-        rho, xdiff, w0 = 2.0, 0.5, 10.0
-        w_after_update = w0 + rho * xdiff                  # 11.0
-        # factor=0.5 -> half the step -> w0 + 0.5*rho*xdiff = 10.5
-        self.assertAlmostEqual(
-            wosc.w_damped(w_after_update, rho, xdiff, 0.5), 10.5)
-
-    def test_factor_zero_cancels_step(self):
-        rho, xdiff, w0 = 3.0, -0.4, 1.0
-        w_after_update = w0 + rho * xdiff
-        # factor=0 fully undoes the increment -> back to w0
-        self.assertAlmostEqual(
-            wosc.w_damped(w_after_update, rho, xdiff, 0.0), w0)
-
-    def test_zero_xdiff_is_inert(self):
-        # at a fixed point x == xbar -> no change regardless of factor
-        self.assertEqual(wosc.w_damped(5.0, 2.0, 0.0, 0.5), 5.0)
-
-
 class TestInterruptConfigValidation(unittest.TestCase):
     def test_action_required_and_known(self):
         with self.assertRaises(ValueError):
             wosc.validate_interrupt_config({})
         with self.assertRaises(ValueError):
             wosc.validate_interrupt_config({"action": "bogus"})
-
-    def test_factor_must_be_in_range(self):
-        # 1.0 is a no-op and >1 / <0 are nonsense: all rejected.
-        for bad in (1.0, 1.5, -0.5):
-            with self.assertRaises(ValueError):
-                wosc.validate_interrupt_config(
-                    {"action": "w_damping", "w_damping": {"factor": bad}})
-        # 0.0 is allowed (fully cancels the dual step that iteration).
-        cfg = wosc.validate_interrupt_config(
-            {"action": "w_damping", "w_damping": {"factor": 0.0}})
-        self.assertEqual(cfg["w_damping"]["factor"], 0.0)
 
     def test_slam_requires_directives_file(self):
         with self.assertRaises(ValueError):
@@ -275,30 +242,22 @@ class TestInterruptConfigValidation(unittest.TestCase):
         # Cooldown 1 reproduces the every-iteration behavior.
         self.assertTrue(wosc.slam_due(8, 7, 1))
 
-    def test_both_requires_both_sections(self):
-        # 'both' needs a valid slam directives file even with w_damping defaults
-        with self.assertRaises(ValueError):
-            wosc.validate_interrupt_config({"action": "both"})
-        cfg = wosc.validate_interrupt_config(
-            {"action": "both", "slam": {"directives_file": "d.csv"}})
-        self.assertIn("w_damping", cfg)
-        self.assertIn("slam", cfg)
-
     def test_trigger_defaults_and_validation(self):
-        cfg = wosc.validate_interrupt_config({"action": "w_damping"})
+        cfg = wosc.validate_interrupt_config(
+            {"action": "slam", "slam": {"directives_file": "d.csv"}})
         self.assertEqual(cfg["trigger"]["start_iter"], 5)
         # the global inter-action cadence knob was dropped (the slam-specific
         # cooldown lives in the slam block as iters_between_slams)
         self.assertNotIn("iters_between_actions", cfg["trigger"])
-        self.assertEqual(cfg["w_damping"]["factor"], 0.5)
         with self.assertRaises(ValueError):
             wosc.validate_interrupt_config(
-                {"action": "w_damping",
+                {"action": "slam", "slam": {"directives_file": "d.csv"},
                  "trigger": {"min_scenarios_flagged": 0}})
 
     def test_detect_block_parsed(self):
         cfg = wosc.validate_interrupt_config({
-            "action": "w_damping",
+            "action": "slam",
+            "slam": {"directives_file": "d.csv"},
             "detect": {"output_csv": "x.csv",
                        "methods": {"zero_crossings": {}}},
         })
@@ -316,8 +275,7 @@ class TestInterruptConfigValidation(unittest.TestCase):
         # clear ValueError (naming the field), not a low-level TypeError from
         # the subsequent dict.update()
         for action, key, block in (
-            ("w_damping", "trigger", [1, 2]),
-            ("w_damping", "w_damping", "0.5"),
+            ("slam", "trigger", [1, 2]),
             ("slam", "slam", ["file.txt"]),
         ):
             with self.assertRaises(ValueError) as ctx:
@@ -327,7 +285,7 @@ class TestInterruptConfigValidation(unittest.TestCase):
 
 @unittest.skipIf(not solver_available, "no MIP solver available")
 class TestEndToEndInterrupt(unittest.TestCase):
-    """--interrupt-W-oscillations drives the W-damping and slam actions.
+    """--interrupt-W-oscillations drives the slam action.
 
     Uses only the interrupt flag (no --detect-W-oscillations) with an inline
     ``detect`` block, so it also exercises the "interruption implies detection"
@@ -335,7 +293,7 @@ class TestEndToEndInterrupt(unittest.TestCase):
     early; the slam directive targets a single crop and fixes it to its lower
     bound (0 acres), which is always feasible for farmer."""
 
-    def test_interrupt_flag_damps_w_and_slams(self):
+    def test_interrupt_flag_slams(self):
         with tempfile.TemporaryDirectory() as tmp:
             out_csv = os.path.join(tmp, "wosc.csv")
             slam_csv = os.path.join(tmp, "slam.csv")
@@ -347,9 +305,8 @@ class TestEndToEndInterrupt(unittest.TestCase):
             ctrl = os.path.join(tmp, "interrupt.json")
             with open(ctrl, "w") as f:
                 json.dump({
-                    "action": "both",
+                    "action": "slam",
                     "trigger": {"min_scenarios_flagged": 1, "start_iter": 3},
-                    "w_damping": {"factor": 0.5},
                     "slam": {"directives_file": slam_csv,
                              "iters_between_slams": 5},
                     "detect": {
@@ -390,17 +347,13 @@ class TestEndToEndInterrupt(unittest.TestCase):
             self.assertEqual(rows[0], wosc._AGG_COLUMNS)
             self.assertTrue(any("DevotedAcreage" in r[2] for r in rows[1:]))
 
-            # Both action layers fired: the Slammer slammed the targeted crop
-            # and the monitor damped W on the flagged nonants.
+            # The slam action fired: the Slammer slammed the targeted crop.
             self.assertIn("Slammer: slammed", out)
             self.assertIn("DevotedAcreage[SUGAR_BEETS", out)
-            self.assertIn("damped W on", out)
-            # slam fixes at most one nonant per slam event
+            # slam fixes at most one nonant per slam event, and the cooldown
+            # (iters_between_slams=5 > the remaining iterations) then suppresses
+            # further slams, so exactly one successful slam occurs.
             self.assertIn("slammed 1 nonant(s)", out)
-            # ... and the cooldown then suppresses further slams while damping
-            # continues (iters_between_slams=5 > the remaining iterations, so
-            # the run ends inside the cooldown).
-            self.assertIn("slam cooling down", out)
             self.assertEqual(out.count("slammed 1 nonant(s)"), 1)
 
     def test_interrupt_without_request_writes_no_report(self):
@@ -408,12 +361,16 @@ class TestEndToEndInterrupt(unittest.TestCase):
         block) runs the detection engine to drive the actions but writes **no**
         cycling report CSV; the report is opt-in."""
         with tempfile.TemporaryDirectory() as tmp:
+            slam_csv = os.path.join(tmp, "slam.csv")
+            with open(slam_csv, "w") as f:
+                f.write("name,can_slam,directions,priority\n")
+                f.write("DevotedAcreage[SUGAR_BEETS*],1,lb,1\n")
             ctrl = os.path.join(tmp, "interrupt.json")
             with open(ctrl, "w") as f:
                 json.dump({
-                    "action": "w_damping",
+                    "action": "slam",
                     "trigger": {"start_iter": 3},
-                    "w_damping": {"factor": 0.5},
+                    "slam": {"directives_file": slam_csv},
                 }, f)
 
             argv = [

--- a/mpisppy/utils/cfg_vanilla.py
+++ b/mpisppy/utils/cfg_vanilla.py
@@ -870,12 +870,14 @@ def add_slammer(hub_dict,
     return hub_dict
 
 def add_w_oscillation(hub_dict, cfg):
-    # W-oscillation detection/reporting; activated only when the detect JSON
-    # control file is supplied (see doc/designs/w_oscillation_design.md).
+    # W-oscillation detection/reporting and (optionally) interruption; activated
+    # when either JSON control file is supplied (see
+    # doc/designs/w_oscillation_design.md).
     from mpisppy.extensions.w_oscillation import WOscillationMonitor
     hub_dict = extension_adder(hub_dict, WOscillationMonitor)
     hub_dict["opt_kwargs"]["options"]["w_oscillation_options"] = {
         "detect_json": cfg.detect_W_oscillations,
+        "interrupt_json": cfg.interrupt_W_oscillations,
         "verbose": cfg.verbose,
     }
     return hub_dict

--- a/mpisppy/utils/config.py
+++ b/mpisppy/utils/config.py
@@ -754,16 +754,26 @@ class Config(pyofig.ConfigDict):
                            default=None)
 
     def w_oscillation_args(self):
-        # Detect oscillation/cycling in the PH W vector and report it to a CSV
-        # (see doc/designs/w_oscillation_design.md). The WOscillationMonitor
-        # extension is activated iff detect_W_oscillations is set; with no
-        # option a run behaves exactly as it does today (pure observation, no
-        # algorithm change). Interruption is a separate piece of work.
+        # Detect (and optionally interrupt) oscillation/cycling in the PH W
+        # vector (see doc/designs/w_oscillation_design.md). The
+        # WOscillationMonitor extension is activated iff either flag is set;
+        # with neither a run behaves exactly as it does today. Detection alone
+        # is pure observation (no algorithm change); interruption acts on the
+        # cycling nonant (rho reduction and/or slamming) and implies detection.
         self.add_to_config("detect_W_oscillations",
                            description="path to a JSON control file for "
                            "W-oscillation detection; its presence activates the "
                            "WOscillationMonitor extension and CSV reporting "
                            "(default None)",
+                           domain=str,
+                           default=None)
+
+        self.add_to_config("interrupt_W_oscillations",
+                           description="path to a JSON control file for "
+                           "W-oscillation interruption (rho reduction and/or "
+                           "slamming); its presence activates the "
+                           "WOscillationMonitor extension in interrupt mode and "
+                           "implies detection (default None)",
                            domain=str,
                            default=None)
 

--- a/mpisppy/utils/config.py
+++ b/mpisppy/utils/config.py
@@ -772,8 +772,10 @@ class Config(pyofig.ConfigDict):
                            description="path to a JSON control file for "
                            "W-oscillation interruption (W-damping and/or "
                            "slamming); its presence activates the "
-                           "WOscillationMonitor extension in interrupt mode and "
-                           "implies detection (default None)",
+                           "WOscillationMonitor extension in interrupt mode, "
+                           "which runs the detection engine to drive the "
+                           "actions (CSV reporting stays opt-in via a 'detect' "
+                           "block) (default None)",
                            domain=str,
                            default=None)
 

--- a/mpisppy/utils/config.py
+++ b/mpisppy/utils/config.py
@@ -759,7 +759,7 @@ class Config(pyofig.ConfigDict):
         # WOscillationMonitor extension is activated iff either flag is set;
         # with neither a run behaves exactly as it does today. Detection alone
         # is pure observation (no algorithm change); interruption acts on the
-        # cycling nonant (rho reduction and/or slamming) and implies detection.
+        # cycling nonants (W-damping and/or slamming) and implies detection.
         self.add_to_config("detect_W_oscillations",
                            description="path to a JSON control file for "
                            "W-oscillation detection; its presence activates the "
@@ -770,7 +770,7 @@ class Config(pyofig.ConfigDict):
 
         self.add_to_config("interrupt_W_oscillations",
                            description="path to a JSON control file for "
-                           "W-oscillation interruption (rho reduction and/or "
+                           "W-oscillation interruption (W-damping and/or "
                            "slamming); its presence activates the "
                            "WOscillationMonitor extension in interrupt mode and "
                            "implies detection (default None)",

--- a/mpisppy/utils/config.py
+++ b/mpisppy/utils/config.py
@@ -759,7 +759,7 @@ class Config(pyofig.ConfigDict):
         # WOscillationMonitor extension is activated iff either flag is set;
         # with neither a run behaves exactly as it does today. Detection alone
         # is pure observation (no algorithm change); interruption acts on the
-        # cycling nonants (W-damping and/or slamming) and implies detection.
+        # cycling nonants (slamming) and implies detection.
         self.add_to_config("detect_W_oscillations",
                            description="path to a JSON control file for "
                            "W-oscillation detection; its presence activates the "
@@ -770,8 +770,8 @@ class Config(pyofig.ConfigDict):
 
         self.add_to_config("interrupt_W_oscillations",
                            description="path to a JSON control file for "
-                           "W-oscillation interruption (W-damping and/or "
-                           "slamming); its presence activates the "
+                           "W-oscillation interruption (slamming); its "
+                           "presence activates the "
                            "WOscillationMonitor extension in interrupt mode, "
                            "which runs the detection engine to drive the "
                            "actions (CSV reporting stays opt-in via a 'detect' "


### PR DESCRIPTION
## What

Scales the W-oscillation **interruption** (PR2) back to **slamming as the only
remedy**.

`--interrupt-W-oscillations` detects W-vector cycling and fixes a cycling
nonanticipative variable (via the existing Slammer action layer), one nonant per
slam event, paced by an `iters_between_slams` cooldown. Detection (PR1, #778) is
unchanged.

## Why slam-only

An earlier revision of this PR also offered a dual-side remedy — first rho
reduction, then a W-step damper (`w_damping`). Experiments on the `sizes` model
showed that **no state-perturbing move breaks the cycle**: W-damping (constant
or randomized), W-reset, and rho reduction all leave the oscillation intact,
decouple the scenarios (the PH primal gap explodes while W merely freezes), or
make it worse. **Only fixing a variable (slam) drives the primal gap down.** The
root cause on `sizes` is that rho is too small (its `_rho_setter` uses
cost × 0.001); a larger rho converges with no interruption at all.

The full empirical study lands in a **separate experiments PR**.

## Changes

- Remove the `w_damping` action: `w_damped()`, `_damp_w()`,
  `_W_DAMPING_DEFAULTS`, and the `both` action; `VALID_ACTIONS = ("slam",)`.
- Slam-only config validation and `_apply_interruption`.
- Tests: drop the W-damping tests; the end-to-end test asserts slam-only
  behavior.
- Config example, CLI help, and docs updated to slam-only. (The detector's
  `diffs_ratio` "damping ratio" statistic is unrelated and kept.)

The `action` field is retained (single-valued `"slam"`) as an extensibility
hook.
