### PR TITLE
Five bugs that bite on a single run

### DIFF
--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -1374,6 +1374,7 @@ jobs:
             mpisppy/tests/test_nice_join.py \
             mpisppy/tests/test_solver_spec.py \
             mpisppy/tests/test_extensions.py \
+            mpisppy/tests/test_extension_hooks.py \
             mpisppy/tests/test_jensens.py \
             mpisppy/tests/test_vss.py \
             mpisppy/tests/test_feasible_xhat.py \

--- a/codecov.yml
+++ b/codecov.yml
@@ -9,4 +9,5 @@ coverage:
 
 ignore:
   - "examples/**"
+  - "mpisppy/agnostic/examples/**"
   - "mpisppy/tests/**"

--- a/examples/farmer/agnostic/farmer_gurobipy_agnostic.py
+++ b/examples/farmer/agnostic/farmer_gurobipy_agnostic.py
@@ -348,15 +348,14 @@ def _restore_nonants(Ag, s=None):
     _copy_nonants_from_host(s)
 
 def _restore_original_fixedness(Ag, s):
-    # s, not scenario: see the note on _fix_root_nonants below. Reached on an
-    # ordinary single run through SPOpt.post_solve_bound.
+    # The host calls this through callout_agnostic, which does
+    # fct(Ag=self, **{"s": s}), so the second parameter must be named s.
+    # SPOpt.post_solve_bound reaches it on an ordinary run.
     _copy_nonants_from_host(s)
 
 def _fix_nonants(Ag, s=None):
     _copy_nonants_from_host(s)
 
 def _fix_root_nonants(Ag, s):
-    # s, not scenario: SPOpt._fix_root_nonants passes {"s": s}, and
-    # callout_agnostic calls fct(Ag=self, **kwargs), so any other parameter
-    # name is a TypeError as soon as the host calls the callout
+    # named s for the same reason as _restore_original_fixedness above
     _copy_nonants_from_host(s)

--- a/examples/farmer/agnostic/farmer_gurobipy_agnostic.py
+++ b/examples/farmer/agnostic/farmer_gurobipy_agnostic.py
@@ -347,11 +347,16 @@ def _copy_nonants_from_host(s):
 def _restore_nonants(Ag, s=None):
     _copy_nonants_from_host(s)
 
-def _restore_original_fixedness(Ag, scenario):
-    _copy_nonants_from_host(scenario)
+def _restore_original_fixedness(Ag, s):
+    # s, not scenario: see the note on _fix_root_nonants below. Reached on an
+    # ordinary single run through SPOpt.post_solve_bound.
+    _copy_nonants_from_host(s)
 
 def _fix_nonants(Ag, s=None):
     _copy_nonants_from_host(s)
 
-def _fix_root_nonants(Ag, scenario):
-    _copy_nonants_from_host(scenario)
+def _fix_root_nonants(Ag, s):
+    # s, not scenario: SPOpt._fix_root_nonants passes {"s": s}, and
+    # callout_agnostic calls fct(Ag=self, **kwargs), so any other parameter
+    # name is a TypeError as soon as the host calls the callout
+    _copy_nonants_from_host(s)

--- a/mpisppy/agnostic/examples/farmer_gurobipy_model.py
+++ b/mpisppy/agnostic/examples/farmer_gurobipy_model.py
@@ -254,11 +254,16 @@ def _copy_nonants_from_host(s):
 def _restore_nonants(Ag, s=None):
     _copy_nonants_from_host(s)
 
-def _restore_original_fixedness(Ag, scenario):
-    _copy_nonants_from_host(scenario)
+def _restore_original_fixedness(Ag, s):
+    # s, not scenario: see the note on _fix_root_nonants below. Reached on an
+    # ordinary single run through SPOpt.post_solve_bound.
+    _copy_nonants_from_host(s)
 
 def _fix_nonants(Ag, s=None):
     _copy_nonants_from_host(s)
 
-def _fix_root_nonants(Ag, scenario):
-    _copy_nonants_from_host(scenario)
+def _fix_root_nonants(Ag, s):
+    # s, not scenario: SPOpt._fix_root_nonants passes {"s": s}, and
+    # callout_agnostic calls fct(Ag=self, **kwargs), so any other parameter
+    # name is a TypeError as soon as the host calls the callout
+    _copy_nonants_from_host(s)

--- a/mpisppy/agnostic/examples/farmer_gurobipy_model.py
+++ b/mpisppy/agnostic/examples/farmer_gurobipy_model.py
@@ -255,15 +255,14 @@ def _restore_nonants(Ag, s=None):
     _copy_nonants_from_host(s)
 
 def _restore_original_fixedness(Ag, s):
-    # s, not scenario: see the note on _fix_root_nonants below. Reached on an
-    # ordinary single run through SPOpt.post_solve_bound.
+    # The host calls this through callout_agnostic, which does
+    # fct(Ag=self, **{"s": s}), so the second parameter must be named s.
+    # SPOpt.post_solve_bound reaches it on an ordinary run.
     _copy_nonants_from_host(s)
 
 def _fix_nonants(Ag, s=None):
     _copy_nonants_from_host(s)
 
 def _fix_root_nonants(Ag, s):
-    # s, not scenario: SPOpt._fix_root_nonants passes {"s": s}, and
-    # callout_agnostic calls fct(Ag=self, **kwargs), so any other parameter
-    # name is a TypeError as soon as the host calls the callout
+    # named s for the same reason as _restore_original_fixedness above
     _copy_nonants_from_host(s)

--- a/mpisppy/extensions/cross_scen_extension.py
+++ b/mpisppy/extensions/cross_scen_extension.py
@@ -57,7 +57,7 @@ class CrossScenarioExtension(Extension):
             self.reenable_prox = True
         elif not opt.W_disabled:
             opt._disable_W()
-            self.eenable_W = True
+            self.reenable_W = True
         elif not opt.prox_disabled:
             opt._disable_prox()
             self.reenable_prox = True

--- a/mpisppy/extensions/integer_relax_then_enforce.py
+++ b/mpisppy/extensions/integer_relax_then_enforce.py
@@ -45,16 +45,32 @@ class IntegerRelaxThenEnforce(mpisppy.extensions.extension.Extension):
         self._integers_relaxed = False
 
     def miditer(self):
+        # Each branch below returns after unrelaxing: the conditions are
+        # independent and more than one can be true in the same pass -- a run
+        # that is past its time fraction and its iteration fraction at once --
+        # and the second undo raises, because Pyomo's first one deletes
+        # _relaxed_integer_vars.
         if not self._integers_relaxed:
             return
         # time is running out
-        if self.opt.options["time_limit"] is not None and ( time.perf_counter() - self.opt.start_time ) > (self.opt.options["time_limit"] * self.ratio):
+        #
+        # Reduced: this is the one test of the three that is rank-local, a
+        # per-process clock, and _unrelax_integers is not collective. Left per
+        # rank, one rank crossing the fraction a moment before another has
+        # some ranks solving MIPs and the rest LPs in the same iteration, with
+        # Compute_Xbar and Update_W averaging the two.
+        time_limit = self.opt.options["time_limit"]
+        out_of_time = time_limit is not None and self.opt.allreduce_or(
+            (time.perf_counter() - self.opt.start_time) > (time_limit * self.ratio))
+        if out_of_time:
             global_toc(f"{self.__class__.__name__}: enforcing integrality constraints, ran so far for more than {self.opt.options['time_limit']*self.ratio} seconds", self.opt.cylinder_rank == 0)
             self._unrelax_integers()
+            return
         # iterations are running out
         if self.opt._PHIter > self.opt.options["PHIterLimit"] * self.ratio:
             global_toc(f"{self.__class__.__name__}: enforcing integrality constraints, ran so far for {self.opt._PHIter - 1} iterations", self.opt.cylinder_rank == 0)
             self._unrelax_integers()
+            return
         # nearly converged
         if self.opt.conv < (self.opt.options["convthresh"] * 1.1):
             global_toc(f"{self.__class__.__name__}: Enforcing integrality constraints, PH is nearly converged", self.opt.cylinder_rank == 0)

--- a/mpisppy/extensions/integer_relax_then_enforce.py
+++ b/mpisppy/extensions/integer_relax_then_enforce.py
@@ -60,7 +60,7 @@ class IntegerRelaxThenEnforce(mpisppy.extensions.extension.Extension):
         # two. The other conditions below read _PHIter and conv, which are the
         # same on every rank.
         time_limit = self.opt.options["time_limit"]
-        out_of_time = time_limit is not None and self.opt.allreduce_or(
+        out_of_time = time_limit not in (None, float("inf")) and self.opt.allreduce_or(
             (time.perf_counter() - self.opt.start_time) > (time_limit * self.ratio))
         if out_of_time:
             global_toc(f"{self.__class__.__name__}: enforcing integrality constraints, ran so far for more than {self.opt.options['time_limit']*self.ratio} seconds", self.opt.cylinder_rank == 0)

--- a/mpisppy/extensions/integer_relax_then_enforce.py
+++ b/mpisppy/extensions/integer_relax_then_enforce.py
@@ -54,11 +54,11 @@ class IntegerRelaxThenEnforce(mpisppy.extensions.extension.Extension):
             return
         # time is running out
         #
-        # Reduced: this is the one test of the three that is rank-local, a
-        # per-process clock, and _unrelax_integers is not collective. Left per
-        # rank, one rank crossing the fraction a moment before another has
-        # some ranks solving MIPs and the rest LPs in the same iteration, with
-        # Compute_Xbar and Update_W averaging the two.
+        # Each rank has its own clock, so without allreduce_or the ranks stop
+        # relaxing at different iterations: some would solve MIPs while the
+        # others were still solving LPs, and Compute_Xbar would average the
+        # two. The other conditions below read _PHIter and conv, which are the
+        # same on every rank.
         time_limit = self.opt.options["time_limit"]
         out_of_time = time_limit is not None and self.opt.allreduce_or(
             (time.perf_counter() - self.opt.start_time) > (time_limit * self.ratio))

--- a/mpisppy/extensions/wtracker_extension.py
+++ b/mpisppy/extensions/wtracker_extension.py
@@ -48,7 +48,10 @@ class Wtracker_extension(mpisppy.extensions.extension.Extension):
     def post_everything(self):
         reportlen = self.options.get("reportlen")
         stdevthresh = self.options.get("stdevthresh")
-        file_prefix = self.options.get("file_prefix")
+        # "" rather than None when the option is unset, matching
+        # report_by_moving_stats's own default: unset, the three reports were
+        # named after a stringified None ("None_summary_iter5_rank0.txt").
+        file_prefix = self.options.get("file_prefix") or ""
         self.wtracker.report_by_moving_stats(self.wlen,
                                              reportlen=reportlen,
                                              stdevthresh=stdevthresh,

--- a/mpisppy/opt/fwph.py
+++ b/mpisppy/opt/fwph.py
@@ -104,6 +104,15 @@ class FWPH(mpisppy.phbase.PHBase):
         return mip_solver_name, qp_solver_name
 
     def fwph_main(self, finalize=True):
+        # FWPH attaches no proximal term, and smoothing rides on that term:
+        # PH_Prep would create neither p nor beta, and Iter0's smoothed == 2
+        # rescale then fails on the p that is not there. Subgradient refuses
+        # the same combination for the same reason (subgradient.py).
+        if self.options.get("smoothed", 0) != 0:
+            raise RuntimeError(
+                "Cannot use smoothing with the FWPH algorithm: it attaches no "
+                "proximal term for the smoothing to ride on. Set "
+                "options[\"smoothed\"] to 0.")
         # defer_attach=False: FWPH snarfs the subproblem objective (with W
         # attached) between PH_Prep and Iter0 via _attach_nonant_objective and
         # _set_QP_objective, so the W terms must be spliced in here rather than

--- a/mpisppy/tests/test_extension_hooks.py
+++ b/mpisppy/tests/test_extension_hooks.py
@@ -61,7 +61,7 @@ class TestIntegerRelaxThenEnforce(unittest.TestCase):
         irte.miditer()                    # must not raise
         self.assertFalse(irte._integers_relaxed)
 
-    def test_the_time_test_is_taken_on_every_rank(self):
+    def test_the_time_condition_is_decided_on_every_rank(self):
         # The time fraction is a per-process clock and _unrelax_integers is
         # not collective, so deciding it per rank leaves some ranks solving
         # MIPs and the rest LPs in the same iteration.
@@ -87,7 +87,28 @@ class TestIntegerRelaxThenEnforce(unittest.TestCase):
         ph.conv = 1.0
         irte.miditer()
         self.assertEqual(reduced, [True],
-                         "the time test was decided without a reduction")
+                         "the time condition was decided without a reduction")
+
+    def test_each_condition_unrelaxes_on_its_own(self):
+        # Three conditions, three returns. The time one is covered above; a
+        # run can also reach the fraction of its iteration limit, or come
+        # near convergence, with the clock nowhere near the limit.
+        from mpisppy.extensions.integer_relax_then_enforce import (
+            IntegerRelaxThenEnforce)
+        for label, phiter, conv in (("iterations", 51, 1.0),
+                                    ("convergence", 1, 1e-9)):
+            with self.subTest(condition=label):
+                ph = _make_ph(time_limit=600, PHIterLimit=100)
+                ph.PH_Prep()
+                for s in ph.local_scenarios.values():
+                    s._solver_plugin = None
+                irte = IntegerRelaxThenEnforce(ph)
+                irte.pre_iter0()
+                ph._PHIter = phiter
+                ph.conv = conv
+                irte.miditer()
+                self.assertFalse(irte._integers_relaxed,
+                                 f"the {label} condition did not unrelax")
 
     def test_no_reduction_when_there_is_no_time_limit(self):
         # time_limit is rank-identical, so an unset one is False everywhere

--- a/mpisppy/tests/test_extension_hooks.py
+++ b/mpisppy/tests/test_extension_hooks.py
@@ -151,6 +151,54 @@ class TestWtrackerReportNames(unittest.TestCase):
         self.assertEqual(seen["prefix"], "")
 
 
+class TestFWPHSmoothing(unittest.TestCase):
+
+    def test_fwph_refuses_smoothing(self):
+        # FWPH attaches no proximal term, and smoothing rides on that term, so
+        # PH_Prep creates neither p nor beta. At smoothed == 2 Iter0's rescale
+        # then dies on the missing p; at 1 the run finishes with the smoothing
+        # silently doing nothing. Subgradient refuses the same combination.
+        from mpisppy.opt.fwph import FWPH
+        for smoothed in (1, 2):
+            with self.subTest(smoothed=smoothed):
+                options = {
+                    "solver_name": "gurobi", "PHIterLimit": 2,
+                    "defaultPHrho": 1, "convthresh": 1e-8, "verbose": False,
+                    "display_timing": False, "display_progress": False,
+                    "smoothed": smoothed, "toc": False,
+                    "FW_iter_limit": 5, "FW_weight": 0.0,
+                    "FW_conv_thresh": 1e-4, "stop_check_tol": 1e-5,
+                    "FW_LP_start_iterations": 0, "FW_verbose": False,
+                    "mip_solver_options": {}, "qp_solver_options": {},
+                    "iter0_solver_options": None, "iterk_solver_options": None,
+                }
+                fw = FWPH(options, [f"Scenario{i+1}" for i in range(3)],
+                          farmer.scenario_creator, farmer.scenario_denouement,
+                          scenario_creator_kwargs={"crops_multiplier": 1})
+                with self.assertRaisesRegex(RuntimeError, "smoothing"):
+                    fw.fwph_main()
+
+    def test_the_fwph_spoke_zeroes_smoothing(self):
+        # A caller reusing a PH hub's options dict brings smoothed along, and
+        # options_check only fills in a missing key -- so the spoke has to
+        # zero it the way fwph_hub does, or the run aborts at fwph_main.
+        from mpisppy.utils import config
+        import mpisppy.utils.cfg_vanilla as vanilla
+        cfg = config.Config()
+        cfg.popular_args()
+        cfg.ph_args()
+        cfg.two_sided_args()
+        cfg.fwph_args()
+        cfg.num_scens_required()
+        cfg.num_scens = 3
+        cfg.solver_name = "gurobi"
+        cfg.default_rho = 1
+        beans = (cfg, farmer.scenario_creator, farmer.scenario_denouement,
+                 [f"Scenario{i+1}" for i in range(3)])
+        spoke = vanilla.fwph_spoke(*beans)
+        self.assertEqual(spoke["opt_kwargs"]["options"]["smoothed"], 0)
+
+
 class TestAgnosticGuestCallouts(unittest.TestCase):
 
     def test_the_gurobipy_guests_take_the_parameter_the_host_passes(self):

--- a/mpisppy/tests/test_extension_hooks.py
+++ b/mpisppy/tests/test_extension_hooks.py
@@ -1,0 +1,186 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+"""Tests for the hooks of individual extensions, as opposed to
+test_extensions.py, which covers the extension base classes.
+
+These build a real PH object for its scenarios and Params, but never solve, so
+no solver is required.
+"""
+
+import unittest
+
+import mpisppy.opt.ph
+import mpisppy.tests.examples.farmer as farmer
+
+
+def _make_ph(**option_overrides):
+    options = {
+        "solver_name": "gurobi",     # never used; nothing here solves
+        "PHIterLimit": 10,
+        "defaultPHrho": 1,
+        "convthresh": 1e-8,
+        "verbose": False,
+        "display_timing": False,
+        "display_progress": False,
+        "smoothed": 0,
+        "toc": False,
+    }
+    options.update(option_overrides)
+    return mpisppy.opt.ph.PH(
+        options, [f"Scenario{i+1}" for i in range(3)], farmer.scenario_creator,
+        farmer.scenario_denouement,
+        scenario_creator_kwargs={"crops_multiplier": 1})
+
+
+class TestIntegerRelaxThenEnforce(unittest.TestCase):
+
+    def test_unrelaxes_at_most_once_per_pass(self):
+        # The three conditions in miditer are independent, and more than one
+        # can hold in the same pass -- past the time fraction and past the
+        # iteration fraction. Pyomo's undo deletes _relaxed_integer_vars, so
+        # the second call in one pass raises.
+        from mpisppy.extensions.integer_relax_then_enforce import (
+            IntegerRelaxThenEnforce)
+        ph = _make_ph(time_limit=600, PHIterLimit=100)
+        ph.PH_Prep()
+        for s in ph.local_scenarios.values():
+            s._solver_plugin = None       # not persistent; no solver needed
+        irte = IntegerRelaxThenEnforce(ph)
+        irte.pre_iter0()
+        self.assertTrue(irte._integers_relaxed)
+
+        ph.start_time -= 320              # past 600 * 0.5
+        ph._PHIter = 51                   # past 100 * 0.5
+        ph.conv = 1.0
+        irte.miditer()                    # must not raise
+        self.assertFalse(irte._integers_relaxed)
+
+    def test_the_time_test_is_taken_on_every_rank(self):
+        # The time fraction is a per-process clock and _unrelax_integers is
+        # not collective, so deciding it per rank leaves some ranks solving
+        # MIPs and the rest LPs in the same iteration.
+        from mpisppy.extensions.integer_relax_then_enforce import (
+            IntegerRelaxThenEnforce)
+        ph = _make_ph(time_limit=600, PHIterLimit=100)
+        ph.PH_Prep()
+        for s in ph.local_scenarios.values():
+            s._solver_plugin = None
+        irte = IntegerRelaxThenEnforce(ph)
+        irte.pre_iter0()
+
+        reduced = []
+        real = ph.allreduce_or
+
+        def counting(val):
+            reduced.append(val)
+            return real(val)
+
+        ph.allreduce_or = counting
+        ph.start_time -= 320
+        ph._PHIter = 1
+        ph.conv = 1.0
+        irte.miditer()
+        self.assertEqual(reduced, [True],
+                         "the time test was decided without a reduction")
+
+    def test_no_reduction_when_there_is_no_time_limit(self):
+        # time_limit is rank-identical, so an unset one is False everywhere
+        # and reducing it every iteration of the hub's loop is an Allreduce
+        # for a known answer.
+        from mpisppy.extensions.integer_relax_then_enforce import (
+            IntegerRelaxThenEnforce)
+        ph = _make_ph(PHIterLimit=100)
+        ph.PH_Prep()
+        for s in ph.local_scenarios.values():
+            s._solver_plugin = None
+        irte = IntegerRelaxThenEnforce(ph)
+        irte.pre_iter0()
+
+        reduced = []
+        ph.allreduce_or = lambda val: reduced.append(val) or val
+        ph._PHIter = 1
+        ph.conv = 1.0
+        irte.miditer()
+        self.assertEqual(reduced, [])
+
+
+class TestCrossScenarioDisableEnable(unittest.TestCase):
+
+    def test_w_is_put_back_when_prox_was_already_off(self):
+        # _disable_W_and_prox has three branches; the one for "W on, prox
+        # already off" recorded its intention on a misspelled attribute, so
+        # reenable_W stayed False and _enable_W_and_prox never put W back --
+        # every later iteration solved without the dual term while W_disabled
+        # reported the run as normal.
+        from mpisppy.extensions.cross_scen_extension import (
+            CrossScenarioExtension)
+        ph = _make_ph()
+        ph.PH_Prep()
+        for s in ph.local_scenarios.values():
+            s._mpisppy_model.W_on = 1
+            s._mpisppy_model.prox_on = 0
+        ext = CrossScenarioExtension(ph)
+        ext._disable_W_and_prox()
+        self.assertTrue(ph.W_disabled, "W was not turned off")
+        ext._enable_W_and_prox()
+        self.assertFalse(ph.W_disabled, "W was never put back")
+
+
+class TestWtrackerReportNames(unittest.TestCase):
+
+    def test_an_unset_prefix_is_empty_not_None(self):
+        # The three report names are built from file_prefix; unset, they were
+        # named after a stringified None ("None_summary_iter5_rank0.txt").
+        from mpisppy.extensions.wtracker_extension import Wtracker_extension
+        ph = _make_ph()
+        ph.options["wtracker_options"] = {"wlen": 2}
+        ext = Wtracker_extension(ph)
+        seen = {}
+
+        def fake_report(wlen, reportlen=None, stdevthresh=None, file_prefix=''):
+            seen["prefix"] = file_prefix
+
+        ext.wtracker.report_by_moving_stats = fake_report
+        ext.post_everything()
+        self.assertEqual(seen["prefix"], "")
+
+
+class TestAgnosticGuestCallouts(unittest.TestCase):
+
+    def test_the_gurobipy_guests_take_the_parameter_the_host_passes(self):
+        # SPOpt passes {"s": s} for these two callouts, and callout_agnostic
+        # calls fct(Ag=self, **kwargs), so a guest declaring anything else is
+        # a TypeError as soon as the host calls it. Read from the source
+        # rather than imported: these example modules pull in a farmer module
+        # that is not importable from the test environment.
+        import ast
+        import pathlib
+        root = pathlib.Path(__file__).resolve().parents[2]
+        guests = [
+            root / "mpisppy" / "agnostic" / "examples"
+                 / "farmer_gurobipy_model.py",
+            root / "examples" / "farmer" / "agnostic"
+                 / "farmer_gurobipy_agnostic.py",
+        ]
+        wanted = {"_restore_original_fixedness", "_fix_root_nonants"}
+        for guest in guests:
+            if not guest.exists():          # examples/ is not always shipped
+                continue
+            tree = ast.parse(guest.read_text())
+            found = {n.name: [a.arg for a in n.args.args]
+                     for n in tree.body
+                     if isinstance(n, ast.FunctionDef) and n.name in wanted}
+            self.assertEqual(set(found), wanted, f"{guest.name}: {found}")
+            for fname, params in found.items():
+                with self.subTest(guest=guest.name, callout=fname):
+                    self.assertEqual(params, ["Ag", "s"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mpisppy/utils/cfg_vanilla.py
+++ b/mpisppy/utils/cfg_vanilla.py
@@ -1048,6 +1048,12 @@ def fwph_spoke(
     shoptions = shared_options(cfg)
     options = copy.deepcopy(shoptions)
 
+    # Match fwph_hub: FWPH attaches no proximal term, so there is nothing for
+    # smoothing to ride on and fwph_main refuses it. shared_options does not
+    # carry the key today, so options_check would default it -- but a caller
+    # who hands us an options dict built for a PH hub does carry it.
+    options["smoothed"] = 0
+
     options.update(_fwph_options(cfg))
 
     # Match fwph_hub: forward linearize_* so FWPH._options_checks_fw can

--- a/run_coverage.bash
+++ b/run_coverage.bash
@@ -209,6 +209,7 @@ run_phase "serial unit tests (serial)" \
         mpisppy/tests/test_nice_join.py \
         mpisppy/tests/test_solver_spec.py \
         mpisppy/tests/test_extensions.py \
+        mpisppy/tests/test_extension_hooks.py \
         mpisppy/tests/test_buffer_inspect.py \
         mpisppy/tests/test_comm_lor_check.py \
         mpisppy/tests/test_ciutils.py \


### PR DESCRIPTION
## Five bugs that bite on a single run

Found while working on #846, but none of them needs a second run to bite, so
they do not belong in that PR. This branch is off `main` and stands alone.

### `IntegerRelaxThenEnforce` could unrelax twice in one pass and crash

`miditer`'s three conditions are independent `if`s, and more than one can hold
at once — a run past its time fraction *and* its iteration fraction. Pyomo's
undo deletes `_relaxed_integer_vars`, so the second call raises
`AttributeError`. Each branch returns now.

### …and it decided the time one per rank

That test reads a per-process clock (`time.perf_counter() - start_time`), and
`_unrelax_integers` is not collective. One rank crossing the fraction a moment
before another leaves **some ranks solving MIPs and the rest LPs in the same
iteration**, with `Compute_Xbar` and `Update_W` averaging the two. Reduced with
`allreduce_or` — and only when there is a limit to reduce about, since an unset
`time_limit` is `False` on every rank and the hub's loop should not pay for an
`Allreduce` with a known answer. The iteration and convergence conditions are
already rank-identical.

### `CrossScenarioExtension` left W disabled for the rest of the run

`_disable_W_and_prox` has three branches; the one for "W is on, prox is already
off" turns W off and then records that on a misspelled attribute
(`self.eenable_W`), so `reenable_W` stays `False` and `_enable_W_and_prox`
never puts it back. Every iteration after that solves without the dual term,
and `W_disabled` reports the run as normal.

### Two gurobipy guest callouts could not be called at all

`SPOpt` passes `{"s": s}` to `_restore_original_fixedness` and
`_fix_root_nonants`, and `callout_agnostic` calls `fct(Ag=self, **kwargs)`, so
the guests' `scenario` parameter is a `TypeError` on contact.
`post_solve_bound` reaches the first on an ordinary run. The other five guests
already use `s`.

### FWPH accepted a smoothing option it cannot honor

FWPH attaches no proximal term, and smoothing rides on that term, so `PH_Prep`
creates neither `p` nor `beta`. Both without an LP start, on 3-scenario farmer:

| `options["smoothed"]` | before |
|---|---|
| `2` | `AttributeError: 'ScalarBlock' object has no attribute 'p'` from `Iter0`'s rescale |
| `1` | ran to completion, with the smoothing doing nothing at all |

`Subgradient` already refuses this combination in the same words;
`fwph_main` does now too. **That stops the `smoothed == 1` run that used to
finish** — which is the point, since the option was being ignored — so it is a
behavior change, not only a better message. `fwph_spoke` also zeroes
`options["smoothed"]` the way `fwph_hub` already did: it had relied on
`options_check` filling in a *missing* key, which does not help a caller who
reuses an options dict built for a PH hub (`ph_hub` sets `smoothed = 2` under
`cfg.smoothing`).

### And the W tracker's reports were named after a stringified `None`

With `file_prefix` unset the three reports came out as
`None_summary_iter5_rank0.txt` and friends. It is `""` now, which is what
`report_by_moving_stats` itself defaults to. **This renames an existing
output.**

### Tests

New `mpisppy/tests/test_extension_hooks.py` — `test_extensions.py` covers the
extension base classes with mocks, and these want a real PH object (none of
them solves, so no solver is needed). Each test fails without its fix, except
the one asserting there is no `Allreduce` without a time limit, which guards
the change above rather than a bug on `main`.

`test_extension_hooks` / `test_extensions` / `test_ph_extensions` /
`test_ef_ph` / `test_cross_scenario_buffer_sizing` / `test_generic_cylinders` /
`test_config`: 213 passed, 1 skipped. The 5 `test_agnostic` failures need
AMPL/GAMS and fail identically on `main`. `test_with_cylinders` and the
FWPH-spoke cylinder tests pass on two ranks. `ruff` clean.

