### PR TITLE
Explain why a scenario model could not be dilled, instead of just failing

### DIFF
--- a/mpisppy/tests/test_pickle_bundle.py
+++ b/mpisppy/tests/test_pickle_bundle.py
@@ -166,15 +166,17 @@ class Test_dill_failure_diagnostics(unittest.TestCase):
         found = pickle_bundle.find_undillable_closures(
             self._model_with_cfg_in_bounds_rule())
         self.assertEqual(len(found), 1)
-        rule, varname, typename = found[0]
+        rule, varname, typename, kind = found[0]
         self.assertEqual(rule, "bounds_rule")
         self.assertEqual(varname, "cfg")
         self.assertEqual(typename, "Config")
+        self.assertEqual(kind, "closure")
 
     def test_finds_cfg_captured_by_a_constraint_rule(self):
         found = pickle_bundle.find_undillable_closures(
             self._model_with_cfg_in_constraint_rule())
-        self.assertEqual([(r, v) for r, v, _ in found], [("con_rule", "cfg")])
+        self.assertEqual([(r, v) for r, v, _, _ in found],
+                         [("con_rule", "cfg")])
 
     def test_clean_model_has_no_findings(self):
         self.assertEqual(
@@ -263,6 +265,69 @@ class Test_dill_failure_diagnostics(unittest.TestCase):
             finally:
                 os.chmod(fname, 0o600)
 
+    def test_write_error_does_not_leave_a_truncated_pickle(self):
+        """A write failure (disk full, quota) must not leave a partial file.
+
+        open() succeeded and truncated the target, so what is on disk is our
+        own partial write -- exactly the thing a later --unpickle-* run would
+        try to load.
+        """
+        class _FailingDill:
+            def dump(self, model, f):
+                f.write(b"x" * 200)
+                raise OSError(28, "No space left on device")
+
+        model = self._clean_model()
+        saved = pickle_bundle.dill
+        with tempfile.TemporaryDirectory() as tmp:
+            fname = os.path.join(tmp, "scen.dill")
+            try:
+                pickle_bundle.dill = _FailingDill()
+                with self.assertRaises(OSError):
+                    pickle_bundle.dill_pickle(model, fname)
+            finally:
+                pickle_bundle.dill = saved
+            self.assertFalse(
+                os.path.exists(fname),
+                msg="a truncated pickle survived a write failure")
+
+    def test_missing_dill_does_not_truncate_the_target(self):
+        """Refuse before opening, or we destroy a file we cannot rewrite."""
+        model = self._clean_model()
+        with tempfile.TemporaryDirectory() as tmp:
+            fname = os.path.join(tmp, "existing.dill")
+            with open(fname, "wb") as f:
+                f.write(b"previous contents")
+            saved = pickle_bundle.dill_available
+            try:
+                pickle_bundle.dill_available = False
+                with self.assertRaises(RuntimeError) as ctx:
+                    pickle_bundle.dill_pickle(model, fname)
+            finally:
+                pickle_bundle.dill_available = saved
+            self.assertIn("dill is required", str(ctx.exception))
+            with open(fname, "rb") as f:
+                self.assertEqual(f.read(), b"previous contents")
+
+    def test_large_bound_method_owner_is_not_expanded(self):
+        """A Pyomo component owner would bury the answer in red herrings."""
+        cfg = Config()
+        cfg.popular_args()
+        model = pyo.ConcreteModel()
+        model.x = pyo.Var([1, 2])
+
+        def con_rule(m, i):
+            return m.x[i] >= (1 if cfg.max_iterations else 0)
+
+        model.c = pyo.Constraint([1, 2], rule=con_rule)
+        model._helper = model.clone       # bound method owned by the model
+
+        found = pickle_bundle.find_undillable_closures(model)
+        self.assertTrue(found)
+        self.assertEqual(
+            [varname for _, varname, _, kind in found if kind == "self"], [],
+            msg="expanded a Pyomo component as if it were a model builder")
+
     def test_duplicate_captures_are_reported_once(self):
         """A bundle carries one copy of each rule per scenario."""
         def build_block(cfg):
@@ -283,7 +348,7 @@ class Test_dill_failure_diagnostics(unittest.TestCase):
 
         found = pickle_bundle.find_undillable_closures(model)
         self.assertEqual(
-            found, [("con_rule", "cfg", "Config")],
+            found, [("con_rule", "cfg", "Config", "closure")],
             msg="the same capture was reported once per scenario")
 
     def test_bound_method_rule_is_diagnosed(self):
@@ -305,7 +370,7 @@ class Test_dill_failure_diagnostics(unittest.TestCase):
             self.dill.dumps(model)
         found = pickle_bundle.find_undillable_closures(model)
         self.assertTrue(found, msg="bound-method rule was not diagnosed")
-        self.assertIn("self.cfg", [varname for _, varname, _ in found])
+        self.assertIn("self.cfg", [varname for _, varname, _, _ in found])
 
 
 class Test_dill_diagnostics_without_dill(unittest.TestCase):

--- a/mpisppy/tests/test_pickle_bundle.py
+++ b/mpisppy/tests/test_pickle_bundle.py
@@ -16,6 +16,12 @@ import sys
 import tempfile
 import unittest
 
+import pytest
+import pyomo.environ as pyo
+
+import mpisppy.utils.pickle_bundle as pickle_bundle
+from mpisppy.utils.config import Config
+
 import mpisppy.MPI as mpi
 
 from mpisppy.tests.utils import get_solver
@@ -98,6 +104,134 @@ class Test_pickle_bundles(unittest.TestCase):
         ret = os.system(cmdstr)
         if ret != 0:
             raise RuntimeError(f"cylinders part of test run failed with code {ret}")
+
+class Test_dill_failure_diagnostics(unittest.TestCase):
+    """A model that cannot be dilled must say *why*, not just that it failed.
+
+    dill's own message is typically opaque -- "args[0] from __newobj__ args has
+    the wrong class" -- and names neither the component nor the offending
+    object. The common cause is a value captured in the closure of a Pyomo
+    rule: Pyomo keeps the rule function on the component it built, so whatever
+    the rule closed over has to be serializable too. These tests pin that the
+    diagnostic finds such a value and names it, and -- just as important --
+    that it does not claim that cause when the real problem is something else.
+    """
+
+    def setUp(self):
+        self.dill = pytest.importorskip("dill")
+
+    @staticmethod
+    def _model_with_cfg_in_bounds_rule():
+        # Rules must be nested to create a real closure, as they are inside a
+        # scenario_creator; a module-level rule captures a global instead.
+        cfg = Config()
+        cfg.popular_args()
+        model = pyo.ConcreteModel()
+
+        def bounds_rule(m, i):
+            return (0, 10 if cfg.max_iterations else 5)
+
+        model.v = pyo.Var([1, 2], bounds=bounds_rule)
+        return model
+
+    @staticmethod
+    def _model_with_cfg_in_constraint_rule():
+        cfg = Config()
+        cfg.popular_args()
+        model = pyo.ConcreteModel()
+        model.x = pyo.Var([1, 2])
+
+        def con_rule(m, i):
+            return m.x[i] >= (1 if cfg.max_iterations else 0)
+
+        model.c = pyo.Constraint([1, 2], rule=con_rule)
+        return model
+
+    @staticmethod
+    def _clean_model():
+        model = pyo.ConcreteModel()
+        limit = 10
+
+        def bounds_rule(m, i):
+            return (0, limit)
+
+        model.v = pyo.Var([1, 2], bounds=bounds_rule)
+        return model
+
+    def test_finds_cfg_captured_by_a_var_bounds_rule(self):
+        """A Var bounds rule sits three levels down in Pyomo's initializers."""
+        found = pickle_bundle.find_undillable_closures(
+            self._model_with_cfg_in_bounds_rule())
+        self.assertEqual(len(found), 1)
+        rule, varname, typename = found[0]
+        self.assertEqual(rule, "bounds_rule")
+        self.assertEqual(varname, "cfg")
+        self.assertEqual(typename, "Config")
+
+    def test_finds_cfg_captured_by_a_constraint_rule(self):
+        found = pickle_bundle.find_undillable_closures(
+            self._model_with_cfg_in_constraint_rule())
+        self.assertEqual([(r, v) for r, v, _ in found], [("con_rule", "cfg")])
+
+    def test_clean_model_has_no_findings(self):
+        self.assertEqual(
+            pickle_bundle.find_undillable_closures(self._clean_model()), [])
+
+    def test_description_names_the_rule_and_the_variable(self):
+        model = self._model_with_cfg_in_bounds_rule()
+        with self.assertRaises(Exception) as ctx:
+            self.dill.dumps(model)
+        msg = pickle_bundle.describe_dill_failure(model, ctx.exception)
+        self.assertIn("bounds_rule", msg)
+        self.assertIn("cfg", msg)
+        self.assertIn("Config", msg)
+
+    def test_description_does_not_invent_a_closure_cause(self):
+        """The failure mode that matters: do not misdiagnose other causes.
+
+        A model that fails for an unrelated reason must not be handed a
+        confident explanation about rule closures that does not apply to it.
+        """
+        model = pyo.ConcreteModel()
+        model.x = pyo.Var([1, 2])
+        model._gen = (i for i in range(3))   # generators cannot be pickled
+        with self.assertRaises(Exception) as ctx:
+            self.dill.dumps(model)
+        msg = pickle_bundle.describe_dill_failure(model, ctx.exception)
+        self.assertIn("No unserializable value was found", msg)
+        self.assertNotIn("closes over", msg)
+        # The underlying error is still reported verbatim.
+        self.assertIn("generator", msg)
+
+    def test_dill_pickle_raises_with_the_diagnosis(self):
+        model = self._model_with_cfg_in_bounds_rule()
+        with tempfile.TemporaryDirectory() as tmp:
+            fname = os.path.join(tmp, "scen.dill")
+            with self.assertRaises(RuntimeError) as ctx:
+                pickle_bundle.dill_pickle(model, fname)
+            self.assertIn("bounds_rule", str(ctx.exception))
+            self.assertFalse(
+                os.path.exists(fname),
+                msg="a truncated pickle was left behind for a later run to "
+                    "try to load")
+
+    def test_dill_pickle_still_works_on_a_good_model(self):
+        model = self._clean_model()
+        with tempfile.TemporaryDirectory() as tmp:
+            fname = os.path.join(tmp, "scen.dill")
+            pickle_bundle.dill_pickle(model, fname)
+            reloaded = pickle_bundle.dill_unpickle(fname)
+            self.assertEqual(len(list(reloaded.v)), 2)
+
+    def test_dill_unpickle_explains_an_unreadable_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            fname = os.path.join(tmp, "truncated.dill")
+            with open(fname, "wb") as f:
+                f.write(b"not a pickle")
+            with self.assertRaises(RuntimeError) as ctx:
+                pickle_bundle.dill_unpickle(fname)
+            self.assertIn("truncated.dill", str(ctx.exception))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/mpisppy/tests/test_pickle_bundle.py
+++ b/mpisppy/tests/test_pickle_bundle.py
@@ -16,8 +16,8 @@ import sys
 import tempfile
 import unittest
 
-import pytest
 import pyomo.environ as pyo
+from pyomo.common.dependencies import DeferredImportError
 
 import mpisppy.utils.pickle_bundle as pickle_bundle
 from mpisppy.utils.config import Config
@@ -105,6 +105,8 @@ class Test_pickle_bundles(unittest.TestCase):
         if ret != 0:
             raise RuntimeError(f"cylinders part of test run failed with code {ret}")
 
+@unittest.skipUnless(pickle_bundle.dill_available,
+                     "dill is not installed")
 class Test_dill_failure_diagnostics(unittest.TestCase):
     """A model that cannot be dilled must say *why*, not just that it failed.
 
@@ -118,7 +120,8 @@ class Test_dill_failure_diagnostics(unittest.TestCase):
     """
 
     def setUp(self):
-        self.dill = pytest.importorskip("dill")
+        import dill
+        self.dill = dill
 
     @staticmethod
     def _model_with_cfg_in_bounds_rule():
@@ -231,6 +234,152 @@ class Test_dill_failure_diagnostics(unittest.TestCase):
             with self.assertRaises(RuntimeError) as ctx:
                 pickle_bundle.dill_unpickle(fname)
             self.assertIn("truncated.dill", str(ctx.exception))
+
+    def test_io_errors_are_not_dressed_up_as_serialization_failures(self):
+        """A bad path speaks for itself; do not lecture about rule closures."""
+        model = self._clean_model()
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = os.path.join(tmp, "no_such_dir", "scen.dill")
+            with self.assertRaises(OSError):
+                pickle_bundle.dill_pickle(model, missing)
+        with self.assertRaises(OSError):
+            pickle_bundle.dill_unpickle(
+                os.path.join(tempfile.gettempdir(), "mpisppy_no_such_file.dill"))
+
+    def test_failed_open_does_not_delete_a_pre_existing_file(self):
+        """The cleanup must only remove a file this call actually wrote."""
+        model = self._model_with_cfg_in_bounds_rule()
+        with tempfile.TemporaryDirectory() as tmp:
+            fname = os.path.join(tmp, "precious.dill")
+            with open(fname, "wb") as f:
+                f.write(b"someone else's bytes")
+            os.chmod(fname, 0o400)          # unwritable file, writable dir
+            try:
+                with self.assertRaises(OSError):
+                    pickle_bundle.dill_pickle(model, fname)
+                self.assertTrue(
+                    os.path.exists(fname),
+                    msg="a file this call never wrote to was deleted")
+            finally:
+                os.chmod(fname, 0o600)
+
+    def test_duplicate_captures_are_reported_once(self):
+        """A bundle carries one copy of each rule per scenario."""
+        def build_block(cfg):
+            blk = pyo.Block(concrete=True)
+            blk.x = pyo.Var([1, 2])
+
+            def con_rule(b, i):
+                return b.x[i] >= (1 if cfg.max_iterations else 0)
+
+            blk.c = pyo.Constraint([1, 2], rule=con_rule)
+            return blk
+
+        cfg = Config()
+        cfg.popular_args()
+        model = pyo.ConcreteModel()
+        for i in range(5):                  # five "scenarios", one shared cfg
+            setattr(model, f"s{i}", build_block(cfg))
+
+        found = pickle_bundle.find_undillable_closures(model)
+        self.assertEqual(
+            found, [("con_rule", "cfg", "Config")],
+            msg="the same capture was reported once per scenario")
+
+    def test_bound_method_rule_is_diagnosed(self):
+        """A class-based builder reaches its config through self, not a cell."""
+        class Builder:
+            def __init__(self):
+                self.cfg = Config()
+                self.cfg.popular_args()
+
+            def con_rule(self, m, i):
+                return m.x[i] >= (1 if self.cfg.max_iterations else 0)
+
+        builder = Builder()
+        model = pyo.ConcreteModel()
+        model.x = pyo.Var([1, 2])
+        model.c = pyo.Constraint([1, 2], rule=builder.con_rule)
+
+        with self.assertRaises(Exception):
+            self.dill.dumps(model)
+        found = pickle_bundle.find_undillable_closures(model)
+        self.assertTrue(found, msg="bound-method rule was not diagnosed")
+        self.assertIn("self.cfg", [varname for _, varname, _ in found])
+
+
+class Test_dill_diagnostics_without_dill(unittest.TestCase):
+    """With dill absent the diagnostic must not invent a culprit.
+
+    dill is optional and reached through Pyomo's attempt_import, so calling it
+    raises DeferredImportError -- an ordinary Exception. Without a guard, the
+    serializability probe treats every closure value as unserializable and
+    tells the user to rewrite a scenario_creator over, say, an int.
+    """
+
+    def test_find_returns_nothing_when_dill_is_missing(self):
+        """Simulate a genuinely absent dill, not just a lowered flag.
+
+        attempt_import hands back a module proxy that raises on first use, so
+        every serializability probe raises rather than returning False. Merely
+        setting dill_available = False while dill is still importable would not
+        reproduce the bug this guards.
+        """
+        model = pyo.ConcreteModel()
+        limit = 10                      # perfectly serializable
+
+        def bounds_rule(m, i):
+            return (0, limit)
+
+        model.v = pyo.Var([1, 2], bounds=bounds_rule)
+
+        class _AbsentDill:
+            def dumps(self, *args, **kwargs):
+                raise DeferredImportError(
+                    "The dill module (an optional mpi-sppy dependency) failed "
+                    "to import: No module named 'dill'")
+
+        saved_flag = pickle_bundle.dill_available
+        saved_mod = pickle_bundle.dill
+        try:
+            pickle_bundle.dill_available = False
+            pickle_bundle.dill = _AbsentDill()
+            self.assertEqual(
+                pickle_bundle.find_undillable_closures(model), [],
+                msg="with dill absent, every closure value was misreported "
+                    "as the culprit")
+        finally:
+            pickle_bundle.dill_available = saved_flag
+            pickle_bundle.dill = saved_mod
+
+    def test_description_says_dill_is_missing(self):
+        model = pyo.ConcreteModel()
+        saved = pickle_bundle.dill_available
+        try:
+            pickle_bundle.dill_available = False
+            msg = pickle_bundle.describe_dill_failure(
+                model, RuntimeError("boom"))
+        finally:
+            pickle_bundle.dill_available = saved
+        self.assertIn("dill is not installed", msg)
+        self.assertNotIn("closes over", msg)
+
+    def test_broken_diagnostic_is_disclosed_not_hidden(self):
+        """If the walk itself breaks, say so instead of claiming it ran clean."""
+        model = pyo.ConcreteModel()
+        saved = pickle_bundle.find_undillable_closures
+
+        def boom(_model):
+            raise TypeError("diagnostic itself is broken")
+
+        try:
+            pickle_bundle.find_undillable_closures = boom
+            msg = pickle_bundle.describe_dill_failure(
+                model, RuntimeError("original failure"))
+        finally:
+            pickle_bundle.find_undillable_closures = saved
+        self.assertIn("closure diagnostic itself failed", msg)
+        self.assertIn("diagnostic itself is broken", msg)
 
 
 if __name__ == '__main__':

--- a/mpisppy/utils/pickle_bundle.py
+++ b/mpisppy/utils/pickle_bundle.py
@@ -26,6 +26,8 @@ dill, dill_available = attempt_import("dill")
 # BoundInitializer._initializer._fcn), so a shallow depth suffices.
 _DIAGNOSTIC_MAX_DEPTH = 4
 _DIAGNOSTIC_MAX_VISITS = 20000
+# Bound on how many attributes of a bound method's owner get reported.
+_DIAGNOSTIC_MAX_SELF_ATTRS = 5
 
 
 def _attributes_of(obj):
@@ -104,9 +106,12 @@ def _is_dillable(value, memo):
 
 
 def _unserializable_captures(func, memo):
-    """Yield (description, value) for things `func` carries that dill rejects.
+    """Yield (kind, description, value) for what `func` carries that dill rejects.
 
-    Covers both closure cells and, for a bound method, the attributes of the
+    `kind` is "closure" or "self", so the caller can give advice that matches
+    how the value was actually captured.
+
+    Covers closure cells and, for a bound method, the attributes of the
     instance it is bound to -- a rule written as a method on a model-builder
     class reaches its configuration through ``self``, not through a closure.
     """
@@ -118,35 +123,68 @@ def _unserializable_captures(func, memo):
         except ValueError:
             continue  # empty cell
         if not _is_dillable(value, memo):
-            yield name, value
+            yield "closure", name, value
 
     owner = getattr(func, "__self__", None)
-    if owner is not None and not _is_dillable(owner, memo):
-        reported = False
-        for attr, value in _attributes_of(owner):
-            if not _is_dillable(value, memo):
-                yield f"self.{attr}", value
-                reported = True
-        if not reported:
-            # Nothing individually unserializable; the instance itself is.
-            yield "self", owner
+    if owner is None or _is_owner_uninteresting(owner):
+        return
+    if _is_dillable(owner, memo):
+        return
+    # Expanding a large owner is both slow and misleading: every attribute
+    # that merely *reaches* the real culprit tests as unserializable too, so
+    # a model-sized owner buries the answer in red herrings. Report a bounded
+    # number of specific attributes, and fall back to naming the instance.
+    reported = 0
+    for attr, value in _attributes_of(owner):
+        if reported >= _DIAGNOSTIC_MAX_SELF_ATTRS:
+            break
+        if not _is_dillable(value, memo):
+            yield "self", f"self.{attr}", value
+            reported += 1
+    if not reported:
+        yield "self", "self", owner
+
+
+def _is_owner_uninteresting(owner):
+    """True when a bound method's owner is not a model-builder object.
+
+    The case this diagnostic wants is a small class that builds models and
+    holds configuration. A Pyomo component -- most often the model itself,
+    reached through something like ``model._helper = model.clone`` -- is not
+    that, and expanding it produces pages of attributes that are unserializable
+    only because they transitively reach the same real culprit.
+    """
+    try:
+        from pyomo.core.base.component import ComponentBase
+    except ImportError:      # pragma: no cover - very old Pyomo
+        return False
+    return isinstance(owner, ComponentBase)
 
 
 def find_undillable_closures(model):
-    """Locate closure variables on `model` that dill cannot serialize.
+    """Locate values a rule on `model` carries that dill cannot serialize.
 
-    Returns a list of (rule_name, freevar_name, value_type_name), deduplicated:
-    a bundle holds one copy of each rule per scenario, and reporting the same
-    capture hundreds of times helps nobody.
+    Returns a deduplicated list of
+    (rule_name, capture_name, value_type_name, kind), where `kind` is
+    "closure" for a value in a rule's closure cell and "self" for one reached
+    through the instance a bound-method rule belongs to. Deduplication matters
+    because a bundle holds one copy of each rule per scenario.
 
     Pyomo keeps a reference to each rule function on the component it built, so
-    anything a rule closed over is reachable from the model and has to be
+    anything a rule captured is reachable from the model and has to be
     serializable too -- which is how an otherwise ordinary model becomes
     unpicklable.
 
-    Known limitation: this looks at rule *closures*. An unserializable object
-    stored directly on the model (``model._handle = ...``) or inside a plain
-    container is not reported, though it fails just the same.
+    Known limitation: only what a *rule* carries is inspected. An
+    unserializable object stored directly on the model
+    (``model._handle = ...``) or inside a plain container is not reported,
+    though it fails just the same; the caller says so when nothing is found.
+
+    Not idempotent, by nature: probing a value serializes it, and serializing
+    a Pyomo ConfigValue resolves its default and changes its class. Calling
+    this repeatedly on one model can therefore report fewer culprits each
+    time. It runs on a failure path where the run is ending anyway, and
+    resolving a default is semantically a no-op.
     """
     if not dill_available:
         # Without dill every serialization test below would raise, and every
@@ -164,9 +202,9 @@ def find_undillable_closures(model):
             if id(func) in seen_funcs:
                 continue
             seen_funcs.add(id(func))
-            for varname, value in _unserializable_captures(func, memo):
+            for kind, varname, value in _unserializable_captures(func, memo):
                 entry = (getattr(func, "__name__", "<unknown>"),
-                         varname, type(value).__name__)
+                         varname, type(value).__name__, kind)
                 if entry not in found:
                     found.append(entry)
     return found
@@ -204,18 +242,33 @@ def describe_dill_failure(model, exc, what="model"):
             "Pyomo rule. Pyomo keeps the rule function on the component it "
             "built, so whatever the rule closed over must be serializable "
             "too. Found:")
-        for rule, varname, typename in culprits:
-            lines.append(f"  - rule {rule}() closes over '{varname}' "
+        for rule, varname, typename, kind in culprits:
+            verb = "closes over" if kind == "closure" else "reaches"
+            lines.append(f"  - rule {rule}() {verb} '{varname}' "
                          f"of type {typename}")
         lines.append("")
+        if any(kind == "closure" for *_, kind in culprits):
+            lines.append(
+                "For a rule defined as a nested function, fix this in the "
+                "model: read the values the rule needs into plain local "
+                "variables before defining it, so the closure captures those "
+                "values rather than the object holding them. For example, "
+                "'seed = cfg.initial_seed' outside the rule, using 'seed' "
+                "inside it.")
+        if any(kind == "self" for *_, kind in culprits):
+            lines.append(
+                "For a rule defined as a method, the value is reached through "
+                "the instance the method is bound to, not through a closure. "
+                "Either keep the unserializable attribute off that instance, "
+                "or have the method read from plain data copied onto it "
+                "during construction.")
         lines.append(
-            "Fix this in the model: read the values the rule needs into plain "
-            "local variables before defining it, so the closure captures those "
-            "values rather than the object holding them. For example, "
-            "'seed = cfg.initial_seed' outside the rule, using 'seed' inside "
-            "it. (An mpi-sppy Config is a Pyomo ConfigDict, and a populated "
-            "ConfigDict does not survive serialization -- by dill or by the "
-            "standard pickle module.)")
+            "(An mpi-sppy Config is a Pyomo ConfigDict. A ConfigDict whose "
+            "entries still hold unresolved defaults fails the first time it "
+            "is serialized -- a Pyomo lazy-initialization quirk, not "
+            "something dill does differently: reading an entry flips its "
+            "class, and that happens while the pickler is already reading "
+            "its state.)")
     else:
         lines.append("")
         lines.append(
@@ -236,12 +289,27 @@ def describe_dill_failure(model, exc, what="model"):
     return "\n".join(lines)
 
 
+def _remove_quietly(fname):
+    try:
+        os.remove(fname)
+    except OSError:
+        pass
+
+
 def dill_pickle(model, fname):
     """ serialize model using dill to file name"""
     # global_toc(f"about to pickle to {fname}")
+    if not dill_available:
+        # Check before opening: otherwise we truncate the target on the way to
+        # discovering we cannot write it.
+        raise RuntimeError(
+            "dill is required to pickle scenarios and bundles but is not "
+            "installed. It is an optional dependency; install it with "
+            "'pip install mpi-sppy[extras]' (or 'pip install dill')."
+        )
     # Opening is deliberately outside the try below: an OSError here (missing
-    # directory, unwritable path) is self-explanatory and must not be dressed
-    # up as a serialization failure -- nor must it trigger the cleanup, which
+    # directory, unwritable path) is self-explanatory, must not be dressed up
+    # as a serialization failure, and must not trigger the cleanup -- that
     # would delete a pre-existing file this call never wrote to.
     f = open(fname, "wb")
     try:
@@ -250,15 +318,13 @@ def dill_pickle(model, fname):
         finally:
             f.close()
     except OSError:
+        # An OSError from here is a write failure (disk full, quota, NFS),
+        # not an open failure -- the file exists and holds our own truncated
+        # write. Clean it up, then let the error speak for itself.
+        _remove_quietly(fname)
         raise
     except Exception as exc:
-        # We truncated this file on open, so the only thing on disk now is our
-        # own partial write; remove it rather than leave something a later run
-        # would try to load.
-        try:
-            os.remove(fname)
-        except OSError:
-            pass
+        _remove_quietly(fname)
         raise RuntimeError(
             describe_dill_failure(model, exc,
                                   what=f"model destined for '{fname}'")

--- a/mpisppy/utils/pickle_bundle.py
+++ b/mpisppy/utils/pickle_bundle.py
@@ -15,24 +15,189 @@
 
 # BTW: ssn (not in this repo) uses this as of March 2022
 
+import inspect
 import os
 from pyomo.common.dependencies import attempt_import
 dill, dill_available = attempt_import("dill")
 
+# Bound the search in _closures_reachable_from so a large model cannot turn a
+# failed pickle into a long walk. Pyomo nests a rule a few levels down (a
+# Constraint keeps IndexedCallInitializer._fcn; a Var's bounds rule sits under
+# BoundInitializer._initializer._fcn), so a shallow depth suffices.
+_DIAGNOSTIC_MAX_DEPTH = 4
+_DIAGNOSTIC_MAX_VISITS = 20000
+
+
+def _attributes_of(obj):
+    """Yield (name, value) over both __dict__ and __slots__ attributes.
+
+    Pyomo's Initializer classes use __slots__, so vars() alone misses the rule
+    functions this diagnostic is looking for.
+    """
+    d = getattr(obj, "__dict__", None)
+    if isinstance(d, dict):
+        yield from list(d.items())
+    for cls in type(obj).__mro__:
+        for name in getattr(cls, "__slots__", ()) or ():
+            try:
+                yield name, getattr(obj, name)
+            except AttributeError:
+                continue
+
+
+def _closures_reachable_from(root):
+    """Yield functions that carry a closure, reachable from root.
+
+    Walks a bounded neighborhood rather than the whole object graph: we only
+    descend into plain helper objects (Pyomo initializers and the like), never
+    into other model components, and stop at a fixed depth and visit count.
+    """
+    seen = set()
+    visits = 0
+    stack = [(root, 0)]
+    while stack:
+        obj, depth = stack.pop()
+        if depth > _DIAGNOSTIC_MAX_DEPTH:
+            continue
+        if id(obj) in seen:
+            continue
+        seen.add(id(obj))
+        visits += 1
+        if visits > _DIAGNOSTIC_MAX_VISITS:
+            return
+        if inspect.isfunction(obj) or inspect.ismethod(obj):
+            if getattr(obj, "__closure__", None):
+                yield obj
+            continue
+        if isinstance(obj, (str, bytes, int, float, bool, type(None))):
+            continue
+        for _, value in _attributes_of(obj):
+            stack.append((value, depth + 1))
+
+
+def _unserializable_closure_cells(func):
+    """Yield (freevar_name, value) for closure cells dill cannot serialize."""
+    cells = getattr(func, "__closure__", None) or ()
+    names = getattr(getattr(func, "__code__", None), "co_freevars", ()) or ()
+    for name, cell in zip(names, cells):
+        try:
+            value = cell.cell_contents
+        except ValueError:
+            continue  # empty cell
+        try:
+            dill.dumps(value)
+        except Exception:
+            yield name, value
+
+
+def find_undillable_closures(model):
+    """Locate closure variables on `model` that dill cannot serialize.
+
+    Returns a list of (rule_name, freevar_name, value_type_name). Pyomo keeps a
+    reference to each rule function on the component it built, so anything a
+    rule closed over is reachable from the model and has to be serializable
+    too -- which is how an otherwise ordinary model becomes unpicklable.
+    """
+    found = []
+    seen_rules = set()
+    try:
+        components = list(model.component_objects(descend_into=True))
+    except Exception:
+        components = []
+    for comp in [model] + components:
+        for func in _closures_reachable_from(comp):
+            key = (getattr(func, "__qualname__", repr(func)), id(func))
+            if key in seen_rules:
+                continue
+            seen_rules.add(key)
+            for varname, value in _unserializable_closure_cells(func):
+                found.append((getattr(func, "__name__", "<unknown>"),
+                              varname, type(value).__name__))
+    return found
+
+
+def describe_dill_failure(model, exc, what="model"):
+    """Explain, as concretely as possible, why `model` could not be dilled.
+
+    dill's own error is typically opaque (e.g. "args[0] from __newobj__ args
+    has the wrong class"), naming neither the component nor the offending
+    object. When the cause is something captured in a rule's closure -- the
+    common case -- this pins it down by name.
+    """
+    lines = [f"Could not serialize the {what} with dill: "
+             f"{type(exc).__name__}: {exc}"]
+    try:
+        culprits = find_undillable_closures(model)
+    except Exception:
+        culprits = []
+
+    if culprits:
+        lines.append("")
+        lines.append(
+            "The cause appears to be a value captured in the closure of a "
+            "Pyomo rule. Pyomo keeps the rule function on the component it "
+            "built, so whatever the rule closed over must be serializable "
+            "too. Found:")
+        for rule, varname, typename in culprits:
+            lines.append(f"  - rule {rule}() closes over '{varname}' "
+                         f"of type {typename}")
+        lines.append("")
+        lines.append(
+            "Fix this in the model: read the values the rule needs into plain "
+            "local variables before defining it, so the closure captures those "
+            "values rather than the object holding them. For example, "
+            "'seed = cfg.initial_seed' outside the rule, using 'seed' inside "
+            "it. (An mpi-sppy Config is a Pyomo ConfigDict, which dill cannot "
+            "serialize even though the standard pickle module can.)")
+    else:
+        lines.append("")
+        lines.append(
+            "No unserializable value was found in a Pyomo rule closure, so "
+            "something else reachable from the model cannot be serialized: an "
+            "object stored on the model itself, or on one of its components. "
+            "The exception above often names the offending type; dill handles "
+            "more than the standard pickle module does, so what fails here is "
+            "usually a live handle on something outside the process rather "
+            "than ordinary data. Note that mpi-sppy strips the solver plugin "
+            "it attaches before serializing, so an attached solver is only an "
+            "issue if the model holds one of its own.")
+    return "\n".join(lines)
+
+
 def dill_pickle(model, fname):
     """ serialize model using dill to file name"""
     # global_toc(f"about to pickle to {fname}")
-    with open(fname, "wb") as f:
-        dill.dump(model, f)
+    try:
+        with open(fname, "wb") as f:
+            dill.dump(model, f)
+    except Exception as exc:
+        # Do not leave a truncated file that a later run would try to load.
+        try:
+            os.remove(fname)
+        except OSError:
+            pass
+        raise RuntimeError(
+            describe_dill_failure(model, exc,
+                                  what=f"model destined for '{fname}'")
+        ) from exc
     # global_toc(f"done with pickle {fname}")
 
 
 def dill_unpickle(fname):
     """ load a model from fname"""
-    
+
     # global_toc(f"about to unpickle {fname}")
-    with open(fname, "rb") as f:
-        m = dill.load(f)
+    try:
+        with open(fname, "rb") as f:
+            m = dill.load(f)
+    except Exception as exc:
+        raise RuntimeError(
+            f"Could not load the dilled model in '{fname}' "
+            f"({type(exc).__name__}: {exc}). A dilled model is only readable "
+            f"by the same environment that wrote it -- the same Python, "
+            f"Pyomo, dill, and model code -- so this usually means the file "
+            f"is from a different environment, or is truncated."
+        ) from exc
     # global_toc(f"done with unpickle {fname}")
     return m
 

--- a/mpisppy/utils/pickle_bundle.py
+++ b/mpisppy/utils/pickle_bundle.py
@@ -48,9 +48,13 @@ def _attributes_of(obj):
 def _closures_reachable_from(root):
     """Yield functions that carry a closure, reachable from root.
 
-    Walks a bounded neighborhood rather than the whole object graph: we only
-    descend into plain helper objects (Pyomo initializers and the like), never
-    into other model components, and stop at a fixed depth and visit count.
+    Walks a bounded neighborhood of `root` -- following both __dict__ and
+    __slots__ attributes, whatever they hold -- and stops at a fixed depth and
+    visit count. It does descend into whatever it finds, model components
+    included; the caps, not the object kind, are what bound it. The visit cap
+    can truncate the walk on a very large subproblem, which is harmless here
+    because find_undillable_closures re-roots at every component, so a rule
+    missed from one starting point is reached from its own.
     """
     seen = set()
     visits = 0
@@ -66,7 +70,10 @@ def _closures_reachable_from(root):
         if visits > _DIAGNOSTIC_MAX_VISITS:
             return
         if inspect.isfunction(obj) or inspect.ismethod(obj):
-            if getattr(obj, "__closure__", None):
+            # Bound methods are yielded whether or not they close over
+            # anything: for a class-based model builder the culprit is
+            # typically an attribute of __self__, not a closure cell.
+            if inspect.ismethod(obj) or getattr(obj, "__closure__", None):
                 yield obj
             continue
         if isinstance(obj, (str, bytes, int, float, bool, type(None))):
@@ -75,8 +82,34 @@ def _closures_reachable_from(root):
             stack.append((value, depth + 1))
 
 
-def _unserializable_closure_cells(func):
-    """Yield (freevar_name, value) for closure cells dill cannot serialize."""
+def _is_dillable(value, memo):
+    """Test whether dill can serialize `value`, memoized by object identity.
+
+    A proper bundle is an EF over many scenarios, each carrying its own copy of
+    the rule functions, so the same large closure value is reached again and
+    again; without the memo a big dillable dataset gets re-serialized once per
+    scenario. The memo maps id -> (value, result) and holds the value, both to
+    keep the answer and to keep the object alive so its id cannot be recycled.
+    """
+    key = id(value)
+    if key in memo:
+        return memo[key][1]
+    try:
+        dill.dumps(value)
+        result = True
+    except Exception:
+        result = False
+    memo[key] = (value, result)
+    return result
+
+
+def _unserializable_captures(func, memo):
+    """Yield (description, value) for things `func` carries that dill rejects.
+
+    Covers both closure cells and, for a bound method, the attributes of the
+    instance it is bound to -- a rule written as a method on a model-builder
+    class reaches its configuration through ``self``, not through a closure.
+    """
     cells = getattr(func, "__closure__", None) or ()
     names = getattr(getattr(func, "__code__", None), "co_freevars", ()) or ()
     for name, cell in zip(names, cells):
@@ -84,35 +117,58 @@ def _unserializable_closure_cells(func):
             value = cell.cell_contents
         except ValueError:
             continue  # empty cell
-        try:
-            dill.dumps(value)
-        except Exception:
+        if not _is_dillable(value, memo):
             yield name, value
+
+    owner = getattr(func, "__self__", None)
+    if owner is not None and not _is_dillable(owner, memo):
+        reported = False
+        for attr, value in _attributes_of(owner):
+            if not _is_dillable(value, memo):
+                yield f"self.{attr}", value
+                reported = True
+        if not reported:
+            # Nothing individually unserializable; the instance itself is.
+            yield "self", owner
 
 
 def find_undillable_closures(model):
     """Locate closure variables on `model` that dill cannot serialize.
 
-    Returns a list of (rule_name, freevar_name, value_type_name). Pyomo keeps a
-    reference to each rule function on the component it built, so anything a
-    rule closed over is reachable from the model and has to be serializable
-    too -- which is how an otherwise ordinary model becomes unpicklable.
+    Returns a list of (rule_name, freevar_name, value_type_name), deduplicated:
+    a bundle holds one copy of each rule per scenario, and reporting the same
+    capture hundreds of times helps nobody.
+
+    Pyomo keeps a reference to each rule function on the component it built, so
+    anything a rule closed over is reachable from the model and has to be
+    serializable too -- which is how an otherwise ordinary model becomes
+    unpicklable.
+
+    Known limitation: this looks at rule *closures*. An unserializable object
+    stored directly on the model (``model._handle = ...``) or inside a plain
+    container is not reported, though it fails just the same.
     """
+    if not dill_available:
+        # Without dill every serialization test below would raise, and every
+        # closure cell would be misreported as the culprit.
+        return []
     found = []
-    seen_rules = set()
+    seen_funcs = set()
+    memo = {}
     try:
         components = list(model.component_objects(descend_into=True))
     except Exception:
         components = []
     for comp in [model] + components:
         for func in _closures_reachable_from(comp):
-            key = (getattr(func, "__qualname__", repr(func)), id(func))
-            if key in seen_rules:
+            if id(func) in seen_funcs:
                 continue
-            seen_rules.add(key)
-            for varname, value in _unserializable_closure_cells(func):
-                found.append((getattr(func, "__name__", "<unknown>"),
-                              varname, type(value).__name__))
+            seen_funcs.add(id(func))
+            for varname, value in _unserializable_captures(func, memo):
+                entry = (getattr(func, "__name__", "<unknown>"),
+                         varname, type(value).__name__)
+                if entry not in found:
+                    found.append(entry)
     return found
 
 
@@ -126,10 +182,20 @@ def describe_dill_failure(model, exc, what="model"):
     """
     lines = [f"Could not serialize the {what} with dill: "
              f"{type(exc).__name__}: {exc}"]
+
+    if not dill_available:
+        lines.append("")
+        lines.append(
+            "dill is not installed. It is an optional dependency; install it "
+            "with 'pip install mpi-sppy[extras]' (or 'pip install dill').")
+        return "\n".join(lines)
+
+    diagnostic_error = None
     try:
         culprits = find_undillable_closures(model)
-    except Exception:
+    except Exception as diag_exc:
         culprits = []
+        diagnostic_error = f"{type(diag_exc).__name__}: {diag_exc}"
 
     if culprits:
         lines.append("")
@@ -147,31 +213,48 @@ def describe_dill_failure(model, exc, what="model"):
             "local variables before defining it, so the closure captures those "
             "values rather than the object holding them. For example, "
             "'seed = cfg.initial_seed' outside the rule, using 'seed' inside "
-            "it. (An mpi-sppy Config is a Pyomo ConfigDict, which dill cannot "
-            "serialize even though the standard pickle module can.)")
+            "it. (An mpi-sppy Config is a Pyomo ConfigDict, and a populated "
+            "ConfigDict does not survive serialization -- by dill or by the "
+            "standard pickle module.)")
     else:
         lines.append("")
         lines.append(
             "No unserializable value was found in a Pyomo rule closure, so "
             "something else reachable from the model cannot be serialized: an "
-            "object stored on the model itself, or on one of its components. "
-            "The exception above often names the offending type; dill handles "
-            "more than the standard pickle module does, so what fails here is "
-            "usually a live handle on something outside the process rather "
-            "than ordinary data. Note that mpi-sppy strips the solver plugin "
-            "it attaches before serializing, so an attached solver is only an "
-            "issue if the model holds one of its own.")
+            "object stored on the model itself, or on one of its components, "
+            "or held inside a plain container. The exception above often names "
+            "the offending type. Note that a live handle on something outside "
+            "the process -- a solver interface, a connection, an open "
+            "resource -- is the usual culprit; keep such things off the model "
+            "if it has to be serialized.")
+        if diagnostic_error is not None:
+            lines.append("")
+            lines.append(
+                f"(The closure diagnostic itself failed with "
+                f"{diagnostic_error}, so it could not rule that cause in or "
+                f"out. This is a bug in mpi-sppy, not in your model.)")
     return "\n".join(lines)
 
 
 def dill_pickle(model, fname):
     """ serialize model using dill to file name"""
     # global_toc(f"about to pickle to {fname}")
+    # Opening is deliberately outside the try below: an OSError here (missing
+    # directory, unwritable path) is self-explanatory and must not be dressed
+    # up as a serialization failure -- nor must it trigger the cleanup, which
+    # would delete a pre-existing file this call never wrote to.
+    f = open(fname, "wb")
     try:
-        with open(fname, "wb") as f:
+        try:
             dill.dump(model, f)
+        finally:
+            f.close()
+    except OSError:
+        raise
     except Exception as exc:
-        # Do not leave a truncated file that a later run would try to load.
+        # We truncated this file on open, so the only thing on disk now is our
+        # own partial write; remove it rather than leave something a later run
+        # would try to load.
         try:
             os.remove(fname)
         except OSError:
@@ -187,16 +270,25 @@ def dill_unpickle(fname):
     """ load a model from fname"""
 
     # global_toc(f"about to unpickle {fname}")
+    # As in dill_pickle: a missing or unreadable file speaks for itself, and
+    # saying "this is from a different environment" about a path that does not
+    # exist would be actively misleading. Bundle file names are constructed by
+    # name (see proper_bundler), so a naming mismatch lands here routinely.
+    f = open(fname, "rb")
     try:
-        with open(fname, "rb") as f:
+        try:
             m = dill.load(f)
+        finally:
+            f.close()
+    except OSError:
+        raise
     except Exception as exc:
         raise RuntimeError(
             f"Could not load the dilled model in '{fname}' "
             f"({type(exc).__name__}: {exc}). A dilled model is only readable "
             f"by the same environment that wrote it -- the same Python, "
             f"Pyomo, dill, and model code -- so this usually means the file "
-            f"is from a different environment, or is truncated."
+            f"was written by a different environment, or is truncated."
         ) from exc
     # global_toc(f"done with unpickle {fname}")
     return m


### PR DESCRIPTION
Addresses the "clearer error" half of #828. Independent of #830, which fixes
the `stoch_distr` example itself; this makes the *next* such model diagnosable.

## The problem

`dill_pickle` was a bare `dill.dump` with no error handling, and none of its
call sites wrapped it, so a user whose scenario model could not be serialized
got the raw exception:

```
_pickle.PicklingError: args[0] from __newobj__ args has the wrong class
```

That names neither the model, nor the component, nor the object that actually
failed. Diagnosing one real instance of it took a control experiment plus a
`dill.detect.trace` walk.

The common cause is a value captured in the closure of a Pyomo rule. Pyomo
keeps the rule function on the component it built, so whatever the rule closed
over has to be serializable too — and a rule defined inside a
`scenario_creator` that reads `cfg` directly captures the entire `Config`,
which is a Pyomo `ConfigDict`; a populated ConfigDict does not survive
serialization (see the correction at the end of this description).

## What this does

`find_undillable_closures(model)` walks a bounded neighborhood of each
component for rule functions and tests each closure cell, so the message can
name the rule and the variable. The walk handles `__slots__` as well as
`__dict__` — Pyomo's initializers use slots, and a `Var` bounds rule sits three
levels down under `BoundInitializer._initializer._fcn`. It is depth- and
visit-capped, and runs only on the failure path.

On the pre-fix `stoch_distr` example:

```
Could not serialize the model destined for '.../scen.dill' with dill:
PicklingError: args[0] from __newobj__ args has the wrong class

The cause appears to be a value captured in the closure of a Pyomo rule. Pyomo
keeps the rule function on the component it built, so whatever the rule closed
over must be serializable too. Found:
  - rule FlowBalance_rule() closes over 'cfg' of type Config
  - rule slackBounds_rule() closes over 'cfg' of type Config

Fix this in the model: read the values the rule needs into plain local
variables before defining it, so the closure captures those values rather than
the object holding them. ...
```

Both offending rules, by name.

**When no closure culprit is found**, the message says exactly that and reports
the underlying exception, rather than asserting a cause that may not apply. A
confidently wrong explanation is worse than a raw traceback, because it sends
the reader down the wrong path; a test pins that the closure explanation does
not appear in that case.

Placement is deliberate: `pickle_bundle.dill_pickle` is the chokepoint every
dill application already funnels through — all four `generic/scenario_io.py`
call sites (`--pickle-scenarios-dir`, `--pickle-bundles-dir`, the pre-pickle
pipeline) and `aircondB.py` — so they all benefit with no call-site changes,
and checkpoint/resume (#777) can drop its own local hint and call this instead.

## Behavior changes to be aware of

- A failed `dill_pickle` now raises `RuntimeError` (chained from the original
  via `raise ... from exc`) rather than propagating `PicklingError` directly.
  Anything catching `PicklingError` around it would need updating; nothing in
  the repo does.
- `dill_pickle` removes a partially written file before re-raising, so a later
  run cannot try to load a truncated pickle.
- `dill_unpickle` wraps load errors to explain that a dilled model is only
  readable by the environment that wrote it.

## Tests

8 tests added to `mpisppy/tests/test_pickle_bundle.py` (already CI-wired):
the culprit is found via a `Var` bounds rule and via a `Constraint` rule, a
clean model yields no findings, the description names the rule/variable/type,
an unrelated failure is *not* misdiagnosed, `dill_pickle` raises with the
diagnosis and leaves no partial file, a good model still round-trips, and
`dill_unpickle` explains an unreadable file.

Note for anyone extending these: the rules must be defined *nested* to create a
real closure, as they are inside a `scenario_creator`. A module-level rule
captures a global instead, and the failure does not reproduce.

`test_pickle_bundle.py`, `test_pre_pickle_pipeline.py` and
`test_proper_bundler.py`: 43 passed. `ruff check` clean.

---

## Update: review findings fixed, and a correction

A review pass found several ways this could mislead rather than help. All are
fixed in `69f0cb67`; each new test was checked against the pre-fix code and
fails there.

**Correction to the claim above.** I originally wrote that a Pyomo `ConfigDict`
fails under `dill` but pickles fine with the stdlib. That is false — and so is
the opposite. Measured with a *fresh* object each time:

| object | `pickle` | `dill` |
|---|---|---|
| bare `ConfigDict()` | OK | OK |
| `ConfigDict` + one `ConfigValue` | **FAIL** | **FAIL** |
| `Config().popular_args()` | **FAIL** | **FAIL** |

A populated ConfigDict fails under **both**. The earlier result came from
serializing the *same* object twice within one test: the first attempt fails
and the second succeeds, whichever library goes first, and merely reading the
object's slots beforehand is enough to make it succeed. So this is a
lazy-initialization problem in Pyomo rather than a dill-vs-pickle difference,
and it means the failure can depend on whether anything touched the config
earlier. The message text now claims only what is true.

**Fixes:**

1. **dill absent produced a fabricated culprit.** `dill` is optional and reached
   through `attempt_import`, so each probe raised `DeferredImportError`, which
   the broad `except` read as "unserializable" — reporting *every* closure cell.
   A user without dill was told an `int` was unserializable and to go rewrite
   their `scenario_creator`. Both entry points now check `dill_available` and
   say plainly that dill is missing.
2. **`os.remove` could delete a file the call never wrote.** `open()` was inside
   the `try`, so a read-only target in a writable directory failed to open and
   was then removed. `open()` is now outside it.
3. **I/O errors were dressed up as serialization failures.** `OSError` now
   propagates unwrapped in both directions. A missing directory or a misspelled
   bundle name is self-explanatory, and bundle file names are built by name
   (`proper_bundler.py`), so that path is routine rather than exotic.
4. **Removed an unsupported claim** that mpi-sppy strips the solver plugin
   before serializing — true of the checkpointing code, not of this one.
5. **Bundles.** Results are deduplicated and dillability memoized by identity.
   Previously a 25-scenario bundle printed 25 identical lines and re-serialized
   the same large captured value 25 times (~21s).
6. **A failure of the walk itself is disclosed** rather than silently reported
   as "nothing found".
7. **Bound-method rules are diagnosed** through `__self__`, which a class-based
   model builder needs.
8. **Tests no longer use `pytest.importorskip`** — this file is run as a script
   by `run_coverage.bash` and CI, where pytest's `Skipped` is not
   `unittest.SkipTest` and surfaces as an error rather than a skip.

**Known limitation, now in the docstring:** only rule closures and bound-method
owners are inspected. An unserializable object stored directly on the model
still reports "cause not found", along with the underlying exception, which
usually names the offending type.

50 tests pass across `test_pickle_bundle.py`, `test_pre_pickle_pipeline.py` and
`test_proper_bundler.py`, in both pytest and script mode. `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
