### PR TITLE
PH_Prep refuses a second run

### DIFF
--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -618,7 +618,7 @@ jobs:
           include-hidden-files: true
 
   ph-main:
-    name: PH ph_main and prep tests
+    name: PH ph_main tests
     runs-on: ubuntu-latest
     needs: [ruff]
     steps:

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -618,7 +618,7 @@ jobs:
           include-hidden-files: true
 
   ph-main:
-    name: PH ph_main tests
+    name: PH ph_main and prep tests
     runs-on: ubuntu-latest
     needs: [ruff]
     steps:
@@ -641,6 +641,7 @@ jobs:
         run: |
           cd mpisppy/tests
           coverage run $COV_ARGS test_ph_main.py
+          coverage run $COV_ARGS test_ph_prep_once.py
 
       - name: Upload coverage data
         if: always()

--- a/mpisppy/phbase.py
+++ b/mpisppy/phbase.py
@@ -1025,7 +1025,7 @@ class PHBase(mpisppy.spopt.SPOpt):
 
         Note:
             PH_Prep may be run only once on an object, so a PH object solves
-            one problem. Running it twice used to look like it worked and
+            one problem. Running PH_Prep twice used to look like it worked and
             quietly solve something else: attach_Ws_and_prox re-declared W and
             rho as fresh Params, discarding the duals the first run produced,
             and attach_PH_to_objective appended a *second* PH term to the same
@@ -1035,8 +1035,8 @@ class PHBase(mpisppy.spopt.SPOpt):
             W_on count from 1 to 2, with no error and no warning.
 
             Making it genuinely re-entrant is possible but is not free -- see
-            issue #848 -- and nothing in the tree wants it: every caller that
-            runs PH more than once builds a new object. So it refuses.
+            issue #848 -- and no caller wants it: every one that runs PH more
+            than once builds a new object.
         """
         if self._PH_prep_done:
             raise RuntimeError(
@@ -1067,11 +1067,8 @@ class PHBase(mpisppy.spopt.SPOpt):
         if not self._deferred_ph_attach:
             self.attach_PH_to_objective(attach_duals, attach_prox, attach_smooth)
 
-        # Last, so that a prep which died on the way here -- a rho_setter that
-        # raised, a model the prox approximation cannot take -- does not leave
-        # the object claiming a prep it never finished. Retrying then meets
-        # whatever actually went wrong instead of "already been run", which
-        # would point at the wrong fix.
+        # Last, so a prep that raised leaves the object unprepped and the
+        # retry reports the real failure, not "already been run".
         self._PH_prep_done = True
 
 

--- a/mpisppy/phbase.py
+++ b/mpisppy/phbase.py
@@ -301,6 +301,10 @@ class PHBase(mpisppy.spopt.SPOpt):
         self.convobject = None  # PH converger
         self.attach_xbars()
 
+        # Whether PH_Prep has run. It refuses a second time: this object's W,
+        # rho and objective terms belong to one run. See PH_Prep.
+        self._PH_prep_done = False
+
     @property
     def iter0_solver_options(self):
         """Read-only fold of solver_options_layers for iteration 0.
@@ -1018,7 +1022,29 @@ class PHBase(mpisppy.spopt.SPOpt):
         Note:
             This function constructs an Extension object if one was specified
             at the time the PH object was created.
+
+        Note:
+            PH_Prep may be run only once on an object, so a PH object solves
+            one problem. Running it twice used to look like it worked and
+            quietly solve something else: attach_Ws_and_prox re-declared W and
+            rho as fresh Params, discarding the duals the first run produced,
+            and attach_PH_to_objective appended a *second* PH term to the same
+            objective, leaving the first live and anchored to the previous
+            run's xbar. Measured on farmer, W went from
+            [8.374, 33.574, -41.948] to [0.0, 0.0, 0.0] and the objective's
+            W_on count from 1 to 2, with no error and no warning.
+
+            Making it genuinely re-entrant is possible but is not free -- see
+            issue #848 -- and nothing in the tree wants it: every caller that
+            runs PH more than once builds a new object. So it refuses.
         """
+        if self._PH_prep_done:
+            raise RuntimeError(
+                "PH_Prep has already been run on this object. A PH object "
+                "solves one problem: W, rho and the objective terms it "
+                "carries belong to that run, and a second prep would discard "
+                "the first and double the terms. Build a new object.")
+        self._PH_prep_done = True
 
         self.attach_Ws_and_prox()
         if attach_smooth:

--- a/mpisppy/phbase.py
+++ b/mpisppy/phbase.py
@@ -1044,7 +1044,6 @@ class PHBase(mpisppy.spopt.SPOpt):
                 "solves one problem: W, rho and the objective terms it "
                 "carries belong to that run, and a second prep would discard "
                 "the first and double the terms. Build a new object.")
-        self._PH_prep_done = True
 
         self.attach_Ws_and_prox()
         if attach_smooth:
@@ -1067,6 +1066,13 @@ class PHBase(mpisppy.spopt.SPOpt):
         self._deferred_ph_attach = defer_attach and (self.Ag is None)
         if not self._deferred_ph_attach:
             self.attach_PH_to_objective(attach_duals, attach_prox, attach_smooth)
+
+        # Last, so that a prep which died on the way here -- a rho_setter that
+        # raised, a model the prox approximation cannot take -- does not leave
+        # the object claiming a prep it never finished. Retrying then meets
+        # whatever actually went wrong instead of "already been run", which
+        # would point at the wrong fix.
+        self._PH_prep_done = True
 
 
     def options_check(self):

--- a/mpisppy/tests/test_ph_prep_once.py
+++ b/mpisppy/tests/test_ph_prep_once.py
@@ -1,0 +1,101 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+"""PH_Prep runs once per object, and says so rather than quietly solving
+something else.
+
+Running it twice used to discard the duals and double the PH term in the
+objective. See issue #848 for what supporting a second run would take.
+"""
+
+import unittest
+
+import pyomo.environ as pyo
+
+import mpisppy.opt.ph
+import mpisppy.tests.examples.farmer as farmer
+from mpisppy.tests.utils import get_solver
+
+solver_available, solver_name, _, _ = get_solver()
+
+
+def _make_ph(**option_overrides):
+    options = {
+        "solver_name": solver_name,
+        "PHIterLimit": 2,
+        "defaultPHrho": 1,
+        "convthresh": 1e-8,
+        "verbose": False,
+        "display_timing": False,
+        "display_progress": False,
+        "smoothed": 0,
+        "toc": False,
+    }
+    options.update(option_overrides)
+    return mpisppy.opt.ph.PH(
+        options, [f"Scenario{i+1}" for i in range(3)], farmer.scenario_creator,
+        farmer.scenario_denouement,
+        scenario_creator_kwargs={"crops_multiplier": 1})
+
+
+class TestPHPrepRunsOnce(unittest.TestCase):
+
+    def test_a_second_prep_is_refused(self):
+        ph = _make_ph()
+        ph.PH_Prep()
+        with self.assertRaisesRegex(RuntimeError, "already been run"):
+            ph.PH_Prep()
+
+    def test_the_refusal_leaves_the_first_prep_alone(self):
+        # The point of refusing is that the first run's state survives: a
+        # second prep used to replace the W Param (dropping whatever was in
+        # it) and splice a second PH term into the same objective.
+        ph = _make_ph()
+        ph.PH_Prep(defer_attach=False)
+        marks, expressions = {}, {}
+        for k, s in ph.local_scenarios.items():
+            for idx in s._mpisppy_model.W:
+                s._mpisppy_model.W[idx]._value = 7.0
+            marks[k] = id(s._mpisppy_model.W)
+            expressions[k] = str(ph.saved_objectives[k].expr)
+
+        with self.assertRaises(RuntimeError):
+            ph.PH_Prep(defer_attach=False)
+
+        for k, s in ph.local_scenarios.items():
+            self.assertEqual(id(s._mpisppy_model.W), marks[k],
+                             "the W Param was replaced")
+            for idx in s._mpisppy_model.W:
+                self.assertEqual(pyo.value(s._mpisppy_model.W[idx]), 7.0)
+            self.assertEqual(str(ph.saved_objectives[k].expr), expressions[k],
+                             "a second PH term was spliced in")
+            self.assertEqual(expressions[k].count("W_on"), 1)
+
+    @unittest.skipIf(not solver_available,
+                     "%s solver is not available" % (solver_name,))
+    def test_a_second_ph_main_is_refused(self):
+        # ph_main preps, so this is the same refusal reached the way a user
+        # would reach it.
+        ph = _make_ph()
+        ph.ph_main()
+        with self.assertRaisesRegex(RuntimeError, "already been run"):
+            ph.ph_main()
+
+    @unittest.skipIf(not solver_available,
+                     "%s solver is not available" % (solver_name,))
+    def test_one_run_still_works(self):
+        ph = _make_ph(PHIterLimit=5)
+        conv, obj, trivial_bound = ph.ph_main()
+        self.assertIsNotNone(obj)
+        # farmer minimizes, so the bound with nonanticipativity dropped is
+        # below the expected value of the objective
+        self.assertLessEqual(trivial_bound, obj + 1e-6)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mpisppy/tests/test_ph_prep_once.py
+++ b/mpisppy/tests/test_ph_prep_once.py
@@ -76,6 +76,18 @@ class TestPHPrepRunsOnce(unittest.TestCase):
                              "a second PH term was spliced in")
             self.assertEqual(expressions[k].count("W_on"), 1)
 
+    def test_a_prep_that_raised_is_not_counted(self):
+        # The flag is set once the prep has been through, so a prep that died
+        # partway does not leave the object claiming one. Retrying meets the
+        # real failure rather than "already been run", which would point at
+        # the wrong fix.
+        ph = _make_ph(defaultPHrho=-1)      # attach_Ws_and_prox rejects this
+        with self.assertRaisesRegex(RuntimeError, "defaultPHrho"):
+            ph.PH_Prep()
+        self.assertFalse(ph._PH_prep_done)
+        ph.options["defaultPHrho"] = 1
+        ph.PH_Prep()                        # the corrected call goes through
+
     @unittest.skipIf(not solver_available,
                      "%s solver is not available" % (solver_name,))
     def test_a_second_ph_main_is_refused(self):

--- a/run_coverage.bash
+++ b/run_coverage.bash
@@ -107,6 +107,9 @@ run_phase "test_prox_solver_compat (serial)" \
 run_phase "test_ph_main (serial)" \
     coverage run --rcfile=.coveragerc mpisppy/tests/test_ph_main.py
 
+run_phase "test_ph_prep_once (serial)" \
+    coverage run --rcfile=.coveragerc mpisppy/tests/test_ph_prep_once.py
+
 run_phase "test_ph_extensions (serial)" \
     coverage run --rcfile=.coveragerc mpisppy/tests/test_ph_extensions.py
 


### PR DESCRIPTION
## `PH_Prep` refuses a second run

Calling `ph_main()` twice on the same object silently solved a different
problem than the caller asked for.

`attach_Ws_and_prox` re-declared `W` and `rho` as fresh Params, discarding
whatever the first run put in them, and `attach_PH_to_objective` appended a
*second* PH term to the same `saved_objectives` entry, leaving the first live
and anchored to the previous run's `xbar`. Measured on farmer:

```
W after writing into it:  [8.374, 33.574, -41.948]
W after a second PH_Prep: [0.0,    0.0,     0.0]      (and a new Param id)
objective W_on count:     1 -> 2
```

No error, no warning, wrong answer. Split out of #799, where an in-place
re-solve was a prerequisite; that PR shipped EF-only.

`PH_Prep` now raises on a second call. That is the whole change — 26 lines in
`phbase.py`. A PH object solves one problem, and the W, rho and objective
terms it carries belong to that run.

### Why refuse rather than support it

I wrote the re-entrant version first: preserve the Params instead of
re-declaring them, track per scenario what each objective already carries,
refuse the option changes a restart cannot honor (`attach_prox`,
`options["smoothed"]`, `defaultPHrho`, `linearize_proximal_terms`), keep those
refusals consistent across ranks, survive an attach that raises partway
through the scenarios, and repair the ten or so extensions that keep per-run
state. It works, and it is about 800 lines in `phbase.py` and `spopt.py` plus
the extension sweep.

Nothing wants it. Every place in the tree that runs PH more than once builds a
new object — `examples/sizes/sizes_demo.py` does it six times — and
`APH_main` and `fwph_main` cannot be re-entered at all for reasons of their
own. So this PR buys the same protection against the silent wrong answer
without asking the project to carry machinery no caller exercises.

#848 records what re-entrancy would cost, extension by extension, so that work
does not have to be rediscovered if a caller ever turns up.

### Tests

`mpisppy/tests/test_ph_prep_once.py`:

- a second `PH_Prep` is refused
- the refusal leaves the first prep alone — the `W` Param is not replaced, the
  values written into it survive, and no second term appears in the objective
- a second `ph_main()` is refused, which is how a user would meet it
- one run still works, and its trivial bound is still a bound

Three of the four fail without the change.

`test_ph_prep_once` / `test_ef_ph` / `test_aph` / `test_outer_bound_only` /
`test_extensions` / `test_ph_extensions` / prox / smoothing / maximization /
config / proper_bundler / gradient_rho / generic_cylinders / grad_rho_bundles /
reduced_costs_fixer / rho_enforcement / solver_options_layers / slammer /
w_oscillation: 591 passed, 3 skipped. `test_with_cylinders` and the FWPH-spoke
cylinder tests pass on two ranks. `ruff` clean.

### Related

- #847 — four bugs found alongside this one that bite on a *single* run
- #848 — what supporting a second run would take
