### PR TITLE
Dependency cleanup phase 2: CI runners consume the [test] extra

### DIFF
--- a/.github/workflows/pyotracker.yml
+++ b/.github/workflows/pyotracker.yml
@@ -27,9 +27,7 @@ jobs:
       - name: Install dependencies
         run: |
           conda install mpi4py pandas setuptools git
-          pip install sphinx sphinx_rtd_theme sphinx-copybutton cplex
-          pip install xpress
-          pip install matplotlib
+          pip install cplex xpress
 
       - name: set up pyomo
         run: |
@@ -37,7 +35,10 @@ jobs:
 
       - name: setup the program
         run: |
-          pip install -e .
+          # [doc] too: this job runs "make doctest" below.  The tracked
+          # pyomo (installed from git above) already satisfies the pyomo
+          # requirement, so pip does not replace it.
+          pip install -e ".[test,doc]"
 
       - name: Test EF/PH
         run: |

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -45,12 +45,11 @@ jobs:
           python-version: 3.11
       - name: Install dependencies
         run: |
-          pip install sphinx sphinx_rtd_theme cplex
-          pip install xpress pandas dill coverage
+          pip install cplex xpress
 
       - name: setup the program
         run: |
-          pip install -e .
+          pip install -e ".[test]"
 
       - name: PH EF tests
         run: |
@@ -79,8 +78,9 @@ jobs:
       - name: Install dependencies
         run: |
           conda install mpi4py pandas setuptools
-          pip install pyomo sphinx sphinx_rtd_theme sphinx-copybutton dill gridx-egret cplex pybind11
-          pip install xpress coverage
+          # pyomo + pybind11 explicit: the build-extensions step below runs
+          # before the editable install; solvers are in no extra (licensing)
+          pip install pyomo pybind11 cplex xpress
 
       - name: Build pyomo extensions
         run: |
@@ -89,7 +89,8 @@ jobs:
 
       - name: setup the program
         run: |
-          pip install -e .
+          # [doc] too: this job runs "make doctest" below
+          pip install -e ".[test,doc]"
 
       - name: Test EF/PH
         run: |
@@ -193,12 +194,9 @@ jobs:
       - name: Install dependencies
         run: |
           conda install mpi4py pandas setuptools
-          pip install pyomo sphinx sphinx_rtd_theme dill gridx-egret cplex pybind11
-          pip install xpress coverage
-          # usar runs in first-part and imports matplotlib + scipy at module load
-          pip install matplotlib scipy
-          # dcap (SMPS) runs in first-part; its reader needs python-mip
-          pip install mip
+          # pyomo + pybind11 explicit: the build-extensions step below runs
+          # before the editable install; solvers are in no extra (licensing)
+          pip install pyomo pybind11 cplex xpress
 
       - name: Build pyomo extensions
         run: |
@@ -207,7 +205,7 @@ jobs:
 
       - name: setup the program
         run: |
-          pip install -e .
+          pip install -e ".[test]"
 
       - name: Test run_all nouc (first part)
         run: |
@@ -239,8 +237,9 @@ jobs:
       - name: Install dependencies
         run: |
           conda install mpi4py pandas setuptools
-          pip install pyomo sphinx sphinx_rtd_theme dill gridx-egret cplex pybind11
-          pip install xpress coverage
+          # pyomo + pybind11 explicit: the build-extensions step below runs
+          # before the editable install; solvers are in no extra (licensing)
+          pip install pyomo pybind11 cplex xpress
 
       - name: Build pyomo extensions
         run: |
@@ -249,7 +248,7 @@ jobs:
 
       - name: setup the program
         run: |
-          pip install -e .
+          pip install -e ".[test]"
 
       - name: Test run_all nouc (second part)
         run: |
@@ -279,12 +278,9 @@ jobs:
       - name: Install dependencies
         run: |
           conda install mpi4py pandas setuptools
-          pip install pyomo sphinx sphinx_rtd_theme dill gridx-egret cplex pybind11
-          pip install xpress coverage
-          # usar runs in first-part and imports matplotlib + scipy at module load
-          pip install matplotlib scipy
-          # dcap (SMPS) runs in first-part; its reader needs python-mip
-          pip install mip
+          # pyomo + pybind11 explicit: the build-extensions step below runs
+          # before the editable install; solvers are in no extra (licensing)
+          pip install pyomo pybind11 cplex xpress
 
       - name: Build pyomo extensions
         run: |
@@ -293,7 +289,7 @@ jobs:
 
       - name: setup the program
         run: |
-          pip install -e .
+          pip install -e ".[test]"
 
       - name: Test run_all nouc (first part)
         run: |
@@ -324,8 +320,9 @@ jobs:
       - name: Install dependencies
         run: |
           conda install mpi4py pandas setuptools
-          pip install pyomo sphinx sphinx_rtd_theme dill gridx-egret cplex pybind11
-          pip install xpress coverage
+          # pyomo + pybind11 explicit: the build-extensions step below runs
+          # before the editable install; solvers are in no extra (licensing)
+          pip install pyomo pybind11 cplex xpress
 
       - name: Build pyomo extensions
         run: |
@@ -334,7 +331,7 @@ jobs:
 
       - name: setup the program
         run: |
-          pip install -e .
+          pip install -e ".[test]"
 
       - name: Test run_all nouc (second part)
         run: |
@@ -366,12 +363,13 @@ jobs:
       - name: Install dependencies
         run: |
           conda install mpi4py pandas setuptools
-          pip install pyomo dill pybind11 highspy coverage
-          pip install git+https://github.com/grid-parity-exchange/egret.git
+          # gridx-egret comes from the [test] extra; the git egret install
+          # lives only in the weekly UC workflow (test_uc_weekly.yml)
+          pip install pybind11 highspy
 
       - name: setup the program
         run: |
-          pip install -e .
+          pip install -e ".[test]"
 
       - name: Run run_uc_pr.py
         run: |
@@ -421,7 +419,7 @@ jobs:
           pyomo build-extensions
           cd ../
           pip install git+https://github.com/parapint/parapint.git
-          pip install -e .
+          pip install -e ".[test]"
 
       - name: Test with pytest (serial)
         shell: bash -l {0}
@@ -455,11 +453,11 @@ jobs:
       - name: Install dependencies
         run: |
           conda install mpi4py pandas setuptools
-          pip install pyomo xpress cplex dill matplotlib scipy coverage
+          pip install cplex xpress
 
       - name: setup the program
         run: |
-          pip install -e .
+          pip install -e ".[test]"
 
       - name: mpi tests
         run: |
@@ -489,11 +487,11 @@ jobs:
       - name: Install dependencies
         run: |
           conda install mpi4py pandas setuptools
-          pip install pyomo gurobipy dill matplotlib scipy coverage pytest
+          pip install gurobipy
 
       - name: setup the program
         run: |
-          pip install -e .
+          pip install -e ".[test]"
 
       - name: Probe gurobi_persistent availability
         run: |
@@ -531,12 +529,11 @@ jobs:
       - name: Install dependencies
         run: |
           conda install mpi4py pandas setuptools
-          pip install pyomo xpress cplex
-          pip install numpy packaging coverage
+          pip install cplex xpress
 
       - name: setup the program
         run: |
-          pip install -e .
+          pip install -e ".[test]"
 
       - name: run tests
         timeout-minutes: 10
@@ -569,11 +566,11 @@ jobs:
       - name: Install dependencies
         run: |
           conda install mpi4py pandas setuptools
-          pip install pyomo xpress cplex coverage
+          pip install cplex xpress
 
       - name: setup the program
         run: |
-          pip install -e .
+          pip install -e ".[test]"
 
       - name: run tests
         timeout-minutes: 10
@@ -603,12 +600,11 @@ jobs:
       - name: Install dependencies
         run: |
           conda install mpi4py pandas setuptools
-          # scipy is needed for the prox-linearization (linearize_proximal_terms) test
-          pip install pyomo xpress cplex scipy coverage
+          pip install cplex xpress
 
       - name: setup the program
         run: |
-          pip install -e .
+          pip install -e ".[test]"
 
       - name: run tests
         timeout-minutes: 10
@@ -638,11 +634,11 @@ jobs:
       - name: Install dependencies
         run: |
           conda install mpi4py pandas setuptools
-          pip install pyomo xpress cplex coverage pytest
+          pip install cplex xpress
 
       - name: setup the program
         run: |
-          pip install -e .
+          pip install -e ".[test]"
 
       - name: run tests
         timeout-minutes: 10
@@ -676,11 +672,11 @@ jobs:
       - name: Install dependencies
         run: |
           conda install mpi4py "numpy" setuptools
-          pip install pyomo pandas xpress cplex scipy sympy dill PyYAML Pympler networkx pandas packaging coverage
+          pip install cplex xpress
 
       - name: setup the program
         run: |
-          pip install -e .
+          pip install -e ".[test]"
 
       - name: run pickled bundles tests
         timeout-minutes: 10
@@ -712,11 +708,11 @@ jobs:
       - name: Install dependencies
         run: |
           conda install mpi4py "numpy" setuptools
-          pip install pyomo pandas xpress cplex scipy sympy dill PyYAML Pympler networkx packaging coverage pytest
+          pip install cplex xpress
 
       - name: setup the program
         run: |
-          pip install -e .
+          pip install -e ".[test]"
 
       - name: run pre-pickle pipeline tests
         timeout-minutes: 10
@@ -751,11 +747,11 @@ jobs:
       - name: Install dependencies
         run: |
           conda install mpi4py pandas setuptools
-          pip install pyomo xpress cplex mip coverage
+          pip install cplex xpress
 
       - name: setup the program
         run: |
-          pip install -e .
+          pip install -e ".[test]"
 
       - name: run MPS tests
         timeout-minutes: 2
@@ -789,11 +785,11 @@ jobs:
       - name: Install dependencies
         run: |
           conda install mpi4py pandas setuptools
-          pip install pyomo xpress cplex mip pytest coverage
+          pip install cplex xpress
 
       - name: setup the program
         run: |
-          pip install -e .
+          pip install -e ".[test]"
 
       - name: run SMPS tests
         timeout-minutes: 2
@@ -827,11 +823,11 @@ jobs:
       - name: Install dependencies
         run: |
           conda install mpi4py "numpy" setuptools
-          pip install pyomo pandas xpress cplex scipy sympy dill packaging coverage
+          pip install cplex xpress
 
       - name: setup the program
         run: |
-          pip install -e .
+          pip install -e ".[test]"
 
       - name: run farmer tests
         timeout-minutes: 10
@@ -894,7 +890,9 @@ jobs:
       - name: Install dependencies
         run: |
           conda install mpi4py pandas setuptools
-          pip install pyomo sphinx sphinx_rtd_theme dill gridx-egret cplex pybind11 mip coverage
+          # pyomo + pybind11 explicit: the build-extensions step below runs
+          # before the editable install; solvers are in no extra (licensing)
+          pip install pyomo pybind11 cplex
 
       - name: Build pyomo extensions
         run: |
@@ -903,7 +901,7 @@ jobs:
 
       - name: setup the program
         run: |
-          pip install -e .
+          pip install -e ".[test]"
 
       - name: Test test_generic nouc
         run: |
@@ -940,11 +938,11 @@ jobs:
         run: |
           conda install -y conda-forge::libstdcxx-ng
           conda install -y -c conda-forge openmpi mpi4py "numpy" setuptools cmake pip
-          conda run -n test_env --no-capture-output pip install pyomo pandas xpress cplex scipy sympy dill packaging coverage
+          conda run -n test_env --no-capture-output pip install cplex xpress
 
       - name: setup the program
         run: |
-          conda run -n test_env --no-capture-output pip install -e .
+          conda run -n test_env --no-capture-output pip install -e ".[test]"
 
       - name: run gradient/rho tests
         timeout-minutes: 10
@@ -974,11 +972,11 @@ jobs:
       - name: Install dependencies
         run: |
           conda install mpi4py "numpy" setuptools
-          pip install pyomo addheader pyyaml pytest
+          pip install pyyaml
 
       - name: setup the program
         run: |
-          pip install -e .
+          pip install -e ".[test]"
 
       - name: run headers test
         timeout-minutes: 10
@@ -999,11 +997,11 @@ jobs:
       - name: Install dependencies
         run: |
           conda install mpi4py pandas setuptools pytest pyyaml networkx
-          pip install pyomo xpress cplex coverage
+          pip install cplex xpress
 
       - name: setup the program
         run: |
-          pip install -e .
+          pip install -e ".[test]"
 
       - name: run pysp model tests
         timeout-minutes: 10
@@ -1039,11 +1037,11 @@ jobs:
       - name: Install dependencies
         run: |
           conda install mpi4py "numpy" setuptools
-          pip install pyomo pandas xpress cplex scipy packaging coverage
+          pip install cplex xpress
 
       - name: setup the program
         run: |
-          pip install -e .
+          pip install -e ".[test]"
 
       - name: run tests
         timeout-minutes: 10
@@ -1085,11 +1083,11 @@ jobs:
       - name: Install dependencies
         run: |
           conda install mpi4py pandas setuptools
-          pip install pyomo xpress cplex coverage
+          pip install cplex xpress
 
       - name: setup the program
         run: |
-          pip install -e .
+          pip install -e ".[test]"
 
       - name: run CG serial tests
         timeout-minutes: 10
@@ -1149,19 +1147,17 @@ jobs:
       - name: Install dependencies
         run: |
           conda install mpi4py pandas setuptools
-          pip install pyomo xpress cplex coverage
-          pip install numpy packaging
+          pip install cplex xpress
           python -m pip install amplpy --upgrade
           python -m amplpy.modules install highs cbc gurobi
           conda install -c conda-forge openssl
           echo "LD_LIBRARY_PATH=${CONDA_PREFIX}/lib:${LD_LIBRARY_PATH:-}" >> $GITHUB_ENV
           python -m pip install gamspy
-          python -m pip install mip
           # license?
 
       - name: setup the program
         run: |
-          pip install -e .
+          pip install -e ".[test]"
 
       - name: run agnostic tests
         timeout-minutes: 10
@@ -1206,11 +1202,10 @@ jobs:
       - name: Install dependencies
         run: |
           conda install mpi4py pandas setuptools
-          pip install pyomo pytest coverage
 
       - name: setup the program
         run: |
-          pip install -e .
+          pip install -e ".[test]"
 
       - name: run unit tests
         run: |

--- a/.github/workflows/test_uc_weekly.yml
+++ b/.github/workflows/test_uc_weekly.yml
@@ -29,12 +29,14 @@ jobs:
       - name: Install dependencies
         run: |
           conda install mpi4py pandas setuptools
-          pip install pyomo dill pybind11 highspy
+          pip install pybind11 highspy
           pip install git+https://github.com/grid-parity-exchange/egret.git
 
       - name: setup the program
         run: |
-          pip install -e .
+          # the git egret installed above already satisfies the [test]
+          # extra's gridx-egret requirement, so pip does not replace it
+          pip install -e ".[test]"
 
       - name: Run run_uc.py
         run: |


### PR DESCRIPTION
Second of three PRs implementing `doc/designs/dependency_cleanup_design.md` (first: #811, merged; third will add `attempt_import` guards for the four opt-in modules).

Per §4 of the design doc, every CI job's hand-rolled feature-package pip list is replaced by `pip install -e ".[test]"` at the existing editable-install step, so adding a test dependency becomes a one-line `pyproject.toml` change instead of ~12 YAML edits. Touches `test_pr_and_main.yml`, `pyotracker.yml`, and `test_uc_weekly.yml`; net −2 lines with more of the remaining lines being comments.

## What stays explicit, per job

- **Solvers** (`cplex`, `xpress`, `gurobipy`, `highspy`) — deliberately in no extra (licensing).
- **`pyomo` + `pybind11`** in the five jobs whose `pyomo build-extensions` step runs before the editable install (regression, the four run_all jobs, generic_tester).
- **Git installs**: parapint/pyutilib/git-pyomo in schur-complement; the git egret in `test_uc_weekly.yml` (installed before `[test]`, so it satisfies the extra's `gridx-egret` requirement and is not replaced).
- **conda lines** (`mpi4py pandas setuptools` etc.) — conda jobs get mpi4py from conda, so `[mpi]` is unnecessary in CI.
- `pyyaml` in test-headers, and test-pysp's conda `pytest pyyaml networkx`.

## Deliberate changes beyond pure consolidation

- **uc-relaxed now uses `gridx-egret` from the `[test]` extra** instead of a git egret install — standardizing on the released egret in the PR workflow; the git egret lives only in the weekly UC workflow.
- **sphinx dropped from non-doc jobs**; the two jobs that run `make doctest` (regression, pyotracker) use `".[test,doc]"`.
- **`sympy` and `Pympler` installs dropped entirely** — neither is imported anywhere in `mpisppy/` or `examples/` (cargo-cult carryover).
- The no-solver **unit-tests job now installs the feature packages** (scipy, dill, etc. arrive via `[test]`), so optional-dependency test paths that were silently skipped there now run.

The ruff job's pinned `astral-sh/ruff-action@v3` (0.15.21, from #812) is untouched.

## Verification

The full matrix running on this PR is the verification, per the design doc ("it already runs on PRs"). The two scheduled workflows (`pyotracker`, `test_uc_weekly`) don't run on PRs; their edits follow the identical pattern, and `test_uc_weekly` supports `workflow_dispatch` for a manual check after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
