### PR TITLE
Docs: make the console scripts the documented way to run mpi-sppy

### DIFF
--- a/doc/src/console_scripts.rst
+++ b/doc/src/console_scripts.rst
@@ -1,0 +1,105 @@
+.. _console_scripts:
+
+Console Scripts
+===============
+
+Installing mpi-sppy -- with ``pip install mpi-sppy`` or with
+``pip install -e .`` from a clone -- puts three console scripts on your
+``PATH``. They are the shortest way to run mpi-sppy: no path to a file
+inside the repository, and no need to be in the directory where
+mpi-sppy was cloned.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 32 68
+
+   * - Console script
+     - Equivalent module form
+   * - ``mpi-sppy-generic-cylinders``
+     - ``python -m mpisppy.generic_cylinders``
+   * - ``mpi-sppy-mrp-generic``
+     - ``python -m mpisppy.mrp_generic``
+   * - ``mpi-sppy-one-sided-test``
+     - ``python -m mpi_one_sided_test``
+
+Each console script takes exactly the same command-line arguments as the
+module form it replaces, so anywhere in this documentation that shows
+``python -m mpisppy.generic_cylinders ...`` you may type
+``mpi-sppy-generic-cylinders ...`` instead:
+
+.. code-block:: bash
+
+   mpi-sppy-generic-cylinders --module-name farmer --num-scens 3 \
+       --EF --EF-solver-name gurobi
+
+What each one does
+------------------
+
+``mpi-sppy-generic-cylinders``
+    The main driver: command-line access to the hub-and-spoke system,
+    the extensive form, confidence intervals, and much more, without
+    writing a driver program. See :ref:`generic_cylinders`.
+
+``mpi-sppy-mrp-generic``
+    Sequential sampling (the Multiple Replication Procedure). See
+    :ref:`Sequential Sampling Confidence Intervals`.
+
+``mpi-sppy-one-sided-test``
+    A small MPI one-sided-communication test used to check that your MPI
+    installation is suitable for mpi-sppy. It takes no arguments and is
+    meant to be run under ``mpiexec``. See :ref:`Install mpi4py`.
+
+Running in parallel
+-------------------
+
+Give the console script to ``mpiexec`` the same way you would give it any
+other command:
+
+.. code-block:: bash
+
+   mpiexec -np 3 mpi-sppy-generic-cylinders --module-name farmer \
+       --num-scens 3 --solver-name gurobi --max-iterations 10 \
+       --default-rho 1 --lagrangian --xhatshuffle
+
+The console scripts abort the whole job when a rank dies, exactly as
+``python -m mpi4py`` does: if one rank raises an uncaught exception, the
+traceback is printed and ``MPI_Abort`` is called, rather than leaving the
+surviving ranks blocked forever in a collective and the ``mpiexec`` job
+hung. That is why
+
+.. code-block:: bash
+
+   mpiexec -np 3 mpi-sppy-generic-cylinders ...
+
+and the longer module form
+
+.. code-block:: bash
+
+   mpiexec -np 3 python -m mpi4py -m mpisppy.generic_cylinders ...
+
+are equally safe. A plain ``mpiexec -np 3 python -m mpisppy.generic_cylinders ...``
+(no ``mpi4py`` runner) is the form to avoid, since a dying rank can hang
+the job. Serial runs of the console scripts re-raise normally, so
+tracebacks and exit codes are unchanged.
+
+Troubleshooting
+---------------
+
+``command not found`` (or, on Windows, "not recognized")
+    The console scripts go into the ``bin`` (``Scripts`` on Windows)
+    directory of the Python environment that ran ``pip install``, so
+    they are on your ``PATH`` only while that environment is active.
+    Activate it (``conda activate ...`` or ``source .../bin/activate``)
+    and confirm with ``which mpi-sppy-generic-cylinders`` (``where`` on
+    Windows).
+
+Running from a clone without installing
+    If you are working from a checkout and have not run ``pip install``,
+    the console scripts do not exist. Use the file form from the top of
+    the clone instead, e.g.
+    ``mpiexec -np 3 python -m mpi4py mpisppy/generic_cylinders.py ...``.
+
+Stale scripts after moving or renaming the clone
+    An editable install records the path to the clone. If you move or
+    rename the directory, re-run ``pip install -e ".[mpi]"`` from the new
+    location.

--- a/doc/src/console_scripts.rst
+++ b/doc/src/console_scripts.rst
@@ -46,8 +46,8 @@ What each one does
 
 ``mpi-sppy-one-sided-test``
     A small MPI one-sided-communication test used to check that your MPI
-    installation is suitable for mpi-sppy. It takes no arguments and is
-    meant to be run under ``mpiexec``. See :ref:`Install mpi4py`.
+    installation might be suitable for mpi-sppy. It takes no arguments
+    and is meant to be run under ``mpiexec``. See :ref:`Install mpi4py`.
 
 Running in parallel
 -------------------
@@ -94,10 +94,16 @@ Troubleshooting
     Windows).
 
 Running from a clone without installing
-    If you are working from a checkout and have not run ``pip install``,
-    the console scripts do not exist. Use the file form from the top of
-    the clone instead, e.g.
-    ``mpiexec -np 3 python -m mpi4py mpisppy/generic_cylinders.py ...``.
+    If you are working from a checkout and have not installed it with
+
+    .. code-block:: bash
+
+       pip install -e ".[mpi]"
+
+    then the console scripts do not exist. Either run that command from
+    the top of the clone, or use the file form instead, e.g.
+    ``mpiexec -np 3 python -m mpi4py mpisppy/generic_cylinders.py ...``,
+    also from the top of the clone.
 
 Stale scripts after moving or renaming the clone
     An editable install records the path to the clone. If you move or

--- a/doc/src/generic_cylinders.rst
+++ b/doc/src/generic_cylinders.rst
@@ -9,8 +9,7 @@ system, the extensive form solver, confidence intervals, and many
 other features without requiring you to write a driver program.
 
 .. note::
-   Installing mpi-sppy (with ``pip install mpi-sppy`` or with
-   ``pip install -e .`` from a clone) puts a console script named
+   Installing mpi-sppy puts a console script named
    ``mpi-sppy-generic-cylinders`` on your ``PATH``. It is equivalent to
    ``python -m mpisppy.generic_cylinders``, so in every example below you
    can substitute ``mpi-sppy-generic-cylinders`` for the
@@ -18,12 +17,10 @@ other features without requiring you to write a driver program.
 
        mpi-sppy-generic-cylinders --module-name farmer --num-scens 3 --EF --EF-solver-name gurobi
 
-   The console script installs the same abort-on-exception protection
-   as mpi4py's runner, so for multi-rank parallel runs
-   ``mpiexec -np 3 mpi-sppy-generic-cylinders ...`` and the
-   ``mpiexec -np 3 python -m mpi4py -m mpisppy.generic_cylinders ...``
-   module form shown below are equally safe: if one rank raises an
-   exception, all ranks are aborted rather than leaving the job hung.
+   For multi-rank parallel runs the console script is as safe as the
+   ``python -m mpi4py`` module form shown below: both abort all ranks
+   when one of them raises an exception, rather than leaving the job
+   hung. See :ref:`console_scripts`.
 
 Your Model File (Module)
 ------------------------

--- a/doc/src/index.rst
+++ b/doc/src/index.rst
@@ -10,6 +10,7 @@ MPI is used.
    :caption: Getting Started
 
    quick_start.rst
+   console_scripts.rst
    install_mpi.rst
 
 .. toctree::

--- a/doc/src/quick_start.rst
+++ b/doc/src/quick_start.rst
@@ -300,7 +300,7 @@ Windows.
 
    .. code-block:: powershell
 
-      mpiexec -n 3 python -m mpi4py mpisppy\generic_cylinders.py ...
+      mpiexec -n 3 mpi-sppy-generic-cylinders ...
 
 
 Install from PyPI (not recommended)
@@ -325,23 +325,25 @@ Verify Installation
 The following three checks confirm that mpi-sppy, your solver, and (if
 you installed it) MPI are all working. The commands below are
 shell-neutral: they work in bash, zsh, the WSL2 Ubuntu shell, and
-Windows PowerShell. On native Windows, if ``python`` is not on PATH but
-the Python launcher is, substitute ``py`` for ``python``. Start from the
-top of the cloned ``mpi-sppy`` repository; step 1 changes into
-``examples/farmer`` and the remaining commands are run from there.
+Windows PowerShell. They use the ``mpi-sppy-generic-cylinders`` and
+``mpi-sppy-one-sided-test`` console scripts, which the install put on
+your ``PATH`` (see :ref:`console_scripts`). Start from the top of the
+cloned ``mpi-sppy`` repository; step 1 changes into ``examples/farmer``
+and the remaining commands are run from there.
 
-1. **mpi-sppy is importable and the CLI works.** This confirms the
-   editable install succeeded and Python can import the package.
+1. **The command-line driver works.** This confirms the install
+   succeeded and put the console scripts on your ``PATH``.
 
    .. code-block:: text
 
       cd examples/farmer
-      python -m mpisppy.generic_cylinders --module-name farmer --help
+      mpi-sppy-generic-cylinders --module-name farmer --help
 
    You should see a long help message listing all available
-   command-line options. If you see ``ModuleNotFoundError: No module
-   named 'mpisppy'``, the install did not take effect in this
-   environment (most often a virtual-environment issue).
+   command-line options. If the shell reports that the command is not
+   found, the install did not take effect in this environment (most
+   often a virtual-environment issue); see :ref:`console_scripts` for
+   what to check.
 
 2. **Your solver works.** Solve the farmer extensive form directly
    with three scenarios. Substitute the solver you installed
@@ -349,14 +351,13 @@ top of the cloned ``mpi-sppy`` repository; step 1 changes into
 
    .. code-block:: text
 
-      python -m mpisppy.generic_cylinders --module-name farmer --num-scens 3 --EF --EF-solver-name gurobi
+      mpi-sppy-generic-cylinders --module-name farmer --num-scens 3 --EF --EF-solver-name gurobi
 
    You should see the solver print progress and the script print an
    optimal objective value. This check does *not* use MPI.
 
 3. **MPI works** (only if you installed MPI and ``mpi4py``). Run the
-   bundled one-sided MPI test (the console script is on your ``PATH``
-   after installation, so no path is needed):
+   bundled one-sided MPI test:
 
    .. code-block:: text
 
@@ -368,7 +369,7 @@ top of the cloned ``mpi-sppy`` repository; step 1 changes into
 
    .. code-block:: text
 
-      mpiexec -n 3 python -m mpi4py -m mpisppy.generic_cylinders --module-name farmer --num-scens 3 --solver-name gurobi --max-iterations 5 --default-rho 1 --lagrangian --xhatshuffle
+      mpiexec -n 3 mpi-sppy-generic-cylinders --module-name farmer --num-scens 3 --solver-name gurobi --max-iterations 5 --default-rho 1 --lagrangian --xhatshuffle
 
    You should see iteration output and the run should terminate
    normally.
@@ -385,17 +386,22 @@ Running the Farmer Example
 
 .. code-block:: bash
 
-   python -m mpisppy.generic_cylinders --module-name farmer \
+   mpi-sppy-generic-cylinders --module-name farmer \
        --num-scens 3 --EF --EF-solver-name gurobi
 
 **Run PH with spokes** (requires MPI):
 
 .. code-block:: bash
 
-   mpiexec -np 3 python -m mpi4py mpisppy/generic_cylinders.py \
+   mpiexec -np 3 mpi-sppy-generic-cylinders \
        --module-name farmer --num-scens 3 \
        --solver-name gurobi_persistent --max-iterations 10 \
        --default-rho 1 --lagrangian --xhatshuffle --rel-gap 0.01
+
+``mpi-sppy-generic-cylinders`` is a console script created by the
+install; it is equivalent to ``python -m mpisppy.generic_cylinders``,
+and it aborts every rank if one of them dies. See
+:ref:`console_scripts`.
 
 For more detail, see :ref:`generic_cylinders` and :ref:`Examples`.
 
@@ -412,10 +418,11 @@ following functions:
 - ``inparser_adder`` -- adds problem-specific command-line arguments (see :ref:`helper_functions`)
 - ``scenario_denouement`` -- called at termination (can be ``None``; see :ref:`helper_functions`)
 
-Once you have these functions, you can use ``generic_cylinders.py``
-(see :ref:`generic_cylinders`) to solve your problem using the EF or
-the hub-and-spoke system. See the ``farmer`` directory in ``examples``
-for a complete working example (``farmer.py`` and ``farmer_generic.bash``).
+Once you have these functions, you can use
+``mpi-sppy-generic-cylinders`` (see :ref:`generic_cylinders`) to solve
+your problem using the EF or the hub-and-spoke system. See the
+``farmer`` directory in ``examples`` for a complete working example
+(``farmer.py`` and ``farmer_generic.bash``).
 
 For models written in an algebraic modeling language other than Pyomo
 (e.g., AMPL or GAMS), see :doc:`agnostic`. For models supplied as

--- a/doc/src/seqsamp.rst
+++ b/doc/src/seqsamp.rst
@@ -20,14 +20,13 @@ The recommended way to run sequential sampling is with
 a ``--module-name`` argument pointing to your model module.
 
 .. note::
-   Installing mpi-sppy (with ``pip install mpi-sppy`` or with
-   ``pip install -e .`` from a clone) puts the console script
+   Installing mpi-sppy puts the console script
    ``mpi-sppy-mrp-generic`` on your ``PATH``; it is equivalent to
    ``python -m mpisppy.mrp_generic`` and can be used in place of that
-   prefix in the examples below; the console script installs the same
-   abort-on-exception handler as the ``python -m mpi4py`` module form,
-   so either is safe for the ``--xhat-method cylinders`` (multi-rank)
-   case.
+   prefix in the examples below. It aborts all ranks when one of them
+   raises an exception, just as the ``python -m mpi4py`` module form
+   does, so either is safe for the ``--xhat-method cylinders``
+   (multi-rank) case. See :ref:`console_scripts`.
 
 Your model module must provide the same functions required by
 ``generic_cylinders``: ``scenario_creator``, ``scenario_names_creator``,


### PR DESCRIPTION
Now that the console scripts exist, the docs should tell people to use them.

**Quick Start now uses them.** All of the verification checks, both farmer
examples, and the native-Windows `mpiexec` example switch from
`python -m mpisppy.generic_cylinders` / `python -m mpi4py mpisppy/generic_cylinders.py`
to `mpi-sppy-generic-cylinders`. The step-1 failure hint changes accordingly
from `ModuleNotFoundError` to "command not found", and the
"substitute `py` for `python` on Windows" sentence goes away with the last
`python` invocation in that section.

**New Console Scripts page** (`doc/src/console_scripts.rst`, added to the
Getting Started toctree):

- a table of all three entry points against their equivalent module forms:
  `mpi-sppy-generic-cylinders`, `mpi-sppy-mrp-generic`, `mpi-sppy-one-sided-test`
- what each one is for, linking to the pages that document it
- running under `mpiexec`, and why the console script is as safe as
  `python -m mpi4py` (both abort every rank when one dies) while plain
  `mpiexec ... python -m mpisppy.generic_cylinders` is the form to avoid
- troubleshooting: `command not found` / wrong environment, working from a
  clone with nothing installed, and a stale editable install after the clone
  is moved or renamed

The notes already in `generic_cylinders.rst` and `seqsamp.rst` now point at
the new page instead of restating the abort behavior.

Docs only; no code changes.

**Verification.** `make html SPHINXOPTS="-W --keep-going"` builds clean, so
every new cross-reference resolves. Each command form was run before being
documented: `mpi-sppy-generic-cylinders --help`, the farmer EF solve
(objective -108390.0), `mpiexec -n 3 mpi-sppy-generic-cylinders ...` with
`--lagrangian --xhatshuffle`, `mpiexec -n 2 mpi-sppy-one-sided-test`, and
`python -m mpi_one_sided_test` from outside the repository to confirm the
module form listed for it in the table.
