### PR TITLE
Ignore three more example artifacts that #833 missed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,6 +189,15 @@ examples/farmer/farmersol.npy
 examples/farmer/farmersol_soldir/
 examples/farmer/archive/farmer_plant.csv
 examples/farmer/archive/results/
+# examples/usar/write_solutions.py writes one directory per --output-dir; the
+# only committed thing beside them is that script, so the wildcard is safe
+examples/usar/solutions_*/
+# the uc EF driver writes one json per scenario here.  Named exactly:
+# examples/uc/3scenarios_r1/ next door is committed input data, so there is
+# deliberately no blanket examples/uc/3scenario* rule
+examples/uc/3scenario_EF_solution/
+# what --solution-base-name leaves behind in examples/farmer/CI
+examples/farmer/CI/farmer_mrp_xhat.*
 
 # examples/run_more.py writes <ID>.perf.csv next to itself
 examples/*.perf.csv


### PR DESCRIPTION
A follow-up to #833, which added ignore rules for the artifacts an ordinary
session leaves behind. Three more survive that sweep, and still show up
untracked after running `examples/run_all.py`:

- `examples/usar/solutions_ef/` and `examples/usar/solutions_ws/` — twelve PDFs
  between them (gantts and walks)
- `examples/uc/3scenario_EF_solution/` — one json per scenario
- `examples/farmer/CI/farmer_mrp_xhat.npy` — what `--solution-base-name` writes

The patterns follow the convention #833 established: named exactly where a
wildcard would shadow a committed fixture. `examples/uc/3scenarios_r1/` next
door is committed input data, so there is deliberately no blanket
`examples/uc/3scenario*` rule. The usar wildcard is safe because the only
committed file beside those directories is `write_solutions.py`, which is what
writes them — and it also covers the `solutions_ws_feas/` that `run_all.py`
writes on a third pass but which had not been generated locally.

Verified both directions with `git check-ignore`: the fixture and
`write_solutions.py` stay visible, the artifacts are ignored.
