### PR TITLE
Hotfix: pin ruff in CI (ruff 0.16.0 release turned every PR's lint check red)

### DIFF
--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -26,7 +26,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: chartboost/ruff-action@v1
+      # Pin the ruff version: an unpinned linter means an upstream release
+      # can turn every PR red overnight (ruff 0.16.0 did exactly that by
+      # expanding the default rule set).  Bump deliberately.
+      - uses: astral-sh/ruff-action@v3
+        with:
+          version: "0.15.21"
 
   nompi4py:
     name: no mpi4py


### PR DESCRIPTION
**Hotfix — every open PR is currently failing the Ruff Linting check** (#810, #811, and anything else that runs CI from now on), through no fault of their own.

## What happened

- ruff **0.16.0 was released today** and greatly expanded the default rule set (pyupgrade `UP*`, `TRY*`, `FURB*`, `SIM*`, `PL*`, `EXE001`, ...).
- The lint job used `chartboost/ruff-action@v1` — an **archived** action — with **no version pin**, so it installs whatever ruff is latest at run time.
- Verified locally on the same tree: ruff 0.15.21 reports "All checks passed!"; ruff 0.16.0 reports **2,487 errors**, almost all in files the failing PRs never touched (e.g. `doc/src/conf.py`, example models).
- Timeline matches: main passed lint at 17:30 UTC today; PR #810 failed at 19:43 UTC with repo-wide errors.

## The fix

Switch to the maintained `astral-sh/ruff-action@v3` pinned to `version: "0.15.21"` — the version CI was effectively using until today. A comment in the workflow explains why the pin must be bumped deliberately, not floated.

Whether to *adopt* (or configure away) the new 0.16 default rules is a separate decision that can be made calmly later.

After this merges, #810 and #811 just need a rebase or a re-run against main to go green on lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
