### PR TITLE
Tidy xhat bounders: drop module-scope COMM_WORLD, log with own comm (#782)

### DIFF
--- a/mpisppy/cylinders/xhatspecific_bounder.py
+++ b/mpisppy/cylinders/xhatspecific_bounder.py
@@ -13,12 +13,7 @@ from mpisppy.extensions.xhatspecific import XhatSpecific
 from mpisppy.cylinders.xhatbase import XhatInnerBoundBase
 from mpisppy.cylinders._preloop_xhat_mixin import _PreLoopXhatMixin
 
-import mpisppy.MPI as mpi
 import logging
-
-fullcomm = mpi.COMM_WORLD
-global_rank = fullcomm.Get_rank()
-fullcom_n_proc = fullcomm.Get_size()
 
 
 ############################################################################
@@ -34,8 +29,9 @@ class XhatSpecificInnerBound(_PreLoopXhatMixin, XhatInnerBoundBase):
         Entry point. Communicates with the optimization companion.
 
         """
-        dtm = logging.getLogger(f'dtm{global_rank}')
-        logging.debug("Enter xhatspecific main on rank {}".format(global_rank))
+        rank = self.cylinder_rank
+        dtm = logging.getLogger(f'dtm{rank}')
+        logging.debug("Enter xhatspecific main on rank {}".format(rank))
 
         # What to try does not change, but the data in the scenarios should
         xhat_scenario_dict = self.opt.options["xhat_specific_options"]\
@@ -50,15 +46,15 @@ class XhatSpecificInnerBound(_PreLoopXhatMixin, XhatInnerBoundBase):
 
         ib_iter = 1  # ib is for inner bound
         while (not self.got_kill_signal()):
-            logging.debug('   IB loop iter={} on global rank {}'.\
-                          format(ib_iter, global_rank))
+            logging.debug('   IB loop iter={} on rank {}'.\
+                          format(ib_iter, rank))
             # _log_values(ib_iter, self._locals, dtm)
 
-            logging.debug('   IB got from opt on global rank {}'.\
-                          format(global_rank))
+            logging.debug('   IB got from opt on rank {}'.\
+                          format(rank))
             if self.update_nonants():
-                logging.debug('  and its new! on global rank {}'.\
-                              format(global_rank))
+                logging.debug('  and its new! on rank {}'.\
+                              format(rank))
                 logging.debug('  localnonants={}'.format(str(self.localnonants)))
 
                 self.opt._put_nonant_cache(self.localnonants)  # don't really need all caches

--- a/mpisppy/cylinders/xhatxbar_bounder.py
+++ b/mpisppy/cylinders/xhatxbar_bounder.py
@@ -14,12 +14,7 @@ from mpisppy.extensions.xhatxbar import XhatXbar
 from mpisppy.cylinders.xhatbase import XhatInnerBoundBase
 from mpisppy.cylinders._preloop_xhat_mixin import _PreLoopXhatMixin
 
-import mpisppy.MPI as mpi
 import logging
-
-fullcomm = mpi.COMM_WORLD
-global_rank = fullcomm.Get_rank()
-fullcom_n_proc = fullcomm.Get_size()
 
 
 def _attach_xbars(opt):
@@ -57,8 +52,9 @@ class XhatXbarInnerBound(_PreLoopXhatMixin, XhatInnerBoundBase):
         Entry point. Communicates with the optimization companion.
 
         """
-        dtm = logging.getLogger(f'dtm{global_rank}')
-        logging.debug("Enter xhatxbar main on rank {}".format(global_rank))
+        rank = self.cylinder_rank
+        dtm = logging.getLogger(f'dtm{rank}')
+        logging.debug("Enter xhatxbar main on rank {}".format(rank))
 
         xhatter = self.xhat_prep()
 
@@ -69,15 +65,15 @@ class XhatXbarInnerBound(_PreLoopXhatMixin, XhatInnerBoundBase):
 
         ib_iter = 1  # ib is for inner bound
         while (not self.got_kill_signal()):
-            logging.debug('   IB loop iter={} on global rank {}'.\
-                          format(ib_iter, global_rank))
+            logging.debug('   IB loop iter={} on rank {}'.\
+                          format(ib_iter, rank))
             # _log_values(ib_iter, self._locals, dtm)
 
-            logging.debug('   IB got from opt on global rank {}'.\
-                          format(global_rank))
+            logging.debug('   IB got from opt on rank {}'.\
+                          format(rank))
             if self.update_nonants():
-                logging.debug('  and its new! on global rank {}'.\
-                              format(global_rank))
+                logging.debug('  and its new! on rank {}'.\
+                              format(rank))
                 logging.debug('  localnonants={}'.format(str(self.localnonants)))
                 self.opt._put_nonant_cache(self.localnonants)  # don't really need all caches
                 # just for sending the values to other scenarios


### PR DESCRIPTION
Fixes #782.

`xhatspecific_bounder.py` and `xhatxbar_bounder.py` each captured
`mpi.COMM_WORLD` at module scope purely to build a logging label:

```python
fullcomm = mpi.COMM_WORLD
global_rank = fullcomm.Get_rank()
fullcom_n_proc = fullcomm.Get_size()
```

`fullcomm` and `fullcom_n_proc` were dead, and `global_rank` was used only to
name the per-rank `dtm` logger and a handful of `logging.debug(...)` messages.
This is not a computational bug — these spokes already solve on the
communicator they inherit from `SPBase` — but reaching across the whole world
for a log label is untidy when a wheel is run on a sub-communicator.

## Changes

- Remove the dead `fullcomm` / `fullcom_n_proc` module globals (and the
  now-unused `import mpisppy.MPI as mpi`).
- Derive the logging rank from the spoke's own communicator
  (`self.cylinder_rank`, set on the `SPCommunicator` base) inside `main()`.
- Reword the debug messages from "global rank" to "rank" since they now
  reflect the spoke's own (possibly sub-) communicator.

No behavior change.

## Why it matters

Prerequisite tidy-up for running cylinder solves on rank subgroups — splitting
one MPI allocation into groups and running a wheel on each group's
sub-communicator (the pattern a planned bootstrap-CI integration into
`generic_cylinders` will use).

## Testing

- `ruff check` clean; both modules parse and import.
- `mpiexec -np 2 python -m mpi4py -m pytest mpisppy/tests/test_with_cylinders.py -k xhatxbar`
  passes — this exercises the xhatxbar spoke's `main()` at runtime, confirming
  `self.cylinder_rank` is available there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
