### PR TITLE
Fix outer/inner bound assignment for maximization in amalgamator

### DIFF
--- a/mpisppy/utils/amalgamator.py
+++ b/mpisppy/utils/amalgamator.py
@@ -328,12 +328,14 @@ class Amalgamator():
             
             self.is_minimizing = objs[0].is_minimizing
             #TBD : Write a function doing this
+            # The solver's Lower and Upper bounds bracket the optimal value, so
+            # which one is the outer (relaxation) bound depends on the sense.
             if self.is_minimizing:
                 self.best_outer_bound = results.Problem[0]['Lower bound']
                 self.best_inner_bound = results.Problem[0]['Upper bound']
             else:
-                self.best_inner_bound = results.Problem[0]['Upper bound']
-                self.best_outer_bound = results.Problem[0]['Lower bound']
+                self.best_outer_bound = results.Problem[0]['Upper bound']
+                self.best_inner_bound = results.Problem[0]['Lower bound']
             self.ef = ef
             
             if 'write_solution' in self.cfg:


### PR DESCRIPTION
Fixes #836.

In `Amalgamator.run`, the `best_outer_bound` / `best_inner_bound` assignment branched on `is_minimizing`, but both branches assigned the same right-hand sides — only the order of the two statements differed, which has no effect. For a maximization model the solver's `Upper bound` is the relaxation (outer) bound and the `Lower bound` is the incumbent (inner) bound, so the `else` branch had them backwards.

The fix mirrors the handling already in `mpisppy/spopt.py` (lines 370-373 and 432-437), which branches on the sense correctly. Minimization is unaffected, since the `if` branch was already right.

## Why it matters

`ciutils.gap_estimators` takes the batch optimum as `ama_object.best_outer_bound`. On a maximization model that was the incumbent rather than the relaxation bound, so the batch gap lost the conservative direction it is meant to have; that feeds the MMW confidence interval in `mmw_ci.py` and the sequential-sampling drivers.

## Scope and testing

Deliberately minimal: two right-hand sides, plus a comment on why the mapping depends on the sense.

I have not added a regression test. The existing amalgamator tests all require a solver and a full EF solve, so covering this would mean adding a maximization example model and gating the test on solver availability — disproportionate to a two-line fix, and a maintainer call rather than mine. If you would like the coverage, the cheaper route is the one the `#TBD : Write a function doing this` comment already suggests: extract the sense-to-bound mapping into a small helper shared with `spopt.py`, which would make it unit-testable with no solver at all. Happy to do that in a follow-up if you want it.

Verified that `ruff check mpisppy/utils/amalgamator.py` reports the same 9 pre-existing findings before and after, so the change is lint-neutral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
