### PR TITLE
Fix option_dict_to_string flag serialization (missing f-string)

### DIFF
--- a/mpisppy/utils/sputils.py
+++ b/mpisppy/utils/sputils.py
@@ -944,13 +944,8 @@ def option_dict_to_string(odict):
     """
     if odict is None:
         return None
-    ostr = ""
-    for i, v in odict.items():
-        if v is None:
-            ostr += "{i} "
-        else:
-            ostr += f"{i}={v} "
-    return ostr
+    return "".join(f"{k} " if v is None else f"{k}={v} "
+                   for k, v in odict.items())
 
 
 # Solver-options layered representation. See


### PR DESCRIPTION
## What

`sputils.option_dict_to_string` serialized a valueless (flag-style) option — one whose value is `None` — as the literal string `{i}` instead of the option's name. The `None` branch used a plain string literal where an f-string was intended:

```python
if v is None:
    ostr += "{i} "        # emitted literal "{i}"
else:
    ostr += f"{i}={v} "
```

So, e.g., `option_dict_to_string({'LogFile': None, 'mipgap': 0.01})` returned `'{i} mipgap=0.01 '`.

## Fix

Use an f-string for the flag branch so flags serialize as their name and round-trip cleanly back through `option_string_to_dict`. The accumulator loop is collapsed into a single `join` while here.

```python
return "".join(f"{k} " if v is None else f"{k}={v} "
               for k, v in odict.items())
```

Behavior is unchanged for the other cases and preserves the docstring's "None begets None, empty begets empty" contract:

| input | output |
|---|---|
| `None` | `None` |
| `{}` | `''` |
| `{'LogFile': None}` | `'LogFile '` |
| `{'mipgap': 0.01}` | `'mipgap=0.01 '` |
| `{'LogFile': None, 'mipgap': 0.01, 'threads': 4}` | `'LogFile mipgap=0.01 threads=4 '` |

All round-trip back through `option_string_to_dict`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
