### PR TITLE
Replace mid-run quit() with RuntimeError in cylinder-executed code

### DIFF
--- a/mpisppy/cylinders/lshaped_bounder.py
+++ b/mpisppy/cylinders/lshaped_bounder.py
@@ -36,17 +36,13 @@ class XhatLShapedInnerBound(spoke.InnerBoundNonantSpoke):
         )
         self.opt._update_E1()  # Apologies for doing this after the solves...
         if abs(1 - self.opt.E1) > self.opt.E1_tolerance:
-            if self.opt.cylinder_rank == 0:
-                print("ERROR")
-                print("Total probability of scenarios was ", self.opt.E1)
-                print("E1_tolerance = ", self.opt.E1_tolerance)
-            quit()
+            raise RuntimeError(
+                f"Total probability of scenarios was {self.opt.E1}; "
+                f"E1_tolerance = {self.opt.E1_tolerance}")
         infeasP = self.opt.no_incumbent_prob()
         if infeasP != 0.:
-            if self.opt.cylinder_rank == 0:
-                print("ERROR")
-                print("Infeasibility detected; E_infeas, E1=", infeasP, self.opt.E1)
-            quit()
+            raise RuntimeError(
+                f"Infeasibility detected; E_infeas = {infeasP}, E1 = {self.opt.E1}")
 
         self.opt._save_nonants() # make the cache
 

--- a/mpisppy/extensions/diagnoser.py
+++ b/mpisppy/extensions/diagnoser.py
@@ -26,10 +26,8 @@ class Diagnoser(mpisppy.extensions.xhatbase.XhatBase):
     def __init__(self, ph):
         dirname = ph.options["diagnoser_options"]["diagnoser_outdir"]
         if os.path.exists(dirname):
-            if ph.cylinder_rank == 0:
-                print ("Shutting down because Diagnostic directory exists:",
-                       dirname)
-            quit()
+            raise RuntimeError(
+                f"Diagnostic directory already exists: {dirname}")
         if ph.cylinder_rank == 0:
             os.mkdir(dirname) # just let it crash
 

--- a/mpisppy/extensions/xhatlooper.py
+++ b/mpisppy/extensions/xhatlooper.py
@@ -71,8 +71,9 @@ class XhatLooper(mpisppy.extensions.xhatbase.XhatBase):
                 if seed is None:
                     snumlists[ndn] = [i % nsize for i in range(llim)]
                 else:
-                    print ("need a random permutation in snumlist xxxx quitting")
-                    quit()
+                    raise RuntimeError("XhatLooper does not support a seed: "
+                                       "a random permutation in snumlist "
+                                       "is not implemented")
         
         self.opt._save_nonants() # to cache for use in fixing
         # for the moment (dec 2019) treat two-stage as special

--- a/mpisppy/utils/w_utils/wxbarreader.py
+++ b/mpisppy/utils/w_utils/wxbarreader.py
@@ -76,18 +76,14 @@ class WXBarReader(mpisppy.extensions.extension.Extension):
 
         if w_fname is not None:
             if (not os.path.exists(w_fname)):
-                if (rank == 0):
-                    if (sep_files):
-                        print('Cannot find path', w_fname)
-                    else:
-                        print('Cannot find file', w_fname)
-                quit()
+                if (sep_files):
+                    raise RuntimeError(f'Cannot find path {w_fname}')
+                else:
+                    raise RuntimeError(f'Cannot find file {w_fname}')
 
         if x_fname is not None:
             if (not os.path.exists(x_fname)):
-                if (rank == 0):
-                    print('Cannot find file', x_fname)
-                quit()
+                raise RuntimeError(f'Cannot find file {x_fname}')
 
         if (x_fname is None and w_fname is None and rank==0):
             print('Warning: no input files provided to WXBarReader. '


### PR DESCRIPTION
Follow-on to #815. The abort-on-uncaught-exception protection (mpi4py's runner and, since #815, the console-script wrappers) only helps when a failing rank actually raises. A `quit()` raises `SystemExit(None)`, which both treat as a normal exit — so when one fires on one cylinder's ranks mid-run, that cylinder exits quietly while every other cylinder waits forever and the `mpiexec` job hangs.

This PR converts the mid-run `quit()` calls in cylinder-executed library code to `RuntimeError`, so these failures abort the whole job with a traceback instead:

- `cylinders/lshaped_bounder.py` — iter0 E1 (total scenario probability) and infeasibility checks in the xhat-L-shaped spoke
- `utils/w_utils/wxbarreader.py` — missing W / xbar input file
- `extensions/diagnoser.py` — diagnostic output directory already exists
- `extensions/xhatlooper.py` — unimplemented seeded-sampling path

The former rank-0-only `print` guards are folded into the exception messages; unconditional raising matches the other `RuntimeError`s already in these files (the first rank to raise triggers the abort, which stops the rest).

Left alone deliberately: the usage-message `quit()`s in `generic_cylinders.py`, `mrp_generic.py`, `agnostic/agnostic_cylinders.py`, and the demo `__main__` in `opt/ph.py`. Those fire identically on every rank before any collective work, so they cannot strand anyone, and converting them would turn clean usage exits into tracebacks.

Verified with a 2-rank `mpiexec` farmer run (`--lshaped-hub --xhatlshaped`, gurobi): the patched iter0 checks execute on the happy path and the run converges to gap 0 as before. `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
