### PR TITLE
Harden do_mmw temp file handling (secure mkdtemp)

### DIFF
--- a/mpisppy/generic/mmw.py
+++ b/mpisppy/generic/mmw.py
@@ -63,9 +63,15 @@ def do_mmw(module_fname, cfg, wheel=None):
                 "do_mmw: mmw_xhat_input_file_name must be set when no wheel is provided"
             )
         # Write the wheel's best xhat to a temporary file readable by all ranks.
+        # Rank 0 owns a secure temp directory; write_first_stage_solution writes
+        # the .npy inside it only when a feasible first-stage solution exists, so
+        # the file's absence after the barrier means "no feasible solution".
+        # (A pre-created temp file, e.g. from mkstemp, would defeat that test.)
         if global_rank == 0:
-            tmp_path = tempfile.mktemp(suffix=".npy")
+            tmp_dir = tempfile.mkdtemp()
+            tmp_path = os.path.join(tmp_dir, "xhat.npy")
         else:
+            tmp_dir = None
             tmp_path = None
         tmp_path = global_comm.bcast(tmp_path, root=0)
 
@@ -77,11 +83,17 @@ def do_mmw(module_fname, cfg, wheel=None):
 
         if not os.path.exists(tmp_path):
             global_toc("MMW CI skipped: no feasible solution found by the main algorithm.")
+            if global_rank == 0:
+                try:
+                    os.rmdir(tmp_dir)
+                except OSError:
+                    pass
             return
         xhat = ciutils.read_xhat(tmp_path)
         if global_rank == 0:
             try:
                 os.remove(tmp_path)
+                os.rmdir(tmp_dir)
             except OSError:
                 pass
 


### PR DESCRIPTION
`generic/mmw.py::do_mmw` wrote the wheel's best xhat to a `tempfile.mktemp()` path, which is deprecated (predictable name, TOCTOU-prone). This switches it to a secure `mkdtemp()` directory with the `.npy` placed inside.

The key subtlety: `write_first_stage_solution` writes the file *lazily*, only when a feasible first-stage solution exists, and `do_mmw` uses the file's **absence** after the barrier to decide "no feasible solution — skip MMW." A naive switch to `mkstemp()` would pre-create the file and silently defeat that check, so the file is instead created lazily inside the secure directory. Both the feasible path and the skip/early-return path remove the temp directory.

This matches the same secure temp-file pattern used in `generic/mrp.py` (from the `mrp_generic` work / Copilot review on #639).

**Testing:** exercised the real `do_mmw` + wheel + temp-file path under 2-rank MPI:

```
mpiexec -np 2 python -m mpi4py -m mpisppy.generic_cylinders \
    --module-name mpisppy.tests.examples.farmer --num-scens 3 \
    --solver-name gurobi --max-solver-threads 1 --default-rho 1 \
    --max-iterations 3 --xhatshuffle \
    --mmw-num-batches 2 --mmw-batch-size 3 --mmw-start 4
```

MMW CI result prints and the run exits 0. `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)